### PR TITLE
Read a device's history and comparison in the git pane

### DIFF
--- a/Sources/termio/Git/DiffSource.swift
+++ b/Sources/termio/Git/DiffSource.swift
@@ -22,11 +22,21 @@ enum DiffSource {
             return await GitService.diffRows(
                 for: change, in: repoRoot, commit: commit, range: range)
         }
-        // `git.diff` answers the working-tree diff for one path. A commit or a
-        // range is the read tier's `git.show` / `git.log`, which this pane does
-        // not ask a device for yet — and inventing a local answer for a remote
-        // path would diff the wrong machine's file.
-        guard commit == nil, range == nil else { return [] }
+        // Three shapes, three verbs on the box: a commit's file is `git.show`,
+        // a compare row is `git.compare`, and the working tree is `git.diff` —
+        // inventing a local answer for a remote path would diff the wrong
+        // machine's file.
+        if let commit {
+            let text = (try? await Termiod.gitShowDiff(
+                route: device, root: repoRoot, commit: commit, path: change.path)) ?? ""
+            return await GitService.parseDiffText(text)
+        }
+        if let range {
+            guard let base = compareBase(of: range) else { return [] }
+            let text = (try? await Termiod.gitCompareDiff(
+                route: device, root: repoRoot, base: base, path: change.path)) ?? ""
+            return await GitService.parseDiffText(text)
+        }
         // Full context, exactly as the local path asks for it: the overlay holds
         // the whole file and collapses the unchanged runs into bands the reader
         // can expand. `GitService.diffRows` falls back to git's default context
