### PR TITLE
Serve sessions read from the daemon

### DIFF
--- a/.github/workflows/termiod.yml
+++ b/.github/workflows/termiod.yml
@@ -138,6 +138,13 @@ jobs:
           pkill -9 -f "target/debug/[t]ermiod|deps/[t]ermiod-" || true
           python3 remote_smoke_test.py
 
+      # The daemon half of `sessions read` against a real daemon — the Stage 10
+      # gate that a never-opened session answers, with no app socket anywhere.
+      - name: Read smoke test
+        run: |
+          pkill -9 -f "target/debug/[t]ermiod|deps/[t]ermiod-" || true
+          python3 tests/cli_read_smoke.py
+
       # The Rust termio client against the shell client it replaces: request
       # bytes, stdout, stderr, and exit codes must be identical on every verb
       # (unify-server-plane Stage 10's freeze). macOS only — the shell client
@@ -233,3 +240,8 @@ jobs:
         run: |
           pkill -9 -f "target/debug/[t]ermiod|deps/[t]ermiod-" || true
           python3 remote_smoke_test.py
+
+      - name: Read smoke test
+        run: |
+          pkill -9 -f "target/debug/[t]ermiod|deps/[t]ermiod-" || true
+          python3 tests/cli_read_smoke.py

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
         }
         Some("version") => version::print_table(&channel, provenance).await,
         Some("remote") => remote_passthrough(&channel, &arguments[1..]),
-        Some("sessions") => sessions(&channel, &arguments[1..]),
+        Some("sessions") => sessions(&channel, &arguments[1..]).await,
         Some("agent") => agent_report(&channel, &arguments[1..]),
         Some("notify") => notify(&channel, &arguments[1..]),
         Some("open") => {
@@ -119,7 +119,7 @@ fn exit_outcome(outcome: Outcome) -> ! {
     })
 }
 
-fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
+async fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
     let op = arguments.first().map(String::as_str).unwrap_or("list");
     let rest = if arguments.is_empty() { &[][..] } else { &arguments[1..] };
 
@@ -142,7 +142,9 @@ fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
         std::process::exit(0);
     }
 
-    app_socket::require_socket(channel);
+    if op != "read" {
+        app_socket::require_socket(channel);
+    }
 
     let mut format = "text";
     let mut agent = String::new();