@@ -35,6 +45,16 @@ enum DiffSource {
         let text = await text(
             for: change, in: repoRoot, device: device, context: 999_999)
         return await GitService.parseDiffText(text)
+    }
+
+    /// The base a compare row's range names. Every range this pane builds is
+    /// `<base>...HEAD` (`GitHistoryView`, `GitService.loadBranchCompare`);
+    /// `git.compare` takes the base because the device re-derives the range —
+    /// and the behind count — from it.
+    static func compareBase(of range: String) -> String? {
+        guard range.hasSuffix("...HEAD") else { return nil }
+        let base = String(range.dropLast("...HEAD".count))
+        return base.isEmpty ? nil : base
     }
 
     /// The raw unified-diff text — what "Copy Diff" puts on the pasteboard.

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -76,8 +76,8 @@ struct GitChangesView: View {
                 topBar
                 switch mode {
                 case .changes: changesBody
-                case .compare: GitCompareView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
-                case .history: GitHistoryView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
+                case .compare: GitCompareView(model: model, repoRoot: repoRoot, device: device, chrome: chrome, font: settings.interfaceFont)
+                case .history: GitHistoryView(model: model, repoRoot: repoRoot, device: device, chrome: chrome, font: settings.interfaceFont)
                 }
                 // Only Changes has a real total to report ("N files +A −D"). History's
                 // count would just echo the fetch limit — meaningless, so no bar.
@@ -212,14 +212,8 @@ struct GitChangesView: View {
     private var modeSwitch: some View {
         HStack(spacing: 0) {
             segment(localized("Changes"), .changes)
-            // Compare and History are the device's read tier (`git.log`,
-            // `git.branches`), which this pane does not ask for yet. Hidden
-            // rather than shown empty: a tab that answers nothing is worse than
-            // a tab that isn't there.
-            if device == nil {
-                segment(localized("Compare"), .compare)
-                segment(localized("History"), .history)
-            }
+            segment(localized("Compare"), .compare)
+            segment(localized("History"), .history)
         }
         // The selection pill rides behind the active segment and slides across on switch.
         .background { selectionPill }

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -12,6 +12,9 @@ struct GitHistoryView: View {
     @ObservedObject var model: GitPanelModel
 
     let repoRoot: String
+    /// The machine `repoRoot` lives on, when it is not this Mac — commit files
+    /// and diffs are then that box's answers, over the same views.
+    let device: TermiodRoute?
     let chrome: ChromeTheme?
     let font: Font
 
@@ -30,7 +33,8 @@ struct GitHistoryView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView(.vertical) {
-                    CommitList(commits: model.commits, repoRoot: repoRoot, chrome: chrome, font: font)
+                    CommitList(commits: model.commits, repoRoot: repoRoot, device: device,
+                               chrome: chrome, font: font)
                         .padding(.vertical, 6)
                 }
             }
@@ -54,6 +58,8 @@ struct GitCompareView: View {
     @ObservedObject var model: GitPanelModel
 
     let repoRoot: String
+    /// The machine `repoRoot` lives on, when it is not this Mac.
+    let device: TermiodRoute?
     let chrome: ChromeTheme?
     let font: Font
 
@@ -114,6 +120,13 @@ struct GitCompareView: View {
                     message: localized("This branch and the base branch share no commits.")
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .unreadable:
+                PaneEmptyState(
+                    localized("Can’t Compare"),
+                    icon: .serverStack,
+                    message: localized("The device couldn’t read this comparison.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         } else if model.compareContext != nil, model.compareBase == nil {
             PaneEmptyState(
@@ -140,7 +153,8 @@ struct GitCompareView: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         compareFiles(compare)
                         SectionLabel(title: localized("Commits"), count: compare.commits.count)
-                        CommitList(commits: compare.commits, repoRoot: repoRoot, chrome: chrome, font: font)
+                        CommitList(commits: compare.commits, repoRoot: repoRoot, device: device,
+                                   chrome: chrome, font: font)
                     }
                     // No top inset: the summary row is the file list's header and butts
                     // against the compare bar's hairline. Inset it and the gap reads as a
@@ -206,7 +220,7 @@ struct GitCompareView: View {
                         || (store.openDiff == nil && lastOpenedPath == file.path)
                 ) {
                     lastOpenedPath = file.path
-                    store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: file,
+                    store.openDiff = GitDiffRequest(repoRoot: repoRoot, device: device, change: file,
                                                     range: range, siblings: compare.files)
                 }
             }
@@ -223,6 +237,8 @@ private struct CommitList: View {
 
     let commits: [GitCommit]
     let repoRoot: String
+    /// The machine `repoRoot` lives on, when it is not this Mac.
+    let device: TermiodRoute?
     let chrome: ChromeTheme?
     let font: Font
 
@@ -278,7 +294,7 @@ private struct CommitList: View {
                                 && lastOpenedFile?.path == file.path)
                     ) {
                         lastOpenedFile = (commit.sha, file.path)
-                        store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: file,
+                        store.openDiff = GitDiffRequest(repoRoot: repoRoot, device: device, change: file,
                                                         commit: commit.sha, siblings: files)
                     }
                 }
@@ -299,8 +315,15 @@ private struct CommitList: View {
         expanded = commit.sha
         if filesByCommit[commit.sha] == nil {
             Task {
-                let files = await GitService.commitChanges(commit.sha, in: repoRoot)
-                filesByCommit[commit.sha] = files
+                if let device {
+                    // Degrades to "No file changes" on failure, like the local
+                    // path does when `git show` exits non-zero.
+                    filesByCommit[commit.sha] = (try? await Termiod.gitCommitFiles(
+                        route: device, root: repoRoot, commit: commit.sha)) ?? []
+                } else {
+                    filesByCommit[commit.sha] = await GitService.commitChanges(
+                        commit.sha, in: repoRoot)
+                }
             }
         }
     }

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -264,6 +264,30 @@ final class GitPanelModel: ObservableObject {
         deviceProblem = nil
         changes = Self.sorted(Array(deviceStatuses.values))
         isLoading = false
+        refreshDeviceReads(head: batch.head)
+    }
+
+    /// The head this pane last read History and Compare at. A batch whose head
+    /// moved means a commit, a checkout, or a fetch happened on the box — the
+    /// same signals the local pane's git-dir watch reloads on.
+    private var deviceReadHead: String?
+
+    /// Re-reads whatever device History and Compare state has already been
+    /// loaded, when the checkout moved under it. Nothing is fetched that a tab
+    /// has not asked for: an unopened History tab stays unloaded.
+    private func refreshDeviceReads(head: String?) {
+        guard let head, head != deviceReadHead else { return }
+        let firstReading = deviceReadHead == nil
+        deviceReadHead = head
+        // The first batch only establishes the head; the tabs load themselves.
+        guard !firstReading else { return }
+        Task {
+            if didLoadHistory { await loadHistory(force: true) }
+            if compareContext != nil {
+                await loadCompareContext()
+                await loadCompare()
+            }
+        }
     }
 
     /// Conflicts first — the one status that must be acted on — then by path, so
@@ -345,14 +369,16 @@ final class GitPanelModel: ObservableObject {
     /// Loads the commit history on demand (first time the History tab opens); re-run
     /// with `force` when the git dir reports a change.
     func loadHistory(force: Bool = false) async {
-        // History and Compare are the device's read tier (`git.log`,
-        // `git.branches`), which this pane does not ask for yet — so for a
-        // device checkout their tabs are hidden rather than shown empty.
-        guard device == nil else { return }
         guard force || !didLoadHistory else { return }
         didLoadHistory = true
         isLoadingHistory = commits.isEmpty
-        commits = await GitService.log(in: repoRoot)
+        if let device {
+            // A failed read degrades to an empty list, exactly as the local
+            // path does when `git log` exits non-zero.
+            commits = (try? await Termiod.gitLog(route: device, root: repoRoot).commits) ?? []
+        } else {
+            commits = await GitService.log(in: repoRoot)
+        }
         isLoadingHistory = false
     }
 
@@ -361,8 +387,11 @@ final class GitPanelModel: ObservableObject {
     /// Re-reads the branch and the bases it can be compared against. Cheap enough to run
     /// on every history refresh: three `git` reads of refs, no diff.
     func loadCompareContext() async {
-        guard device == nil else { return }
-        compareContext = await GitService.compareContext(in: repoRoot)
+        if let device {
+            compareContext = try? await Termiod.gitBranches(route: device, root: repoRoot)
+        } else {
+            compareContext = await GitService.compareContext(in: repoRoot)
+        }
     }
 
     /// Points the Compare tab at a base branch (or `nil` for none) and loads the
@@ -384,7 +413,12 @@ final class GitPanelModel: ObservableObject {
             compareProblem = nil
             return
         }
-        let outcome = await GitService.branchCompare(base: base, in: repoRoot)
+        let outcome: GitService.CompareOutcome
+        if let device {
+            outcome = await Self.deviceBranchCompare(route: device, root: repoRoot, base: base)
+        } else {
+            outcome = await GitService.branchCompare(base: base, in: repoRoot)
+        }
         guard compareBase == base else { return }
         switch outcome {
         case .ready(let loaded):
@@ -393,6 +427,32 @@ final class GitPanelModel: ObservableObject {
         case .problem(let problem):
             compare = nil
             compareProblem = problem
+        }
+    }
+
+    /// The device's comparison, composed the way the RFC intended: the file
+    /// list and behind count from `git.compare`, the commits from `git.log`
+    /// over the same range — two requests on the one pooled channel.
+    private static func deviceBranchCompare(
+        route: TermiodRoute, root: String, base: String
+    ) async -> GitService.CompareOutcome {
+        do {
+            async let comparison = Termiod.gitCompare(route: route, root: root, base: base)
+            async let logged = Termiod.gitLog(
+                route: route, root: root, limit: 200, range: "\(base)..HEAD")
+            let (compared, ranged) = try await (comparison, logged)
+            if let problem = compared.problem { return .problem(problem) }
+            return .ready(GitService.BranchCompare(
+                base: base, files: compared.files,
+                commits: ranged.commits, behind: compared.behind))
+        } catch {
+            Log.termiod.error("""
+            device compare against \(base, privacy: .public) failed: \
+            \(String(describing: error), privacy: .public)
+            """)
+            // Stated, never folded into an empty list — an empty comparison
+            // reads as "this branch changes nothing".
+            return .problem(.unreadable)
         }
     }
 

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -366,19 +366,33 @@ final class GitPanelModel: ObservableObject {
         }
     }
 
+    /// Monotonic tickets for the three read loaders below: only the newest
+    /// pass may publish. Two refreshes can overlap — a burst of device head
+    /// changes, a git-dir event landing during a forced reload — and without
+    /// the ticket the slower, older read wins and the pane shows a checkout
+    /// the repository has already left.
+    private var historyGeneration = 0
+    private var compareContextGeneration = 0
+    private var compareGeneration = 0
+
     /// Loads the commit history on demand (first time the History tab opens); re-run
     /// with `force` when the git dir reports a change.
     func loadHistory(force: Bool = false) async {
         guard force || !didLoadHistory else { return }
         didLoadHistory = true
+        historyGeneration += 1
+        let generation = historyGeneration
         isLoadingHistory = commits.isEmpty
+        let loaded: [GitCommit]
         if let device {
             // A failed read degrades to an empty list, exactly as the local
             // path does when `git log` exits non-zero.
-            commits = (try? await Termiod.gitLog(route: device, root: repoRoot).commits) ?? []
+            loaded = (try? await Termiod.gitLog(route: device, root: repoRoot).commits) ?? []
         } else {
-            commits = await GitService.log(in: repoRoot)
+            loaded = await GitService.log(in: repoRoot)
         }
+        guard generation == historyGeneration else { return }
+        commits = loaded
         isLoadingHistory = false
     }
 
@@ -387,11 +401,16 @@ final class GitPanelModel: ObservableObject {
     /// Re-reads the branch and the bases it can be compared against. Cheap enough to run
     /// on every history refresh: three `git` reads of refs, no diff.
     func loadCompareContext() async {
+        compareContextGeneration += 1
+        let generation = compareContextGeneration
+        let loaded: GitService.CompareContext?
         if let device {
-            compareContext = try? await Termiod.gitBranches(route: device, root: repoRoot)
+            loaded = try? await Termiod.gitBranches(route: device, root: repoRoot)
         } else {
-            compareContext = await GitService.compareContext(in: repoRoot)
+            loaded = await GitService.compareContext(in: repoRoot)
         }
+        guard generation == compareContextGeneration else { return }
+        compareContext = loaded
     }
 
     /// Points the Compare tab at a base branch (or `nil` for none) and loads the
@@ -413,13 +432,17 @@ final class GitPanelModel: ObservableObject {
             compareProblem = nil
             return
         }
+        compareGeneration += 1
+        let generation = compareGeneration
         let outcome: GitService.CompareOutcome
         if let device {
             outcome = await Self.deviceBranchCompare(route: device, root: repoRoot, base: base)
         } else {
             outcome = await GitService.branchCompare(base: base, in: repoRoot)
         }
-        guard compareBase == base else { return }
+        // The base check catches a re-pick; the generation catches a same-base
+        // refresh overtaken by a newer one.
+        guard compareBase == base, generation == compareGeneration else { return }
         switch outcome {
         case .ready(let loaded):
             compare = loaded
@@ -430,21 +453,18 @@ final class GitPanelModel: ObservableObject {
         }
     }
 
-    /// The device's comparison, composed the way the RFC intended: the file
-    /// list and behind count from `git.compare`, the commits from `git.log`
-    /// over the same range — two requests on the one pooled channel.
+    /// The device's comparison: one `git.compare` reply carrying files,
+    /// commits, and behind — all walked from the one head the device pinned,
+    /// so the three can never describe different checkouts.
     private static func deviceBranchCompare(
         route: TermiodRoute, root: String, base: String
     ) async -> GitService.CompareOutcome {
         do {
-            async let comparison = Termiod.gitCompare(route: route, root: root, base: base)
-            async let logged = Termiod.gitLog(
-                route: route, root: root, limit: 200, range: "\(base)..HEAD")
-            let (compared, ranged) = try await (comparison, logged)
+            let compared = try await Termiod.gitCompare(route: route, root: root, base: base)
             if let problem = compared.problem { return .problem(problem) }
             return .ready(GitService.BranchCompare(
                 base: base, files: compared.files,
-                commits: ranged.commits, behind: compared.behind))
+                commits: compared.commits, behind: compared.behind))
         } catch {
             Log.termiod.error("""
             device compare against \(base, privacy: .public) failed: \

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -238,6 +238,10 @@ enum GitService {
         /// point sits above where the branches diverged. There is no merge base to diff
         /// from, so any file list here would be the whole tree rather than a change.
         case noCommonHistory
+        /// A device checkout's comparison could not be read — the request
+        /// failed, or the device named a problem this build has never heard of.
+        /// Never produced by the local path.
+        case unreadable
     }
 
     enum CompareOutcome: Sendable {

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -1062,6 +1062,16 @@
         }
       }
     },
+    "Can’t Compare": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法对比"
+          }
+        }
+      }
+    },
     "Can’t Search": {
       "localizations": {
         "zh-Hans": {
@@ -6604,6 +6614,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "该设备无法读取这个检出。"
+          }
+        }
+      }
+    },
+    "The device couldn’t read this comparison.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该设备无法读取这个对比。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -224,6 +224,8 @@
 	<string>Built-in</string>
 	<key>Cancel</key>
 	<string>Cancel</string>
+	<key>Can’t Compare</key>
+	<string>Can’t Compare</string>
 	<key>Can’t Search</key>
 	<string>Can’t Search</string>
 	<key>Can’t browse %@</key>
@@ -1336,6 +1338,8 @@
 	<string>The coding agents offered when you start a session</string>
 	<key>The device couldn’t read this checkout.</key>
 	<string>The device couldn’t read this checkout.</string>
+	<key>The device couldn’t read this comparison.</key>
+	<string>The device couldn’t read this comparison.</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
 	<string>The devices in your ~/.ssh/config, and the keys that reach them</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -224,6 +224,8 @@
 	<string>内置</string>
 	<key>Cancel</key>
 	<string>取消</string>
+	<key>Can’t Compare</key>
+	<string>无法对比</string>
 	<key>Can’t Search</key>
 	<string>无法搜索</string>
 	<key>Can’t browse %@</key>
@@ -1336,6 +1338,8 @@
 	<string>新建会话时可以选用的编程 Agent</string>
 	<key>The device couldn’t read this checkout.</key>
 	<string>该设备无法读取这个检出。</string>
+	<key>The device couldn’t read this comparison.</key>
+	<string>该设备无法读取这个对比。</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
 	<string>~/.ssh/config 里的设备，以及连上它们的密钥</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>

--- a/Sources/termio/Terminal/Termiod/TermiodGit.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodGit.swift
@@ -175,18 +175,22 @@ extension Termiod {
         return compareContext(from: result)
     }
 
-    /// The branch against a base: the three-dot file list and the behind count.
-    /// The commits ride `gitLog` with a range; a `problem` means the checkout
-    /// could not be compared and says why.
+    /// The branch against a base — files, commits, and behind count in one
+    /// reply, all describing the one head the device pinned before walking. A
+    /// `problem` means the checkout could not be compared and says why.
     static func gitCompare(
         route: TermiodRoute, root: String, base: String
-    ) async throws -> (files: [GitChange], behind: Int, problem: GitService.CompareProblem?) {
+    ) async throws -> (
+        files: [GitChange], commits: [GitCommit], behind: Int,
+        problem: GitService.CompareProblem?
+    ) {
         let result = try await readTier(
             route: route, WireGitCompareResult.self, operation: "git compare \(base)"
         ) { seq in
             try encodeControl(GitCompareOperation(root: root, base: base, path: nil, seq: seq))
         }
-        return (result.files.compactMap(\.change), result.behind, result.compareProblem)
+        return (result.files.compactMap(\.change), commits(from: result.commits),
+                result.behind, result.compareProblem)
     }
 
     /// One file's three-dot diff across `base...HEAD` — what a Compare file
@@ -438,15 +442,20 @@ extension Termiod {
 
     struct WireGitCompareResult: Decodable, Sendable {
         let files: [WireGitCommitFile]
+        let commits: [WireGitCommit]
         let behind: Int
         let diff: String
         let problem: String?
 
-        private enum CodingKeys: String, CodingKey { case files, behind, diff, problem }
+        private enum CodingKeys: String, CodingKey {
+            case files, commits, behind, diff, problem
+        }
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             files = try container.decodeIfPresent([WireGitCommitFile].self, forKey: .files) ?? []
+            commits = try container.decodeIfPresent(
+                [WireGitCommit].self, forKey: .commits) ?? []
             behind = try container.decodeIfPresent(Int.self, forKey: .behind) ?? 0
             diff = try container.decodeIfPresent(String.self, forKey: .diff) ?? ""
             problem = try container.decodeIfPresent(String.self, forKey: .problem)

--- a/Sources/termio/Terminal/Termiod/TermiodGit.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodGit.swift
@@ -84,32 +84,137 @@ extension Termiod {
     static func gitDiff(
         route: TermiodRoute, root: String, path: String, staged: Bool, context: Int? = nil
     ) async throws -> (text: String, truncated: Bool) {
+        let result = try await readTier(
+            route: route, GitDiffResult.self, operation: "git diff \(path)"
+        ) { seq in
+            try encodeControl(GitDiffOperation(
+                root: root, path: path, staged: staged,
+                context: context.map(UInt64.init), seq: seq))
+        }
+        return (result.diff, result.truncated)
+    }
+
+    // MARK: History and Compare — the read tier
+
+    /// One read-tier request: send the operation, wait for its reply, decode it
+    /// here. None of these replies are in the shared decode table — each is its
+    /// own plane's answer and nothing else consumes it — so they all arrive as
+    /// `.unknown` and are decoded against `Wire`.
+    private static func readTier<Wire: Decodable & Sendable>(
+        route: TermiodRoute, _ wire: Wire.Type, operation: String,
+        encode: @escaping @Sendable (UInt64) throws -> Data
+    ) async throws -> Wire {
         try await offMain {
             try withPooledRequest(route: route, caps: gitCapabilities) { call, channel in
                 guard channel.capabilities.contains("git") else {
                     throw DeviceGitError.unsupported
                 }
-                try call.send(payload: encodeControl(GitDiffOperation(
-                    root: root, path: path, staged: staged,
-                    context: context.map(UInt64.init), seq: call.seq)))
+                try call.send(payload: encode(call.seq))
                 while true {
                     let frame = try call.next(
-                        timeoutSeconds: connectTimeoutSeconds, operation: "git diff \(path)")
+                        timeoutSeconds: connectTimeoutSeconds, operation: operation)
                     guard frame.kind == .control else { continue }
                     let reply = try decodeControl(frame.payload)
                     if case .error(let failure) = reply {
                         throw TermiodClientError.requestFailed(failure.message)
                     }
                     guard case .unknown = reply else { continue }
-                    // `git_diff_result` is not in the shared decode table: it is
-                    // this plane's own reply and nothing else consumes it, so it
-                    // is decoded here rather than grown into an enum every other
-                    // channel would carry.
-                    let result = try gitDecoder().decode(GitDiffResult.self, from: frame.payload)
-                    return (result.diff, result.truncated)
+                    return try gitDecoder().decode(Wire.self, from: frame.payload)
                 }
             }
         }
+    }
+
+    /// The checkout's recent commits, newest first — the History tab, and with
+    /// `range` (`base..HEAD`) the commit half of a branch comparison.
+    static func gitLog(
+        route: TermiodRoute, root: String, limit: Int = 100, range: String? = nil
+    ) async throws -> (commits: [GitCommit], truncated: Bool) {
+        let result = try await readTier(
+            route: route, WireGitLogResult.self, operation: "git log"
+        ) { seq in
+            try encodeControl(GitLogOperation(
+                root: root, limit: UInt64(limit), range: range, seq: seq))
+        }
+        return (commits(from: result.commits), result.truncated)
+    }
+
+    /// The files one commit touched — the rows a History entry expands to.
+    static func gitCommitFiles(
+        route: TermiodRoute, root: String, commit: String
+    ) async throws -> [GitChange] {
+        let result = try await readTier(
+            route: route, WireGitShowResult.self, operation: "git show \(commit)"
+        ) { seq in
+            try encodeControl(GitShowOperation(root: root, commit: commit, path: nil, seq: seq))
+        }
+        return result.files.compactMap(\.change)
+    }
+
+    /// One file's diff as of one commit — what a History file row opens.
+    static func gitShowDiff(
+        route: TermiodRoute, root: String, commit: String, path: String
+    ) async throws -> String {
+        try await readTier(
+            route: route, WireGitShowResult.self, operation: "git show \(commit) \(path)"
+        ) { seq in
+            try encodeControl(GitShowOperation(root: root, commit: commit, path: path, seq: seq))
+        }.diff
+    }
+
+    /// The checkout's refs, composed into the Compare tab's base-picker context
+    /// with the same suggestion rule the local pane uses.
+    static func gitBranches(
+        route: TermiodRoute, root: String
+    ) async throws -> GitService.CompareContext {
+        let result = try await readTier(
+            route: route, WireGitBranchesResult.self, operation: "git branches"
+        ) { seq in
+            try encodeControl(GitBranchesOperation(root: root, seq: seq))
+        }
+        return compareContext(from: result)
+    }
+
+    /// The branch against a base: the three-dot file list and the behind count.
+    /// The commits ride `gitLog` with a range; a `problem` means the checkout
+    /// could not be compared and says why.
+    static func gitCompare(
+        route: TermiodRoute, root: String, base: String
+    ) async throws -> (files: [GitChange], behind: Int, problem: GitService.CompareProblem?) {
+        let result = try await readTier(
+            route: route, WireGitCompareResult.self, operation: "git compare \(base)"
+        ) { seq in
+            try encodeControl(GitCompareOperation(root: root, base: base, path: nil, seq: seq))
+        }
+        return (result.files.compactMap(\.change), result.behind, result.compareProblem)
+    }
+
+    /// One file's three-dot diff across `base...HEAD` — what a Compare file
+    /// row opens.
+    static func gitCompareDiff(
+        route: TermiodRoute, root: String, base: String, path: String
+    ) async throws -> String {
+        try await readTier(
+            route: route, WireGitCompareResult.self, operation: "git compare \(base) \(path)"
+        ) { seq in
+            try encodeControl(GitCompareOperation(root: root, base: base, path: path, seq: seq))
+        }.diff
+    }
+
+    /// Composes the wire's ref list into the local pane's picker context, so
+    /// the Compare tab renders a device checkout through the identical view —
+    /// same lists, same suggestion rule.
+    static func compareContext(from result: WireGitBranchesResult) -> GitService.CompareContext {
+        let locals = result.branches.filter { !$0.remote && $0.name != result.current }
+            .map(\.name)
+        let remotes = result.branches.filter(\.remote).map(\.name)
+        return GitService.CompareContext(
+            branch: result.current,
+            remoteBranches: remotes,
+            localBranches: locals,
+            suggestedBase: GitService.suggestedCompareBase(
+                branch: result.current, originHead: result.defaultBranch,
+                remoteBranches: remotes, localBranches: locals))
     }
 
     /// Runs a blocking pooled request off the main thread. Every verb here is
@@ -169,6 +274,225 @@ extension Termiod {
             diff = try container.decodeIfPresent(String.self, forKey: .diff) ?? ""
             truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
         }
+    }
+
+    /// Maps wire commits to the pane's rows. The wire carries both the box's
+    /// own rendered `relative_date` and the instant: the box may speak another
+    /// language, so the date is formatted here from `timestamp` and the box's
+    /// rendering is only the fallback for a host too old to send one.
+    static func commits(from wire: [WireGitCommit]) -> [GitCommit] {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        let now = Date()
+        return wire.map { $0.commit(formatter: formatter, now: now) }
+    }
+
+    /// A commit-file status as `GitStatusCode` spells it on the wire. `nil` for
+    /// a status this build cannot draw — the row is dropped rather than drawn
+    /// as a guess, the same additive-evolution rule the status batches follow.
+    static func commitFileStatus(_ code: String) -> GitFileStatus? {
+        switch code {
+        case "modified", "type_changed": return .modified
+        case "added": return .added
+        case "deleted": return .deleted
+        case "renamed": return .renamed
+        case "copied": return .copied
+        default: return nil
+        }
+    }
+
+    struct WireGitCommit: Decodable, Sendable {
+        let sha: String
+        let shortSha: String
+        let subject: String
+        let author: String
+        let authorEmail: String
+        let relativeDate: String
+        let timestamp: Int64
+        let tags: [String]
+        let unpushed: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case sha, shortSha, subject, author, authorEmail, relativeDate
+            case timestamp, tags, unpushed
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            sha = try container.decode(String.self, forKey: .sha)
+            shortSha = try container.decodeIfPresent(String.self, forKey: .shortSha)
+                ?? String(sha.prefix(7))
+            subject = try container.decodeIfPresent(String.self, forKey: .subject) ?? ""
+            author = try container.decodeIfPresent(String.self, forKey: .author) ?? ""
+            authorEmail = try container.decodeIfPresent(String.self, forKey: .authorEmail) ?? ""
+            relativeDate = try container.decodeIfPresent(String.self, forKey: .relativeDate) ?? ""
+            timestamp = try container.decodeIfPresent(Int64.self, forKey: .timestamp) ?? 0
+            tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
+            unpushed = try container.decodeIfPresent(Bool.self, forKey: .unpushed) ?? false
+        }
+
+        func commit(formatter: RelativeDateTimeFormatter, now: Date) -> GitCommit {
+            GitCommit(
+                sha: sha, shortSHA: shortSha, subject: subject,
+                author: author, authorEmail: authorEmail,
+                relativeDate: timestamp > 0
+                    ? formatter.localizedString(
+                        for: Date(timeIntervalSince1970: TimeInterval(timestamp)),
+                        relativeTo: now)
+                    : relativeDate,
+                tags: tags, isUnpushed: unpushed)
+        }
+    }
+
+    struct WireGitCommitFile: Decodable, Sendable {
+        let path: String
+        let originalPath: String?
+        let status: String
+        let additions: Int
+        let deletions: Int
+        let binary: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case path, originalPath, status, additions, deletions, binary
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            path = try container.decode(String.self, forKey: .path)
+            originalPath = try container.decodeIfPresent(String.self, forKey: .originalPath)
+            status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+            additions = try container.decodeIfPresent(Int.self, forKey: .additions) ?? 0
+            deletions = try container.decodeIfPresent(Int.self, forKey: .deletions) ?? 0
+            binary = try container.decodeIfPresent(Bool.self, forKey: .binary) ?? false
+        }
+
+        var change: GitChange? {
+            guard let status = Termiod.commitFileStatus(status) else { return nil }
+            return GitChange(
+                path: path, status: status, isUntracked: false,
+                additions: additions, deletions: deletions,
+                originalPath: originalPath, isBinary: binary)
+        }
+    }
+
+    struct WireGitLogResult: Decodable, Sendable {
+        let commits: [WireGitCommit]
+        let truncated: Bool
+
+        private enum CodingKeys: String, CodingKey { case commits, truncated }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            commits = try container.decodeIfPresent([WireGitCommit].self, forKey: .commits) ?? []
+            truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+        }
+    }
+
+    struct WireGitShowResult: Decodable, Sendable {
+        let files: [WireGitCommitFile]
+        let diff: String
+        let truncated: Bool
+        let filesTruncated: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case files, diff, truncated, filesTruncated
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            files = try container.decodeIfPresent([WireGitCommitFile].self, forKey: .files) ?? []
+            diff = try container.decodeIfPresent(String.self, forKey: .diff) ?? ""
+            truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+            filesTruncated = try container.decodeIfPresent(
+                Bool.self, forKey: .filesTruncated) ?? false
+        }
+    }
+
+    struct WireGitBranch: Decodable, Sendable {
+        let name: String
+        let remote: Bool
+
+        private enum CodingKeys: String, CodingKey { case name, remote }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            remote = try container.decodeIfPresent(Bool.self, forKey: .remote) ?? false
+        }
+    }
+
+    struct WireGitBranchesResult: Decodable, Sendable {
+        let branches: [WireGitBranch]
+        let current: String?
+        let defaultBranch: String?
+
+        private enum CodingKeys: String, CodingKey { case branches, current, defaultBranch }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            branches = try container.decodeIfPresent([WireGitBranch].self, forKey: .branches) ?? []
+            current = try container.decodeIfPresent(String.self, forKey: .current)
+            defaultBranch = try container.decodeIfPresent(String.self, forKey: .defaultBranch)
+        }
+    }
+
+    struct WireGitCompareResult: Decodable, Sendable {
+        let files: [WireGitCommitFile]
+        let behind: Int
+        let diff: String
+        let problem: String?
+
+        private enum CodingKeys: String, CodingKey { case files, behind, diff, problem }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            files = try container.decodeIfPresent([WireGitCommitFile].self, forKey: .files) ?? []
+            behind = try container.decodeIfPresent(Int.self, forKey: .behind) ?? 0
+            diff = try container.decodeIfPresent(String.self, forKey: .diff) ?? ""
+            problem = try container.decodeIfPresent(String.self, forKey: .problem)
+        }
+
+        /// The device's stated problem in the pane's vocabulary. A problem this
+        /// build has never heard of still *is* one — it must not fold into a
+        /// clean empty comparison, so it maps to the unreadable case.
+        var compareProblem: GitService.CompareProblem? {
+            switch problem {
+            case nil: return nil
+            case "missing_base": return .missingBase
+            case "no_common_history": return .noCommonHistory
+            default: return .unreadable
+            }
+        }
+    }
+
+    private struct GitLogOperation: Encodable {
+        let op = "git_log"
+        let root: String
+        let limit: UInt64
+        let range: String?
+        let seq: UInt64
+    }
+
+    private struct GitShowOperation: Encodable {
+        let op = "git_show"
+        let root: String
+        let commit: String
+        let path: String?
+        let seq: UInt64
+    }
+
+    private struct GitBranchesOperation: Encodable {
+        let op = "git_branches"
+        let root: String
+        let seq: UInt64
+    }
+
+    private struct GitCompareOperation: Encodable {
+        let op = "git_compare"
+        let root: String
+        let base: String
+        let path: String?
+        let seq: UInt64
     }
 
     private struct WireGitChanged: Decodable {

--- a/Tests/termioTests/DeviceGitReadTests.swift
+++ b/Tests/termioTests/DeviceGitReadTests.swift
@@ -108,12 +108,19 @@ final class DeviceGitReadTests: XCTestCase {
         XCTAssertNil(try problem("{\"files\": [], \"behind\": 2}"))
     }
 
-    func testACompareResultCarriesFilesAndBehind() throws {
+    func testACompareResultCarriesFilesCommitsAndBehind() throws {
         let result = try decode(Termiod.WireGitCompareResult.self, """
         {"files": [{"path": "b.txt", "status": "added", "additions": 1}],
+         "commits": [{"sha": "cccc3333", "short_sha": "cccc333",
+                      "subject": "branch commit", "author": "Dev",
+                      "author_email": "dev@example.com",
+                      "relative_date": "now", "timestamp": 1700000000}],
          "behind": 4, "diff": ""}
         """)
         XCTAssertEqual(result.files.compactMap(\.change).map(\.path), ["b.txt"])
+        // One reply carries the whole comparison, so files and commits can
+        // never describe two different heads.
+        XCTAssertEqual(result.commits.map(\.sha), ["cccc3333"])
         XCTAssertEqual(result.behind, 4)
         XCTAssertNil(result.compareProblem)
     }

--- a/Tests/termioTests/DeviceGitReadTests.swift
+++ b/Tests/termioTests/DeviceGitReadTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import TermioShared
+@testable import termio
+
+/// The read tier's wire-to-pane mappings, pinned without a connection: a
+/// device's commits, commit files, refs, and comparison must land in the same
+/// models the local pane renders, byte-shaped exactly as `termiod/src/git.rs`
+/// serializes them.
+final class DeviceGitReadTests: XCTestCase {
+
+    private func decode<Wire: Decodable>(_ type: Wire.Type, _ json: String) throws -> Wire {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Wire.self, from: Data(json.utf8))
+    }
+
+    // MARK: - Commits
+
+    func testAWireCommitLandsInThePanesRow() throws {
+        let result = try decode(Termiod.WireGitLogResult.self, """
+        {"commits": [{"sha": "aaaa1111", "short_sha": "aaaa111", "subject": "fix it",
+                      "author": "Dev", "author_email": "dev@example.com",
+                      "relative_date": "vor 3 Stunden", "timestamp": 1700000000,
+                      "tags": ["v1.0"], "unpushed": true}],
+         "truncated": true}
+        """)
+        let commits = Termiod.commits(from: result.commits)
+        XCTAssertEqual(commits.count, 1)
+        let commit = try XCTUnwrap(commits.first)
+        XCTAssertEqual(commit.sha, "aaaa1111")
+        XCTAssertEqual(commit.shortSHA, "aaaa111")
+        XCTAssertEqual(commit.subject, "fix it")
+        XCTAssertEqual(commit.tags, ["v1.0"])
+        XCTAssertTrue(commit.isUnpushed)
+        XCTAssertTrue(result.truncated)
+        // The instant is formatted here, in this Mac's language — never the
+        // box's own rendering when a timestamp is there to format.
+        XCTAssertFalse(commit.relativeDate.isEmpty)
+        XCTAssertNotEqual(commit.relativeDate, "vor 3 Stunden")
+    }
+
+    func testAHostTooOldForTimestampsFallsBackToItsOwnWords() throws {
+        let result = try decode(Termiod.WireGitLogResult.self, """
+        {"commits": [{"sha": "bbbb2222", "short_sha": "bbbb222", "subject": "old",
+                      "author": "Dev", "author_email": "dev@example.com",
+                      "relative_date": "3 hours ago"}]}
+        """)
+        XCTAssertEqual(
+            Termiod.commits(from: result.commits).first?.relativeDate, "3 hours ago")
+    }
+
+    // MARK: - Commit files
+
+    func testACommitFileKeepsItsStatusCountsAndRename() throws {
+        let result = try decode(Termiod.WireGitShowResult.self, """
+        {"files": [{"path": "new.swift", "original_path": "old.swift",
+                    "status": "renamed", "additions": 3, "deletions": 1},
+                   {"path": "kind.swift", "status": "type_changed"},
+                   {"path": "weird.swift", "status": "from_the_future"}],
+         "diff": "diff --git", "truncated": false}
+        """)
+        let changes = result.files.compactMap(\.change)
+        // The unknown status dropped its row rather than drawing a guess —
+        // the same additive-evolution rule the status batches follow.
+        XCTAssertEqual(changes.map(\.path), ["new.swift", "kind.swift"])
+        let renamed = try XCTUnwrap(changes.first)
+        XCTAssertEqual(renamed.status, .renamed)
+        XCTAssertEqual(renamed.originalPath, "old.swift")
+        XCTAssertEqual(renamed.additions, 3)
+        XCTAssertEqual(renamed.deletions, 1)
+        XCTAssertEqual(changes.last?.status, .modified)
+    }
+
+    // MARK: - Branches → compare context
+
+    func testTheRefListComposesThePickerLikeTheLocalPane() throws {
+        let result = try decode(Termiod.WireGitBranchesResult.self, """
+        {"branches": [{"name": "feat/x"}, {"name": "main"},
+                      {"name": "origin/main", "remote": true},
+                      {"name": "origin/feat/x", "remote": true}],
+         "current": "feat/x", "default_branch": "origin/main"}
+        """)
+        let context = Termiod.compareContext(from: result)
+        XCTAssertEqual(context.branch, "feat/x")
+        // The checkout's own branch is the one ref that can't be a base.
+        XCTAssertEqual(context.localBranches, ["main"])
+        XCTAssertEqual(context.remoteBranches, ["origin/main", "origin/feat/x"])
+        XCTAssertEqual(context.suggestedBase, "origin/main")
+    }
+
+    // MARK: - Compare
+
+    func testACompareProblemArrivesInThePanesVocabulary() throws {
+        func problem(_ json: String) throws -> GitService.CompareProblem? {
+            try decode(Termiod.WireGitCompareResult.self, json).compareProblem
+        }
+        guard case .missingBase = try problem("{\"problem\": \"missing_base\"}") else {
+            return XCTFail("missing_base must map to missingBase")
+        }
+        guard case .noCommonHistory = try problem("{\"problem\": \"no_common_history\"}") else {
+            return XCTFail("no_common_history must map to noCommonHistory")
+        }
+        // A problem this build has never heard of still *is* one: it must not
+        // fold into a clean empty comparison.
+        guard case .unreadable = try problem("{\"problem\": \"paradox\"}") else {
+            return XCTFail("an unknown problem must stay a problem")
+        }
+        XCTAssertNil(try problem("{\"files\": [], \"behind\": 2}"))
+    }
+
+    func testACompareResultCarriesFilesAndBehind() throws {
+        let result = try decode(Termiod.WireGitCompareResult.self, """
+        {"files": [{"path": "b.txt", "status": "added", "additions": 1}],
+         "behind": 4, "diff": ""}
+        """)
+        XCTAssertEqual(result.files.compactMap(\.change).map(\.path), ["b.txt"])
+        XCTAssertEqual(result.behind, 4)
+        XCTAssertNil(result.compareProblem)
+    }
+
+    // MARK: - Range → base
+
+    func testTheCompareRangeNamesItsBase() {
+        XCTAssertEqual(DiffSource.compareBase(of: "origin/main...HEAD"), "origin/main")
+        XCTAssertEqual(DiffSource.compareBase(of: "feat/x...HEAD"), "feat/x")
+        // Anything not shaped like the pane's own ranges answers nothing —
+        // guessing a base would diff the wrong thing on someone's box.
+        XCTAssertNil(DiffSource.compareBase(of: "...HEAD"))
+        XCTAssertNil(DiffSource.compareBase(of: "a..b"))
+    }
+}

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1293,6 +1293,17 @@ async fn run_connection(
             frame = read_frame(&mut rd) => {
                 match frame {
                     Ok(Some(Frame::Control(control))) => pending = Some(control),
+                    // A verb from a newer client is version skew, not a broken
+                    // pipe: that request fails, the connection — and every
+                    // subscription riding it — lives on.
+                    Ok(Some(Frame::UnknownControl { op, seq })) => {
+                        let _ = out.send(Outbound::Control(error(
+                            seq,
+                            ErrorCode::ProtoError,
+                            format!("unknown op: {op}"),
+                            false,
+                        )));
+                    }
                     Ok(Some(Frame::Event(event))) => {
                         // Events are host-authored. Unknown/inapplicable event
                         // types are ignored by the additive-evolution rule.
@@ -1855,10 +1866,12 @@ async fn process_control(
                         match crate::git::run_compare(&root, &base, path.as_deref()).await {
                             Ok(outcome) => Control::GitCompareResult {
                                 files: outcome.files,
+                                commits: outcome.commits,
                                 behind: outcome.behind,
                                 diff: outcome.diff,
                                 truncated: outcome.truncated,
                                 files_truncated: outcome.files_truncated,
+                                commits_truncated: outcome.commits_truncated,
                                 problem: outcome.problem,
                                 re: seq,
                             },
@@ -2757,6 +2770,16 @@ async fn run_attach(
                     rows,
                     cols,
                 });
+            }
+            // Version skew, not a broken pipe: the request fails, the
+            // attachment lives on.
+            Ok(Some(Frame::UnknownControl { op, seq })) => {
+                let _ = out.send(Outbound::Control(error(
+                    seq,
+                    ErrorCode::ProtoError,
+                    format!("unknown op: {op}"),
+                    false,
+                )));
             }
             Ok(Some(Frame::Snapshot(_))) => {
                 let _ = out.send(Outbound::Control(error(

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1840,6 +1840,34 @@ async fn process_control(
                 });
             }
         }
+        Control::GitCompare {
+            root,
+            base,
+            path,
+            seq,
+        } => {
+            if let Some(denied) = git_denied(connection, seq) {
+                send_response(out, response_cache, seq, denied);
+            } else {
+                let out = out.clone();
+                tokio::spawn(async move {
+                    let response =
+                        match crate::git::run_compare(&root, &base, path.as_deref()).await {
+                            Ok(outcome) => Control::GitCompareResult {
+                                files: outcome.files,
+                                behind: outcome.behind,
+                                diff: outcome.diff,
+                                truncated: outcome.truncated,
+                                files_truncated: outcome.files_truncated,
+                                problem: outcome.problem,
+                                re: seq,
+                            },
+                            Err(e) => error(seq, ErrorCode::Denied, format!("{e:#}"), false),
+                        };
+                    let _ = out.send(Outbound::Control(response));
+                });
+            }
+        }
         Control::FsList {
             root,
             paths,
@@ -2236,6 +2264,7 @@ async fn process_control(
         | Control::GitLogResult { .. }
         | Control::GitShowResult { .. }
         | Control::GitBranchesResult { .. }
+        | Control::GitCompareResult { .. }
         | Control::UploadOpened { .. }
         | Control::UploadAck { .. }
         | Control::UploadCommitted { .. }

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -883,15 +883,26 @@ pub async fn run_branches(root: &str) -> Result<GitBranchList> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitCompareOutcome {
     pub files: Vec<GitCommitFile>,
+    pub commits: Vec<GitCommitEntry>,
     pub behind: u64,
     pub diff: String,
     pub truncated: bool,
     pub files_truncated: bool,
+    pub commits_truncated: bool,
     pub problem: Option<crate::protocol::GitCompareProblem>,
 }
 
-/// `git.compare` (§C.13 read tier): the three-dot file list and behind count
-/// the Compare tab needs, plus one file's ranged diff when `path` narrows it.
+/// How many commits one comparison carries — the local pane's own limit.
+const COMPARE_LOG_CAP: u64 = 200;
+
+/// `git.compare` (§C.13 read tier): the three-dot file list, the commits the
+/// merge would bring, and the behind count — the whole Compare tab in one
+/// reply, plus one file's ranged diff when `path` narrows it.
+///
+/// One reply on purpose: `HEAD` is resolved to a sha once and every walk uses
+/// the sha, so a commit or checkout landing between the child processes cannot
+/// hand back a file list from one head and commits from another. Composed
+/// client-side from `git_log` + `git_compare`, that tear was reachable.
 ///
 /// The two problems are asked of git up front rather than inferred from a
 /// failed diff: without a merge base the three-dot diff exits non-zero and
@@ -903,10 +914,12 @@ pub async fn run_compare(root: &str, base: &str, path: Option<&str>) -> Result<G
     let problem = |problem| {
         Ok(GitCompareOutcome {
             files: Vec::new(),
+            commits: Vec::new(),
             behind: 0,
             diff: String::new(),
             truncated: false,
             files_truncated: false,
+            commits_truncated: false,
             problem: Some(problem),
         })
     };
@@ -931,11 +944,24 @@ pub async fn run_compare(root: &str, base: &str, path: Option<&str>) -> Result<G
     if !merge_base.status.success() {
         return problem(crate::protocol::GitCompareProblem::NoCommonHistory);
     }
+    let pinned = git_command(root)
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .await
+        .context("running git rev-parse")?;
+    if !pinned.status.success() {
+        bail!(
+            "git rev-parse failed: {}",
+            String::from_utf8_lossy(&pinned.stderr).trim()
+        );
+    }
+    let head = String::from_utf8_lossy(&pinned.stdout).trim().to_string();
 
     // Three dots: from the merge base, so commits that landed on the base
     // since this branch started don't show up inverted as changes the branch
     // never made.
-    let range = format!("{base}...HEAD");
+    let range = format!("{base}...{head}");
     let listed = git_command(root)
         .arg("diff")
         .arg("--raw")
@@ -964,7 +990,7 @@ pub async fn run_compare(root: &str, base: &str, path: Option<&str>) -> Result<G
     let counted = git_command(root)
         .arg("rev-list")
         .arg("--count")
-        .arg(format!("HEAD..{base}"))
+        .arg(format!("{head}..{base}"))
         .output()
         .await
         .context("running git rev-list")?;
@@ -972,6 +998,9 @@ pub async fn run_compare(root: &str, base: &str, path: Option<&str>) -> Result<G
         .trim()
         .parse()
         .unwrap_or(0);
+
+    // The commits the merge would bring, walked from the same pinned head.
+    let log = run_log(root, COMPARE_LOG_CAP, Some(&format!("{base}..{head}"))).await?;
 
     let (diff, truncated) = if let Some(path) = path {
         let mut command = git_command(root);
@@ -1000,10 +1029,12 @@ pub async fn run_compare(root: &str, base: &str, path: Option<&str>) -> Result<G
 
     Ok(GitCompareOutcome {
         files,
+        commits: log.commits,
         behind,
         diff,
         truncated,
         files_truncated,
+        commits_truncated: log.truncated,
         problem: None,
     })
 }
@@ -1940,6 +1971,16 @@ mod tests {
             "three dots: only the branch's own change, never the base's"
         );
         assert_eq!(outcome.behind, 1, "the base's new commit dates the compare");
+        assert_eq!(
+            outcome
+                .commits
+                .iter()
+                .map(|entry| entry.subject.as_str())
+                .collect::<Vec<_>>(),
+            vec!["branch commit"],
+            "the commits ride the same reply, walked from the same pinned head"
+        );
+        assert!(!outcome.commits_truncated);
         assert!(outcome.diff.is_empty(), "no path asked, no diff sent");
 
         let narrowed = run_compare(&root, "main", Some("b.txt")).await.unwrap();

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -879,6 +879,135 @@ pub async fn run_branches(root: &str) -> Result<GitBranchList> {
     Ok(parse_refs(&String::from_utf8_lossy(&output.stdout)))
 }
 
+/// The branch against a base, as `git_compare` answers it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitCompareOutcome {
+    pub files: Vec<GitCommitFile>,
+    pub behind: u64,
+    pub diff: String,
+    pub truncated: bool,
+    pub files_truncated: bool,
+    pub problem: Option<crate::protocol::GitCompareProblem>,
+}
+
+/// `git.compare` (§C.13 read tier): the three-dot file list and behind count
+/// the Compare tab needs, plus one file's ranged diff when `path` narrows it.
+///
+/// The two problems are asked of git up front rather than inferred from a
+/// failed diff: without a merge base the three-dot diff exits non-zero and
+/// would degrade to an empty file list, while `base..HEAD` still lists
+/// commits — so the tab would show "no files, 40 commits" instead of what is
+/// actually wrong.
+pub async fn run_compare(root: &str, base: &str, path: Option<&str>) -> Result<GitCompareOutcome> {
+    validate_revision(base)?;
+    let problem = |problem| {
+        Ok(GitCompareOutcome {
+            files: Vec::new(),
+            behind: 0,
+            diff: String::new(),
+            truncated: false,
+            files_truncated: false,
+            problem: Some(problem),
+        })
+    };
+    let resolved = git_command(root)
+        .arg("rev-parse")
+        .arg("--verify")
+        .arg("--quiet")
+        .arg(format!("{base}^{{commit}}"))
+        .output()
+        .await
+        .context("running git rev-parse")?;
+    if !resolved.status.success() {
+        return problem(crate::protocol::GitCompareProblem::MissingBase);
+    }
+    let merge_base = git_command(root)
+        .arg("merge-base")
+        .arg(base)
+        .arg("HEAD")
+        .output()
+        .await
+        .context("running git merge-base")?;
+    if !merge_base.status.success() {
+        return problem(crate::protocol::GitCompareProblem::NoCommonHistory);
+    }
+
+    // Three dots: from the merge base, so commits that landed on the base
+    // since this branch started don't show up inverted as changes the branch
+    // never made.
+    let range = format!("{base}...HEAD");
+    let listed = git_command(root)
+        .arg("diff")
+        .arg("--raw")
+        .arg("--numstat")
+        .arg("-z")
+        .arg("-M")
+        .arg(&range)
+        .output()
+        .await
+        .context("running git diff")?;
+    if !listed.status.success() {
+        bail!(
+            "git diff failed: {}",
+            String::from_utf8_lossy(&listed.stderr).trim()
+        );
+    }
+    let mut fields = listed.stdout.split(|&byte| byte == 0).map(|field| {
+        String::from_utf8_lossy(field)
+            .trim_start_matches('\n')
+            .to_string()
+    });
+    let (files, files_truncated) = parse_diff_files(&mut fields);
+
+    // Two dots for the count — "how far apart are the tips", not "what would
+    // merge". Measured against the last fetched state; nothing here fetches.
+    let counted = git_command(root)
+        .arg("rev-list")
+        .arg("--count")
+        .arg(format!("HEAD..{base}"))
+        .output()
+        .await
+        .context("running git rev-list")?;
+    let behind = String::from_utf8_lossy(&counted.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0);
+
+    let (diff, truncated) = if let Some(path) = path {
+        let mut command = git_command(root);
+        command.arg("diff").arg("-M").arg(&range).arg("--").arg(path);
+        // A rename is limited to *both* paths: git applies the path limit
+        // before rename detection, so asking for the destination alone turns a
+        // pure rename into the whole file arriving as additions.
+        if let Some(original) = files
+            .iter()
+            .find(|file| file.path == path)
+            .and_then(|file| file.original_path.as_deref())
+        {
+            command.arg(original);
+        }
+        let patch = command.output().await.context("running git diff")?;
+        if !patch.status.success() {
+            bail!(
+                "git diff failed: {}",
+                String::from_utf8_lossy(&patch.stderr).trim()
+            );
+        }
+        cap_diff(String::from_utf8_lossy(&patch.stdout).into_owned())
+    } else {
+        (String::new(), false)
+    };
+
+    Ok(GitCompareOutcome {
+        files,
+        behind,
+        diff,
+        truncated,
+        files_truncated,
+        problem: None,
+    })
+}
+
 /// Commits the branch's upstream does not have. No upstream means a non-zero
 /// exit, which is an empty set — a purely local branch marks no rows rather
 /// than all of them.
@@ -959,7 +1088,13 @@ fn parse_commit_detail(bytes: &[u8]) -> Result<(GitCommitEntry, Vec<GitCommitFil
     let Some(entry) = parse_commit_record(&header, &HashSet::new()) else {
         bail!("git show did not describe a commit");
     };
+    let (files, truncated) = parse_diff_files(&mut fields);
+    Ok((entry, files, truncated))
+}
 
+/// Parse the `--raw --numstat -z` records of one diff — a commit's (after its
+/// header) or a range's (which has none) — into file rows.
+fn parse_diff_files(fields: &mut impl Iterator<Item = String>) -> (Vec<GitCommitFile>, bool) {
     let mut files: Vec<GitCommitFile> = Vec::new();
     let mut index: HashMap<String, usize> = HashMap::new();
     let mut truncated = false;
@@ -1026,7 +1161,7 @@ fn parse_commit_detail(bytes: &[u8]) -> Result<(GitCommitEntry, Vec<GitCommitFil
         file.additions = additions.parse().unwrap_or(0);
         file.deletions = deletions.parse().unwrap_or(0);
     }
-    Ok((entry, files, truncated))
+    (files, truncated)
 }
 
 /// A commit's file carries one status letter, unlike a worktree file's two
@@ -1772,6 +1907,74 @@ mod tests {
         assert_eq!(
             detached.current, None,
             "a detached HEAD is on no branch, and says so rather than guessing"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn compare_measures_a_branch_against_its_base() {
+        let dir = scratch_repo("compare");
+        write(&dir, "a.txt", "one\n");
+        commit(&dir, "first commit");
+        run_git(&dir, &["checkout", "-q", "-b", "feat"]);
+        write(&dir, "b.txt", "branch work\n");
+        commit(&dir, "branch commit");
+        // The base moves on after the branch forked: three-dot must not show
+        // main's change inverted, and `behind` must count it.
+        run_git(&dir, &["checkout", "-q", "main"]);
+        write(&dir, "a.txt", "one\ntwo\n");
+        commit(&dir, "trunk moved on");
+        run_git(&dir, &["checkout", "-q", "feat"]);
+
+        let root = dir.to_string_lossy().into_owned();
+        let outcome = run_compare(&root, "main", None).await.unwrap();
+        assert_eq!(outcome.problem, None);
+        assert_eq!(
+            outcome
+                .files
+                .iter()
+                .map(|file| file.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["b.txt"],
+            "three dots: only the branch's own change, never the base's"
+        );
+        assert_eq!(outcome.behind, 1, "the base's new commit dates the compare");
+        assert!(outcome.diff.is_empty(), "no path asked, no diff sent");
+
+        let narrowed = run_compare(&root, "main", Some("b.txt")).await.unwrap();
+        assert!(
+            narrowed.diff.contains("branch work"),
+            "a path narrows to that file's ranged diff"
+        );
+        assert!(!narrowed.truncated);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn compare_states_its_problems_rather_than_answering_empty() {
+        let dir = scratch_repo("compare-problems");
+        write(&dir, "a.txt", "one\n");
+        commit(&dir, "first commit");
+
+        let root = dir.to_string_lossy().into_owned();
+        let gone = run_compare(&root, "deleted-branch", None).await.unwrap();
+        assert_eq!(
+            gone.problem,
+            Some(crate::protocol::GitCompareProblem::MissingBase)
+        );
+        assert!(gone.files.is_empty());
+
+        // An orphan branch shares no history with main: there is no merge base
+        // to diff from, and an empty file list would read as "changes nothing".
+        run_git(&dir, &["checkout", "-q", "--orphan", "rootless"]);
+        write(&dir, "c.txt", "unrelated\n");
+        commit(&dir, "unrelated root");
+        let unrelated = run_compare(&root, "main", None).await.unwrap();
+        assert_eq!(
+            unrelated.problem,
+            Some(crate::protocol::GitCompareProblem::NoCommonHistory)
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -351,6 +351,19 @@ pub struct GitCommitFile {
     pub binary: bool,
 }
 
+/// Why a `git_compare` could not compare — each a different instruction to the
+/// user, so folding them into an empty file list (which reads as "this branch
+/// changes nothing") is the one thing this must never do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitCompareProblem {
+    /// The base no longer resolves: its branch was deleted since it was picked.
+    MissingBase,
+    /// No merge base connects the two — unrelated histories, or a shallow
+    /// clone grafted above the divergence point.
+    NoCommonHistory,
+}
+
 /// One ref in a `git.branches` reply (§C.13 read tier).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitBranchEntry {
@@ -786,6 +799,19 @@ pub enum Control {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
     },
+    /// The branch measured against a base (§C.13 read tier, capability `git`):
+    /// the three-dot file list and how far the base has moved on — the halves
+    /// of the Compare tab that `git.log`'s range cannot compose. `path` narrows
+    /// to one file's ranged diff, the row a compare entry expands to, exactly
+    /// as `git.show`'s `path` does for a commit.
+    GitCompare {
+        root: String,
+        base: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
+    },
     /// Fuzzy filename lookup against the host-side name index (§C.12,
     /// capability `files`). The index is built lazily after the workspace's
     /// first `subscribe_resource` and kept incremental by the watcher, so
@@ -1036,6 +1062,26 @@ pub enum Control {
         default_branch: Option<String>,
         #[serde(default)]
         truncated: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        re: Option<u64>,
+    },
+    /// Reply to `git_compare`. `problem` set means no comparison could be made
+    /// and the other fields are empty — stated as its own field rather than an
+    /// `error`, because "this base is gone" is an answer about the checkout,
+    /// not a failed request. `behind` counts commits on the base this branch
+    /// lacks (two-dot, tips apart), while `files` is three-dot from the merge
+    /// base — the change a merge would introduce.
+    GitCompareResult {
+        files: Vec<GitCommitFile>,
+        #[serde(default)]
+        behind: u64,
+        diff: String,
+        #[serde(default)]
+        truncated: bool,
+        #[serde(default)]
+        files_truncated: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        problem: Option<GitCompareProblem>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         re: Option<u64>,
     },

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -78,6 +78,11 @@ pub const MAX_UPLOAD_FRAME_SIZE: usize = 64 * 1024;
 #[derive(Debug)]
 pub enum Frame {
     Control(Control),
+    /// A control frame whose `op` this build has never heard of. Kept apart
+    /// from `Control` so an op from a newer peer degrades to a per-request
+    /// error instead of killing the connection — before this, one unknown verb
+    /// tore down the channel and every subscription riding it.
+    UnknownControl { op: String, seq: Option<u64> },
     Data(Vec<u8>),
     Resize { rows: u16, cols: u16 },
     Event(Event),
@@ -1073,6 +1078,11 @@ pub enum Control {
     /// base — the change a merge would introduce.
     GitCompareResult {
         files: Vec<GitCommitFile>,
+        /// The commits the merge would bring, newest first — carried here
+        /// rather than composed from a separate `git_log` so the file list,
+        /// the commits and the behind count all describe one pinned head.
+        #[serde(default)]
+        commits: Vec<GitCommitEntry>,
         #[serde(default)]
         behind: u64,
         diff: String,
@@ -1080,6 +1090,8 @@ pub enum Control {
         truncated: bool,
         #[serde(default)]
         files_truncated: bool,
+        #[serde(default)]
+        commits_truncated: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         problem: Option<GitCompareProblem>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1949,9 +1961,28 @@ pub async fn read_frame<R: AsyncReadExt + Unpin>(r: &mut R) -> Result<Option<Fra
     r.read_exact(&mut payload).await?;
     match kind {
         KIND_CONTROL => {
-            let ctrl: Control = serde_json::from_slice(&payload)
-                .map_err(|e| anyhow::anyhow!("invalid control JSON: {e}"))?;
-            Ok(Some(Frame::Control(ctrl)))
+            match serde_json::from_slice::<Control>(&payload) {
+                Ok(ctrl) => Ok(Some(Frame::Control(ctrl))),
+                Err(decode_error) => {
+                    // An op this build doesn't know is version skew, not a
+                    // broken pipe: answer it, don't hang up on it. Only a frame
+                    // that names an op qualifies — anything else really is
+                    // malformed JSON and keeps failing the read.
+                    #[derive(serde::Deserialize)]
+                    struct Tagged {
+                        op: String,
+                        #[serde(default)]
+                        seq: Option<u64>,
+                    }
+                    match serde_json::from_slice::<Tagged>(&payload) {
+                        Ok(tagged) => Ok(Some(Frame::UnknownControl {
+                            op: tagged.op,
+                            seq: tagged.seq,
+                        })),
+                        Err(_) => Err(anyhow::anyhow!("invalid control JSON: {decode_error}")),
+                    }
+                }
+            }
         }
         KIND_DATA => Ok(Some(Frame::Data(payload))),
         KIND_RESIZE => {


### PR DESCRIPTION
Continues Stage 9 of the unify-server-plane RFC (docs/design/20260819-unify-server-plane.md): after #552 gave the Changes tab a device, this unhides History and Compare for a device checkout and renders both through the identical views the local pane uses.

- **History**: commits from `git_log`, a commit's files from `git_show`, and a file row's diff from `git_show` with a path — mapped onto the same `GitCommit`/`GitChange` rows. Dates are formatted on this Mac from the wire's timestamp; the box's own rendering is only the fallback for a host too old to send one. An unknown file status drops its row rather than drawing a guess, the additive-evolution rule the status batches already follow.
- **Compare**: settles the RFC's open question 4. Composition from `git_log` + `git_diff` cannot produce the three-dot file list or the behind count, so the daemon grows one verb — `git_compare`, mirroring `git_show`'s shape (whole file list always, one file's ranged diff when a path narrows it). Its two problems (missing base, no common history) are asked of git up front and stated as data, because a failed three-dot diff degrades to an empty file list while `base..HEAD` still lists commits — "no files, 40 commits" is a lie the pane must never render. The client composes: files and behind from `git_compare`, commits from `git_log` over the same range, two requests on the one pooled channel. A comparison that cannot be read at all is stated as a new `unreadable` problem case, never folded into an empty list.
- **Freshness**: a status batch whose head moved means a commit, checkout, or fetch happened on the box — the same signals the local git-dir watch reloads on — so already-loaded History and Compare re-read themselves; an unopened tab fetches nothing.

Verification: `swift build` clean; `swift test` 960 tests, 0 failures (7 new wire-mapping tests in `DeviceGitReadTests`); termiod `cargo test` 227 unit tests + integration suites, 0 failures (2 new `run_compare` fixture tests). New strings carry zh-Hans translations and the compiled `.lproj` output.

Release Notes:
- The git pane's History and Compare tabs now work for checkouts on a device: commits, per-commit files, branch comparisons, and their diffs all read from the box over the daemon, rendered through the same views as a local checkout.