@@ -405,6 +407,16 @@ fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
             "send"
         }
         "read" => {
+            // Device verb, daemon first (unify-server-plane Stage 10): a
+            // session the local daemon hosts answers from its authoritative
+            // VT — including sessions no window ever opened, and boxes with
+            // no app at all. A target the daemon does not own (a session on
+            // a remote device, an app-side title match, a foreign-channel
+            // link) falls through to the app, which keeps its coverage.
+            if let Some(code) = daemon_read(channel, &target, &lines, format).await {
+                std::process::exit(code);
+            }
+            app_socket::require_socket(channel);
             if !lines.is_empty() {
                 extra_json = format!("\"lines\":{lines}");
             }
@@ -440,6 +452,146 @@ fn push_extra(extra: &mut String, fragment: &str) {
         extra.push(',');
     }
     extra.push_str(fragment);
+}
+
+/// `read`'s daemon half. `None` means the target is not a session the local
+/// daemon owns and the app should answer instead; `Some(code)` means the
+/// reply (success or error) was printed here.
+async fn daemon_read(channel: &Channel, target: &str, lines: &str, format: &str) -> Option<i32> {
+    let token = read_token(channel, target)?;
+    let sessions = match termiod::client::sessions_of_running_daemon().await {
+        Ok(Some(sessions)) => sessions,
+        _ => return None,
+    };
+    let token_lower = token.to_lowercase();
+    let matches: Vec<&termiod::protocol::SessionInfo> = sessions
+        .iter()
+        .filter(|info| {
+            let name = info.name.to_lowercase();
+            name == token_lower || name.starts_with(&token_lower)
+        })
+        .collect();
+    match matches.len() {
+        0 => None,
+        1 => Some(serve_daemon_read(channel, matches[0], lines, format).await),
+        _ => {
+            control_error_reply(
+                format,
+                "ambiguous",
+                &format!("'{target}' matches more than one session; use a longer id."),
+            );
+            Some(1)
+        }
+    }
+}
+
+/// The token to match against daemon session names: a bare id as-is, this
+/// channel's own `…://session/<id>` link stripped to the id. A foreign
+/// channel's link (and any other shape) stays with the app, which owns its
+/// error copy.
+fn read_token(channel: &Channel, target: &str) -> Option<String> {
+    let Some(scheme_end) = target.find("://") else {
+        return Some(target.to_string());
+    };
+    if target[..scheme_end] != channel.url_scheme() {
+        return None;
+    }
+    let rest = &target[scheme_end + 3..];
+    let id = rest.rsplit('/').next().unwrap_or_default();
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+async fn serve_daemon_read(
+    channel: &Channel,
+    info: &termiod::protocol::SessionInfo,
+    lines: &str,
+    format: &str,
+) -> i32 {
+    let snapshot = match termiod::client::observe_screen(&info.name, info.rows, info.cols).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            control_error_reply(format, "daemon", &format!("{error:#}"));
+            return 1;
+        }
+    };
+    let mut rows = match termiod::client::snapshot_text_rows(&snapshot) {
+        Ok(rows) => rows,
+        Err(error) => {
+            control_error_reply(format, "daemon", &format!("{error:#}"));
+            return 1;
+        }
+    };
+    if let Ok(cap) = lines.parse::<usize>() {
+        if cap > 0 && rows.len() > cap {
+            rows = rows.split_off(rows.len() - cap);
+        }
+    }
+    let screen = rows.join("\n");
+    if format == "json" {
+        let mut object = std::collections::BTreeMap::new();
+        object.insert("ok", serde_json::Value::Bool(true));
+        object.insert("schema_version", serde_json::Value::from(1));
+        object.insert("screen", serde_json::Value::from(screen));
+        object.insert(
+            "target",
+            serde_json::Value::from(format!(
+                "{}://session/{}",
+                channel.url_scheme(),
+                info.name.to_lowercase()
+            )),
+        );
+        object.insert("title", serde_json::Value::from(read_title(info)));
+        match serde_json::to_string(&object) {
+            Ok(reply) => println!("{reply}"),
+            Err(error) => {
+                control_error_reply(format, "daemon", &format!("{error}"));
+                return 1;
+            }
+        }
+    } else {
+        println!("{}", if screen.is_empty() { "(blank screen)" } else { &screen });
+    }
+    0
+}
+
+/// The best name the daemon knows: the agent-reported title, else the live
+/// foreground program, else the spawned command, else the placeholder every
+/// bare shell gets. The app's own `read` answers with its richer display
+/// title; the daemon plane reports what the roster carries.
+fn read_title(info: &termiod::protocol::SessionInfo) -> String {
+    if let Some(title) = info.title.as_deref().filter(|title| !title.is_empty()) {
+        return title.to_string();
+    }
+    let program = info
+        .foreground_argv
+        .as_ref()
+        .and_then(|argv| argv.first())
+        .map(String::as_str)
+        .or_else(|| info.command.split_whitespace().next())
+        .unwrap_or("");
+    let program = program.rsplit('/').next().unwrap_or(program);
+    if program.is_empty() {
+        "Terminal".to_string()
+    } else {
+        program.to_string()
+    }
+}
+
+/// An error in the app's own reply shape, so both halves of the router speak
+/// one contract to scripts.
+fn control_error_reply(format: &str, code: &str, message: &str) {
+    if format == "json" {
+        let mut object = std::collections::BTreeMap::new();
+        object.insert("error", serde_json::Value::from(code));
+        object.insert("message", serde_json::Value::from(message));
+        object.insert("ok", serde_json::Value::Bool(false));
+        object.insert("schema_version", serde_json::Value::from(1));
+        if let Ok(reply) = serde_json::to_string(&object) {
+            println!("{reply}");
+        }
+    } else {
+        println!("error: {message}");
+    }
 }
 
 /// The public hook contract: `termio agent report <state> …` keeps its name,

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -464,11 +464,20 @@ async fn daemon_read(channel: &Channel, target: &str, lines: &str, format: &str)
         _ => return None,
     };
     let token_lower = token.to_lowercase();
+    // Daemon-first claims only the canonical app-created population:
+    // sessions whose daemon name is a UUID, matched by a hex/dash token. An
+    // adopted session keeps whatever name it had, which the app may scope
+    // and resolve differently — those targets stay with the app.
+    if token_lower.is_empty()
+        || !token_lower.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+    {
+        return None;
+    }
     let matches: Vec<&termiod::protocol::SessionInfo> = sessions
         .iter()
         .filter(|info| {
             let name = info.name.to_lowercase();
-            name == token_lower || name.starts_with(&token_lower)
+            uuid_shaped(&name) && (name == token_lower || name.starts_with(&token_lower))
         })
         .collect();
     match matches.len() {
@@ -486,19 +495,34 @@ async fn daemon_read(channel: &Channel, target: &str, lines: &str, format: &str)
 }
 
 /// The token to match against daemon session names: a bare id as-is, this
-/// channel's own `…://session/<id>` link stripped to the id. A foreign
-/// channel's link (and any other shape) stays with the app, which owns its
-/// error copy.
+/// channel's own `…://session/<id>` link stripped to the id the way the
+/// app's `addressedID` does — case-insensitively, taking the component
+/// after `session/` and stopping at `/` or `?`. A foreign channel's link
+/// (and any other shape) stays with the app, which owns its error copy.
 fn read_token(channel: &Channel, target: &str) -> Option<String> {
-    let Some(scheme_end) = target.find("://") else {
+    let lowered = target.to_lowercase();
+    let Some(scheme_end) = lowered.find("://") else {
         return Some(target.to_string());
     };
-    if target[..scheme_end] != channel.url_scheme() {
+    if lowered[..scheme_end] != channel.url_scheme() {
         return None;
     }
-    let rest = &target[scheme_end + 3..];
-    let id = rest.rsplit('/').next().unwrap_or_default();
-    (!id.is_empty()).then(|| id.to_string())
+    let rest = &lowered[scheme_end + 3..];
+    let after = rest.find("session/").map(|index| &rest[index + 8..])?;
+    let id: String = after
+        .chars()
+        .take_while(|character| *character != '/' && *character != '?')
+        .collect();
+    (!id.is_empty()).then_some(id)
+}
+
+/// The 8-4-4-4-12 shape of an app-created session's daemon name.
+fn uuid_shaped(name: &str) -> bool {
+    name.len() == 36
+        && name.char_indices().all(|(index, character)| match index {
+            8 | 13 | 18 | 23 => character == '-',
+            _ => character.is_ascii_hexdigit(),
+        })
 }
 
 async fn serve_daemon_read(
@@ -507,20 +531,14 @@ async fn serve_daemon_read(
     lines: &str,
     format: &str,
 ) -> i32 {
-    let snapshot = match termiod::client::observe_screen(&info.name, info.rows, info.cols).await {
-        Ok(snapshot) => snapshot,
-        Err(error) => {
-            control_error_reply(format, "daemon", &format!("{error:#}"));
-            return 1;
-        }
-    };
-    let mut rows = match termiod::client::snapshot_text_rows(&snapshot) {
-        Ok(rows) => rows,
-        Err(error) => {
-            control_error_reply(format, "daemon", &format!("{error:#}"));
-            return 1;
-        }
-    };
+    let mut rows =
+        match termiod::client::observe_screen_rows(&info.name, info.rows, info.cols).await {
+            Ok(rows) => rows,
+            Err(error) => {
+                control_error_reply(format, "daemon", &format!("{error:#}"));
+                return 1;
+            }
+        };
     if let Ok(cap) = lines.parse::<usize>() {
         if cap > 0 && rows.len() > cap {
             rows = rows.split_off(rows.len() - cap);
@@ -908,5 +926,46 @@ line; any failure fails the whole command."#
 Select the session in the app and bring termio to the front."#
         }
         _ => USAGE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release() -> Channel {
+        Channel::from_program_name("termio")
+    }
+
+    #[test]
+    fn links_resolve_the_way_the_apps_addressed_id_does() {
+        let id = "8de0b387-485a-4016-8990-cbcbfff03199";
+        let link = format!("termio://session/{id}");
+        assert_eq!(read_token(&release(), &link).as_deref(), Some(id));
+        // Case-insensitive scheme and id, trailing slash, query suffix.
+        assert_eq!(
+            read_token(&release(), &format!("TERMIO://session/{}", id.to_uppercase())).as_deref(),
+            Some(id)
+        );
+        assert_eq!(read_token(&release(), &format!("{link}/")).as_deref(), Some(id));
+        assert_eq!(read_token(&release(), &format!("{link}?focus=1")).as_deref(), Some(id));
+        // A bare token passes through untouched.
+        assert_eq!(read_token(&release(), "8de0b387").as_deref(), Some("8de0b387"));
+    }
+
+    #[test]
+    fn foreign_and_malformed_links_stay_with_the_app() {
+        assert_eq!(read_token(&release(), "termio-dev://session/8de0b387"), None);
+        assert_eq!(read_token(&release(), "https://example.com/session/x"), None);
+        assert_eq!(read_token(&release(), "termio://nothing-here"), None);
+        assert_eq!(read_token(&release(), "termio://session/"), None);
+    }
+
+    #[test]
+    fn only_uuid_shaped_names_belong_to_the_daemon_first_path() {
+        assert!(uuid_shaped("8de0b387-485a-4016-8990-cbcbfff03199"));
+        assert!(!uuid_shaped("8de0b387"));
+        assert!(!uuid_shaped("deadbeef-server"));
+        assert!(!uuid_shaped("8de0b387-485a-4016-8990-cbcbfff0319g"));
     }
 }

--- a/termiod/src/channel.rs
+++ b/termiod/src/channel.rs
@@ -75,6 +75,16 @@ impl Channel {
             None => Channel::release(),
         }
     }
+
+    /// The deep-link scheme this channel's app claims (`termio` /
+    /// `termio-dev`), mirroring `AppChannel.urlScheme`.
+    pub fn url_scheme(&self) -> String {
+        if self.name == "release" {
+            "termio".to_string()
+        } else {
+            format!("termio-{}", self.name)
+        }
+    }
 }
 
 fn program_name() -> String {

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -937,11 +937,17 @@ pub async fn sessions_of_running_daemon() -> Result<Option<Vec<SessionInfo>>> {
 }
 
 /// One read-only look at a session's current screen: an observe-mode
-/// attachment negotiated with the snapshot capability, dropped as soon as the
-/// `S` frame lands. Observe mode never takes the write token and never
+/// attachment negotiated with the snapshot capability, dropped as soon as
+/// the screen is known. Observe mode never takes the write token and never
 /// resizes the PTY, so reading a screen is invisible to the session's real
 /// client. Never spawns a daemon, for the same reason as the roster above.
-pub async fn observe_screen(target: &str, rows: u16, cols: u16) -> Result<Snapshot> {
+///
+/// Two ways the screen arrives: the normal `S` frame, or — when the host's
+/// VT is stale and it explicitly falls back to ring replay — a run of `D`
+/// frames closed by `ready`, which this end replays into its own engine.
+/// Both paths sit under one deadline so a host that answers with neither
+/// can never hang the caller.
+pub async fn observe_screen_rows(target: &str, rows: u16, cols: u16) -> Result<Vec<String>> {
     let sock = paths::socket_path()?;
     let mut stream = UnixStream::connect(&sock)
         .await
@@ -981,14 +987,50 @@ pub async fn observe_screen(target: &str, rows: u16, cols: u16) -> Result<Snapsh
         },
     )
     .await?;
-    loop {
-        match read_frame(&mut stream).await? {
-            Some(Frame::Snapshot(snapshot)) => return Ok(snapshot),
-            Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
-            Some(_) => continue,
-            None => bail!("the daemon closed the stream before sending a snapshot"),
+    let collected = tokio::time::timeout(Duration::from_secs(10), async {
+        let mut dimensions = (rows, cols);
+        let mut replay: Vec<u8> = Vec::new();
+        loop {
+            match read_frame(&mut stream).await? {
+                Some(Frame::Snapshot(snapshot)) => return Ok(Screen::Snapshot(snapshot)),
+                Some(Frame::Control(Control::Attached { rows, cols, .. })) => {
+                    dimensions = (rows, cols);
+                }
+                Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
+                Some(Frame::Data(bytes)) => replay.extend_from_slice(&bytes),
+                Some(Frame::Event(Event::Ready { .. })) => {
+                    return Ok(Screen::Replay {
+                        rows: dimensions.0,
+                        cols: dimensions.1,
+                        bytes: replay,
+                    })
+                }
+                Some(_) => continue,
+                None => bail!("the daemon closed the stream before sending a screen"),
+            }
+        }
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("timed out waiting for the session's screen"))??;
+    match collected {
+        Screen::Snapshot(snapshot) => snapshot_text_rows(&snapshot),
+        Screen::Replay { rows, cols, bytes } => {
+            let mut terminal = termiod_vt::VtTerminal::new(rows, cols)?;
+            terminal.vt_write(&bytes);
+            let grid = terminal.snapshot()?;
+            let mut lines =
+                text_rows(usize::from(grid.cols), grid.cells.iter().map(|cell| cell.codepoint));
+            while lines.last().is_some_and(|line| line.is_empty()) {
+                lines.pop();
+            }
+            Ok(lines)
         }
     }
+}
+
+enum Screen {
+    Snapshot(Snapshot),
+    Replay { rows: u16, cols: u16, bytes: Vec<u8> },
 }
 
 /// A snapshot's text rows the way the app's `read` renders a screen: each row

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -898,3 +898,142 @@ mod autostart_tests {
         assert!(!super::absent_daemon(None));
     }
 }
+
+/// The daemon's roster over a connection that never spawns one. A daemon this
+/// call would have to start hosts no sessions, so an absent daemon simply
+/// answers `None` — and from the `termio` client binary, `current_exe()` is
+/// not the daemon anyway (see the crate-root seam note in `lib.rs`). Errors
+/// only when a live daemon answers badly.
+pub async fn sessions_of_running_daemon() -> Result<Option<Vec<SessionInfo>>> {
+    let sock = paths::socket_path()?;
+    let mut stream = match UnixStream::connect(&sock).await {
+        Ok(stream) => stream,
+        Err(_) => return Ok(None),
+    };
+    write_control(
+        &mut stream,
+        &Control::Hello {
+            proto: PROTOCOL_VERSION,
+            min_proto: PROTOCOL_VERSION,
+            role: ChannelRole::Control,
+            caps: vec!["events".to_string()],
+            client: format!("termiod-cli/{}", env!("CARGO_PKG_VERSION")),
+        },
+    )
+    .await?;
+    match read_frame(&mut stream).await? {
+        Some(Frame::Control(Control::HelloOk { .. })) => {}
+        _ => return Ok(None),
+    }
+    write_control(&mut stream, &Control::List { seq: Some(1) }).await?;
+    loop {
+        match read_frame(&mut stream).await? {
+            Some(Frame::Control(Control::Sessions { sessions, .. })) => return Ok(Some(sessions)),
+            Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
+            Some(_) => continue,
+            None => bail!("the daemon closed the connection before answering list"),
+        }
+    }
+}
+
+/// One read-only look at a session's current screen: an observe-mode
+/// attachment negotiated with the snapshot capability, dropped as soon as the
+/// `S` frame lands. Observe mode never takes the write token and never
+/// resizes the PTY, so reading a screen is invisible to the session's real
+/// client. Never spawns a daemon, for the same reason as the roster above.
+pub async fn observe_screen(target: &str, rows: u16, cols: u16) -> Result<Snapshot> {
+    let sock = paths::socket_path()?;
+    let mut stream = UnixStream::connect(&sock)
+        .await
+        .with_context(|| format!("connecting to termiod at {}", sock.display()))?;
+    write_control(
+        &mut stream,
+        &Control::Hello {
+            proto: PROTOCOL_VERSION,
+            min_proto: PROTOCOL_VERSION,
+            role: ChannelRole::Attach,
+            caps: vec![
+                "events".to_string(),
+                "send_wait".to_string(),
+                "snapshot".to_string(),
+                "scrollback".to_string(),
+            ],
+            client: format!("termiod-cli/{}", env!("CARGO_PKG_VERSION")),
+        },
+    )
+    .await?;
+    match read_frame(&mut stream).await? {
+        Some(Frame::Control(Control::HelloOk { .. })) => {}
+        Some(Frame::Control(Control::HelloErr { code, supported })) => {
+            bail!("protocol negotiation failed ({code:?}); host supports {supported:?}")
+        }
+        _ => bail!("this daemon cannot answer snapshot reads"),
+    }
+    write_control(
+        &mut stream,
+        &Control::Attach {
+            target: target.to_string(),
+            create_if_missing: None,
+            rows,
+            cols,
+            mode: AttachMode::Observe,
+            seq: Some(2),
+        },
+    )
+    .await?;
+    loop {
+        match read_frame(&mut stream).await? {
+            Some(Frame::Snapshot(snapshot)) => return Ok(snapshot),
+            Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
+            Some(_) => continue,
+            None => bail!("the daemon closed the stream before sending a snapshot"),
+        }
+    }
+}
+
+/// A snapshot's text rows the way the app's `read` renders a screen: each row
+/// right-trimmed, trailing blank rows dropped. A v2 payload is VT sequences
+/// replayed into a fresh engine — self-contained by design, proven by
+/// `snapshot_prologue.rs` — and the packed-cell form reads straight off the
+/// grid.
+pub fn snapshot_text_rows(snapshot: &Snapshot) -> Result<Vec<String>> {
+    let mut rows = if let Some(vt) = &snapshot.vt {
+        let mut terminal = termiod_vt::VtTerminal::new(snapshot.rows, snapshot.cols)?;
+        terminal.vt_write(vt);
+        let grid = terminal.snapshot()?;
+        text_rows(usize::from(grid.cols), grid.cells.iter().map(|cell| cell.codepoint))
+    } else {
+        text_rows(
+            usize::from(snapshot.cols),
+            snapshot.cells.iter().map(|cell| cell.codepoint),
+        )
+    };
+    while rows.last().is_some_and(|row| row.is_empty()) {
+        rows.pop();
+    }
+    Ok(rows)
+}
+
+fn text_rows(cols: usize, codepoints: impl Iterator<Item = u32>) -> Vec<String> {
+    if cols == 0 {
+        return Vec::new();
+    }
+    let cells: Vec<u32> = codepoints.collect();
+    cells
+        .chunks(cols)
+        .map(|row| {
+            row.iter()
+                .map(|&codepoint| {
+                    let character = char::from_u32(codepoint).unwrap_or(' ');
+                    if character == '\0' {
+                        ' '
+                    } else {
+                        character
+                    }
+                })
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}

--- a/termiod/tests/cli_compat.py
+++ b/termiod/tests/cli_compat.py
@@ -108,6 +108,11 @@ def run(client, args, env_extra=None):
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "PWD": HOME,
         "TERMIO_SESSION": "TEST-SESSION",
+        # A dead daemon socket: the Rust client answers `read` from a local
+        # daemon when one owns the target, and this harness diffs the
+        # app-socket halves — so pin the daemon side to a path nothing serves
+        # for both clients alike.
+        "TERMIOD_SOCK": os.path.join(HOME, "no-daemon.sock"),
     }
     if env_extra:
         env.update(env_extra)

--- a/termiod/tests/cli_read_smoke.py
+++ b/termiod/tests/cli_read_smoke.py
@@ -92,9 +92,17 @@ def main():
              "printf 'hello from the daemon screen\\n'; sleep 60"],
         )
         check("create", code == 0, f"    {code} {out!r} {err!r}")
-        time.sleep(1.0)
 
-        code, out, err = run(TERMIO, ["sessions", "read", "8d0fbeef"])
+        # The shell needs a moment to print; poll rather than trust a fixed
+        # sleep on a loaded CI runner.
+        deadline = time.time() + 15
+        while True:
+            code, out, err = run(TERMIO, ["sessions", "read", "8d0fbeef"])
+            if code == 0 and "hello from the daemon screen" in out:
+                break
+            if time.time() > deadline:
+                break
+            time.sleep(0.3)
         check(
             "read by prefix, no app anywhere",
             code == 0 and "hello from the daemon screen" in out and err == "",

--- a/termiod/tests/cli_read_smoke.py
+++ b/termiod/tests/cli_read_smoke.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""The daemon half of `termio sessions read` against a real termiod.
+
+Spawns a pinned-socket daemon, creates a session no window has ever opened,
+and reads its screen through the Rust client with no app socket anywhere —
+the Stage 10 gate that `read` works on a box with no Mac app, and that a
+never-opened session answers instead of `not_live`.
+"""
+
+import json
+import os
+import shutil
+import socket as socket_module
+import subprocess
+import sys
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+TERMIOD = os.environ.get(
+    "TERMIO_TERMIOD_TEST_BIN",
+    os.path.join(REPO, "termiod", "target", "debug", "termiod"),
+)
+TERMIO = os.environ.get(
+    "TERMIO_CLI_TEST_BIN",
+    os.path.join(REPO, "termiod", "target", "debug", "termio"),
+)
+
+BASE = f"/tmp/termio-read-{os.getpid()}"
+HOME = os.path.join(BASE, "home")
+SOCK = os.path.join(BASE, "termiod.sock")
+
+failures = []
+passes = 0
+
+
+def check(name, condition, detail=""):
+    global passes
+    if condition:
+        passes += 1
+        print(f"  [PASS] {name}")
+    else:
+        failures.append(name)
+        print(f"  [FAIL] {name}\n{detail}")
+
+
+def run(binary, args):
+    env = {
+        "HOME": HOME,
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "TERMIOD_SOCK": SOCK,
+        "TERMIOD_KEEP_AWAKE": "off",
+    }
+    completed = subprocess.run(
+        [binary] + args, env=env, cwd=HOME, capture_output=True, text=True, timeout=30
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def main():
+    shutil.rmtree(BASE, ignore_errors=True)
+    os.makedirs(HOME)
+    daemon = subprocess.Popen(
+        [TERMIOD, "serve"],
+        env={
+            "HOME": HOME,
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "TERMIOD_SOCK": SOCK,
+            "TERMIOD_KEEP_AWAKE": "off",
+        },
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        for _ in range(100):
+            if os.path.exists(SOCK):
+                try:
+                    probe = socket_module.socket(socket_module.AF_UNIX)
+                    probe.connect(SOCK)
+                    probe.close()
+                    break
+                except OSError:
+                    pass
+            time.sleep(0.05)
+        else:
+            print("daemon never bound its socket", file=sys.stderr)
+            return 2
+
+        name = "8D0FBEEF-0000-4000-8000-000000000001"
+        code, out, err = run(
+            TERMIOD,
+            ["create", "--name", name, "--", "/bin/sh", "-c",
+             "printf 'hello from the daemon screen\\n'; sleep 60"],
+        )
+        check("create", code == 0, f"    {code} {out!r} {err!r}")
+        time.sleep(1.0)
+
+        code, out, err = run(TERMIO, ["sessions", "read", "8d0fbeef"])
+        check(
+            "read by prefix, no app anywhere",
+            code == 0 and "hello from the daemon screen" in out and err == "",
+            f"    {code} {out!r} {err!r}",
+        )
+
+        code, out, err = run(TERMIO, ["sessions", "read", name.lower(), "--json"])
+        try:
+            reply = json.loads(out)
+        except ValueError:
+            reply = {}
+        check(
+            "read --json shape",
+            code == 0
+            and reply.get("ok") is True
+            and reply.get("schema_version") == 1
+            and "hello from the daemon screen" in reply.get("screen", "")
+            and reply.get("target") == f"termio://session/{name.lower()}"
+            and sorted(reply) == ["ok", "schema_version", "screen", "target", "title"],
+            f"    {code} {out!r} {err!r}",
+        )
+
+        code, out, err = run(
+            TERMIO, ["sessions", "read", f"termio://session/{name.lower()}", "--lines", "1"]
+        )
+        check(
+            "read by link with --lines",
+            code == 0 and out.rstrip("\n").splitlines()[-1:] != [] and "sleep" not in out,
+            f"    {code} {out!r} {err!r}",
+        )
+
+        # A target the daemon does not own falls through to the app socket,
+        # and with no app anywhere that is the app-missing error.
+        code, out, err = run(TERMIO, ["sessions", "read", "ffffffff"])
+        check(
+            "unowned target falls through to the app path",
+            code == 1 and "app is not running" in err,
+            f"    {code} {out!r} {err!r}",
+        )
+    finally:
+        daemon.terminate()
+        try:
+            daemon.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+        shutil.rmtree(BASE, ignore_errors=True)
+
+    print()
+    if failures:
+        print(f"{passes} passed, {len(failures)} FAILED: {failures}")
+        return 1
+    print(f"ALL {passes} CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
PR 5 of the CLI port — the first backend flip (unify-server-plane Stage 10, one-path Stage 6 verb 1). A `sessions read` whose target the local daemon owns is answered from the daemon's authoritative VT: an observe-mode attachment negotiated with the `snapshot` capability, dropped once the `S` frame lands. Observe mode takes no write token and never resizes, so a read is invisible to the session's real client. The v2 payload replays into a fresh `termiod-vt` engine and renders rows the way the app renders a screen (right-trimmed, trailing blanks dropped, `--lines` tail, same sorted-key `--json` shape).

This is the verb's designed behavior change, and it showed on a live session during verification: the app path answers `not_live` ("open it once in Termio") for a session no window ever opened, while the daemon path prints its actual screen. The verbs also work on a box with no Mac app at all — the Linux CI job now proves it.

The router keeps an app-socket fallback for coverage the local daemon lacks — sessions on remote devices (their PTYs live in the far daemon; the app's surface is the only local view), app-side title matching, foreign-channel links — so the Swift `readScreen` handler survives until the CLI can route to remote daemons. The new daemon connections never auto-start a daemon: one this call would have to start hosts no sessions, and from this binary `current_exe()` is not the daemon (the `lib.rs` seam).

Tests: `tests/cli_read_smoke.py` pins a private daemon and proves the gates (read by prefix and link with no app socket anywhere, JSON shape, `--lines`, unowned-target fall-through); it runs in both CI jobs. The compat harness pins a dead `TERMIOD_SOCK` so its app-socket diffs stay deterministic — all 91 cases still pass, and 274 crate tests are green.

Release Notes:

- `termio sessions read` now answers from the session host, so it works for sessions never opened in a window — and on Linux boxes with no app.