### PR TITLE
Search with ripgrep's crates instead of a git grep subprocess

### DIFF
--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -336,8 +336,8 @@ struct FileSearchView: View {
 
     /// Runs one query on whichever machine holds the root. The device's search is
     /// a network round trip, so its failures are shown rather than swallowed —
-    /// `git grep` outside a repo, a daemon too old for `fs.search`, a box that
-    /// stopped answering.
+    /// a root that no longer resolves, a daemon too old for `fs.search`, a box
+    /// that stopped answering.
     private func find(_ query: String, limit: Int) async -> [ContentMatch] {
         switch scope {
         case .thisMac(let root):

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -555,15 +555,15 @@ extension Termiod {
     }
 
     /// Searches file contents under `root` on the device `route` leads to: the
-    /// host runs `git grep` and streams `search_results` events, closing with one
-    /// `fs_searched` reply (§C.12).
+    /// host walks the root itself and streams `search_results` events, closing
+    /// with one `fs_searched` reply (§C.12).
     ///
     /// Unlike `fs.list` this is a stream, so the hits are collected here and
     /// handed over whole — the pane renders one result set per query, and a
     /// channel that lives only for this request cannot outlive it anyway.
     ///
-    /// Bounded by an idle deadline rather than an overall one: a grep that walks
-    /// a large checkout for a rare string is slow *and* correct, so what is
+    /// Bounded by an idle deadline rather than an overall one: a search that
+    /// walks a large checkout for a rare string is slow *and* correct, so what is
     /// waited on is the device saying nothing at all. That bound is what keeps a
     /// daemon too old to know `fs_search` — which drops the op silently instead
     /// of refusing it — from parking this thread and its connection forever.
@@ -584,8 +584,8 @@ extension Termiod {
                 root: root, query: query, limit: UInt64(limit), seq: call.seq)))
             // Armed the moment the request is on the wire: from here until the
             // host's terminal reply, every way out of this closure — the idle
-            // bound, a lost pipe, a thrown decode — is a `git grep` still
-            // walking a checkout on someone else's machine.
+            // bound, a lost pipe, a thrown decode — is a search still walking
+            // a checkout on someone else's machine.
             call.cancelIfAbandoned()
             var hits: [SearchHit] = []
             while true {

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -736,7 +736,7 @@ listing, and three mechanisms buy back the replica's perceived speed:
 | --- | --- | --- |
 | `fs.list` | `{root, paths[], page?}` → per-path `{entries[], next_page?, seq}` | entry = `{name, kind: file\|dir\|symlink\|unloaded_dir, size, mtime, symlink_target?}`; pages capped (~2,000 entries); ignored/external dirs are `unloaded_dir` stubs — never walked until explicitly listed (the one Zed lesson kept as invariant) |
 | `fs.read` | `{path, range?}` → chunked binary | 1 MiB soft cap for preview parity with the companion; `range` for the editor later |
-| `fs.search` | `{root, query, limit}` → streamed result events, terminal reply | host runs `git grep`; cancellable by request id (⇧⌘F) |
+| `fs.search` | `{root, query, limit}` → streamed result events, terminal reply | host walks the root with ripgrep's searcher over the ignore rules — no subprocess, no git; cancellable by request id (⇧⌘F) |
 | `fs.match` | `{root, query, limit}` → `{paths[], coverage}` | filename fuzzy (⌘⇧O); see index above |
 
 **Uploads** (capability `upload`) — one mechanism, three gestures (drag onto a

--- a/ios/Sources/TermiodBackend.swift
+++ b/ios/Sources/TermiodBackend.swift
@@ -320,14 +320,14 @@ final class TermiodBackend: DeviceClient {
             return
         }
         // `fs_match` and not `fs_search`: this field searches *names*, and
-        // `fs_search` is the device's content search (`git grep`).
+        // `fs_search` is the device's content search.
         //
         // Nothing is cancelled when a query is abandoned, and nothing needs to
         // be: `fs_match` is one reply off an index the host already holds, and
         // only `fs_search` registers a cancellable request (`daemon.rs`, the
         // `Control::Cancel` arm). That changes the day this pane gains content
-        // search — an abandoned `fs_search` leaves `git grep` running until the
-        // connection drops, and `Termiod.CancelOperation` is what stops it.
+        // search — an abandoned `fs_search` keeps walking the checkout until
+        // the connection drops, and `Termiod.CancelOperation` is what stops it.
         let request = nextSeq()
         pendingSearches[request] = query
         do {

--- a/termiod/Cargo.lock
+++ b/termiod/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +160,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +208,24 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -248,6 +310,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9417543f4870fc8f1c8e1af870afae2431007626d9e703fce6471c468d33847"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72348823a0eafc4bc2e9051064f28b5b42cc100b571b3a35d67918d711efcbc6"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +367,22 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "inotify"
@@ -365,6 +480,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mio"
@@ -498,6 +622,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,11 +770,15 @@ dependencies = [
 name = "termiod"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "bytes",
  "clap",
  "frizbee",
  "futures-util",
+ "grep-matcher",
+ "grep-searcher",
+ "ignore",
  "libc",
  "notify",
  "qrcode",

--- a/termiod/Cargo.toml
+++ b/termiod/Cargo.toml
@@ -46,6 +46,16 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 # QR generation is pure data — a bit matrix, not crypto. Default features pull
 # image and svg renderers this never uses.
 qrcode = { version = "0.14", default-features = false }
+# `fs.search` is ripgrep's engine as libraries, not an `rg` subprocess: termiod
+# ships as one static binary to boxes that have neither ripgrep nor, in the
+# containers, git. `grep-searcher` is the line/context/encoding machinery,
+# `grep-matcher` the trait it searches through, `ignore` the gitignore-aware
+# parallel-capable walk, and `aho-corasick` the fixed-string matcher behind
+# that trait — no regex engine, because the wire has always promised literals.
+grep-searcher = "0.1"
+grep-matcher = "0.1"
+ignore = "0.4"
+aho-corasick = { version = "1", default-features = false, features = ["std", "perf-literal"] }
 
 [dev-dependencies]
 # `connect` only exists so the WSS acceptance test can dial its own listener.

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -63,6 +63,27 @@ pub struct Manager {
     /// the runtime, so replacing the image is its move to make; a connection
     /// task only vets the request and passes it along.
     handoff: mpsc::UnboundedSender<std::path::PathBuf>,
+    /// Slots for `fs.search` walks (§C.12). Daemon-wide: the thing being
+    /// rationed is the blocking pool, and every connection draws on the same
+    /// one.
+    searching: Arc<tokio::sync::Semaphore>,
+}
+
+/// How many `fs.search` walks may run at once.
+///
+/// A walk owns a blocking thread for as long as it takes to cross a tree, so
+/// this is a queue *in front of* tokio's blocking pool rather than a share of
+/// it. Unbounded, a handful of large searches fill the pool, and the next
+/// search sits in it holding a slot it cannot use — including the cancel flag
+/// it exists to notice, which is how an abandoned query turns into a client
+/// waiting out its idle bound. Sized to the machine, floored at two so a second
+/// query is never stuck behind the first, and capped because more concurrent
+/// tree walks than cores buys contention rather than answers.
+fn search_permits() -> usize {
+    std::thread::available_parallelism()
+        .map(|cores| cores.get())
+        .unwrap_or(2)
+        .clamp(2, 8)
 }
 
 impl Manager {
@@ -89,6 +110,7 @@ impl Manager {
             graveyard,
             session_removed: Arc::new(Notify::new()),
             handoff,
+            searching: Arc::new(tokio::sync::Semaphore::new(search_permits())),
         }
     }
 
@@ -1726,6 +1748,7 @@ async fn process_control(
                 tokio::spawn(run_search(
                     out.clone(),
                     searches.clone(),
+                    manager.searching.clone(),
                     cancel_rx,
                     retained,
                     root,
@@ -2260,6 +2283,7 @@ async fn process_control(
 async fn run_search(
     out: mpsc::UnboundedSender<Outbound>,
     searches: SearchMap,
+    permits: Arc<tokio::sync::Semaphore>,
     mut cancel_rx: oneshot::Receiver<()>,
     _retained: Option<oneshot::Sender<()>>,
     root: String,
@@ -2286,6 +2310,41 @@ async fn run_search(
             )));
             return;
         }
+    };
+
+    // Wait for a slot before taking a blocking thread (see `search_permits`).
+    // A search cancelled while it is still queued answers *now*: it has walked
+    // nothing, and there is nothing to be gained by making the client wait out
+    // the searches ahead of it.
+    let permit = tokio::select! {
+        slot = permits.clone().acquire_owned() => slot,
+        _ = &mut cancel_rx => {
+            cleanup(&searches);
+            let _ = out.send(Outbound::Control(Control::FsSearched {
+                matches: 0,
+                limit_hit: false,
+                canceled: true,
+                re: seq,
+            }));
+            return;
+        }
+        // Nobody left to answer.
+        _ = out.closed() => {
+            cleanup(&searches);
+            return;
+        }
+    };
+    // The semaphore is never closed, so this cannot fail; refusing the search
+    // is still better than unwrapping if that ever stops being true.
+    let Ok(_permit) = permit else {
+        cleanup(&searches);
+        let _ = out.send(Outbound::Control(error(
+            seq,
+            ErrorCode::Internal,
+            "the host is no longer accepting searches",
+            true,
+        )));
+        return;
     };
 
     let cancel = Arc::new(AtomicBool::new(false));
@@ -2738,5 +2797,79 @@ mod bind_probe_tests {
         assert!(!super::socket_is_stale(Some(libc::EPERM)));
         assert!(!super::socket_is_stale(Some(libc::EACCES)));
         assert!(!super::socket_is_stale(None));
+    }
+}
+
+#[cfg(test)]
+mod search_queue_tests {
+    use super::*;
+
+    /// The bound in front of the blocking pool must not swallow a `cancel`.
+    ///
+    /// Every permit is held here, so the search under test can only be queued —
+    /// which is the state the bound introduced and the one that would otherwise
+    /// make a cancel arrive whenever the searches ahead of it happened to
+    /// finish. It answers on the cancel instead, having walked nothing.
+    #[tokio::test]
+    async fn a_search_cancelled_while_queued_answers_without_waiting_for_a_slot() {
+        let permits = Arc::new(tokio::sync::Semaphore::new(1));
+        let held = permits.clone().acquire_owned().await.expect("take the only slot");
+
+        let (out, mut replies) = mpsc::unbounded_channel();
+        let searches: SearchMap = Arc::new(Mutex::new(HashMap::new()));
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        searches.lock().unwrap().insert(7, cancel_tx);
+
+        // A directory of its own, not the temp root: if the queue ever stops
+        // holding this search back, the test should notice by failing rather
+        // than by walking everything under /tmp.
+        let root = std::env::temp_dir().join(format!("termiod-queue-{}", std::process::id()));
+        std::fs::create_dir_all(&root).expect("a root to search");
+        let root = root.to_string_lossy().into_owned();
+        let running = tokio::spawn(run_search(
+            out,
+            searches.clone(),
+            permits,
+            cancel_rx,
+            None,
+            root,
+            "needle".to_string(),
+            1000,
+            Some(7),
+        ));
+
+        // Queued means silent: nothing has been searched, so nothing is owed
+        // until the client says how it wants this to end.
+        tokio::task::yield_now().await;
+        assert!(replies.try_recv().is_err(), "a queued search reports nothing");
+
+        let cancel = searches.lock().unwrap().remove(&7).expect("the search registered itself");
+        let _ = cancel.send(());
+
+        let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv())
+            .await
+            .expect("a queued search must answer its cancel without waiting for a slot")
+            .expect("a terminal reply");
+        match reply {
+            Outbound::Control(Control::FsSearched {
+                matches,
+                limit_hit,
+                canceled,
+                re,
+            }) => {
+                assert_eq!(matches, 0);
+                assert!(!limit_hit);
+                assert!(canceled);
+                assert_eq!(re, Some(7));
+            }
+            _ => panic!("a cancelled search ends with fs_searched"),
+        }
+        assert!(
+            searches.lock().unwrap().is_empty(),
+            "a cancelled search must not leave its slot in the map"
+        );
+
+        running.await.expect("the search task ends with its reply");
+        drop(held);
     }
 }

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -18,7 +18,7 @@ use crate::tombstone::{EndReason, Graveyard};
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::{UnixListener, UnixStream};
@@ -2246,19 +2246,16 @@ async fn process_control(
     Ok(ControlFlow::Continue)
 }
 
-/// Matches per `search_results` event — small enough to render as they
-/// arrive, large enough that a big result set is not one event per line.
-const SEARCH_BATCH: usize = 50;
-
-/// Lines of context on each side of a hit. Two is what reads as an excerpt
-/// without the results pane turning into the file.
-const SEARCH_CONTEXT_LINES: usize = 2;
-
-/// Stream one `fs.search` (§C.12): `git grep` under the workspace root,
-/// batched result events, one terminal `fs_searched` reply. Ends on
-/// completion, on the limit, on `cancel`, or on the connection going away
-/// (the cancel sender's map is dropped with it). Result events and the
-/// terminal reply share `out`, which is what guarantees the reply is last.
+/// Stream one `fs.search` (§C.12): ripgrep's own searcher over the workspace
+/// root, batched result events, one terminal `fs_searched` reply. Ends on
+/// completion, on the limit, on `cancel`, or on the connection going away (the
+/// cancel sender's map is dropped with it). Result events and the terminal
+/// reply share `out`, which is what guarantees the reply is last.
+///
+/// The walk itself is blocking and runs on its own thread, so neither a tree
+/// with a million files nor a file the searcher chokes on can stall the
+/// runtime. Cancellation is a flag that thread reads rather than a signal —
+/// there is no subprocess left to kill.
 #[allow(clippy::too_many_arguments)]
 async fn run_search(
     out: mpsc::UnboundedSender<Outbound>,
@@ -2290,183 +2287,48 @@ async fn run_search(
             return;
         }
     };
-    let mut command = tokio::process::Command::new("git");
-    command
-        .arg("-C")
-        .arg(&root)
-        .arg("grep")
-        .arg("-n")
-        .arg("-I")
-        .arg("--no-color")
-        .arg("--untracked")
-        .arg("--fixed-strings");
-    // Smart case, the fzf/ripgrep default every client already expects: an
-    // all-lowercase query matches insensitively, and one uppercase letter opts
-    // back into exactness. Decided from the query itself rather than a flag on
-    // the wire, so a client cannot ask two hosts for the same search and get two
-    // different answers.
-    let insensitive = query == query.to_lowercase();
-    if insensitive {
-        command.arg("--ignore-case");
-    }
-    // Context, so a client can draw an excerpt instead of a naked line. The
-    // separator between runs is what makes the output parseable back into runs.
-    command.arg(format!("-C{SEARCH_CONTEXT_LINES}"));
-    let spawned = command
-        .arg("-e")
-        .arg(&query)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .kill_on_drop(true)
-        .spawn();
-    let mut child = match spawned {
-        Ok(child) => child,
-        Err(e) => {
-            cleanup(&searches);
-            let _ = out.send(Outbound::Control(error(
-                seq,
-                ErrorCode::Internal,
-                format!("spawning git grep: {e}"),
-                true,
-            )));
-            return;
-        }
-    };
-    let Some(stdout) = child.stdout.take() else {
-        cleanup(&searches);
-        let _ = out.send(Outbound::Control(error(
-            seq,
-            ErrorCode::Internal,
-            "git grep stdout unavailable",
-            true,
-        )));
-        return;
-    };
 
-    use tokio::io::AsyncBufReadExt;
-    let mut lines = tokio::io::BufReader::new(stdout).lines();
-    let mut pending: Vec<crate::protocol::SearchMatch> = Vec::new();
-    // Context lines seen since the last match, and the match still collecting
-    // the lines after it. Both are indexes into `pending`, so a batch flush has
-    // to retire them — a match that has left is no longer collecting anything.
-    let mut before: std::collections::VecDeque<String> = std::collections::VecDeque::new();
-    let mut trailing: Option<usize> = None;
-    let mut streamed = 0u64;
-    let mut limit_hit = false;
-    let mut canceled = false;
-    loop {
-        tokio::select! {
-            // Err means the sender vanished without an explicit cancel — the
-            // connection is gone; stop doing work nobody can receive.
-            _ = &mut cancel_rx => {
-                canceled = true;
-                break;
-            }
-            // The connection itself going away. Not covered by `cancel_rx`: a
-            // search addressed by a request id parks its cancel sender in the
-            // shared map, and *this task* holds a reference to that map — so the
-            // sender outlives the connection that owned it and the receiver never
-            // resolves. Without this arm a client that hung up (a timeout, a
-            // keystroke abandoning the query) leaves its grep running to
-            // completion, writing into a channel nobody reads.
-            _ = out.closed() => {
-                canceled = true;
-                break;
-            }
-            line = lines.next_line() => {
-                match line {
-                    Ok(Some(line)) => {
-                        let Some(parsed) = crate::files::parse_grep_output_line(&line) else {
-                            continue;
-                        };
-                        use crate::files::GrepLine;
-                        match parsed {
-                            // A run ended: whatever context was banked belongs to
-                            // nothing that follows it.
-                            GrepLine::Separator => {
-                                before.clear();
-                                trailing = None;
-                                continue;
-                            }
-                            GrepLine::Context { line: number, text, .. } => {
-                                // Context after a match, and context before the
-                                // next one, are the same lines — bank them once
-                                // and let both sides read them.
-                                if let Some(index) = trailing {
-                                    let match_at: &mut crate::protocol::SearchMatch =
-                                        &mut pending[index];
-                                    if match_at.after.len() < SEARCH_CONTEXT_LINES {
-                                        match_at.after.push(text.clone());
-                                    } else {
-                                        trailing = None;
-                                    }
-                                }
-                                before.push_back(text);
-                                if before.len() > SEARCH_CONTEXT_LINES {
-                                    before.pop_front();
-                                }
-                                let _ = number;
-                                continue;
-                            }
-                            GrepLine::Match { path, line: number, text } => {
-                                let mut found = crate::files::match_from_line(
-                                    path, number, &text, &query, insensitive,
-                                );
-                                found.before = before.iter().cloned().collect();
-                                before.clear();
-                                trailing = Some(pending.len());
-                                pending.push(found);
-                            }
-                        }
-                        if streamed + pending.len() as u64 >= limit {
-                            limit_hit = true;
-                            break;
-                        }
-                        if pending.len() >= SEARCH_BATCH {
-                            streamed += pending.len() as u64;
-                            // The batch leaves, so nothing in it can still be
-                            // collecting its trailing context.
-                            trailing = None;
-                            let _ = out.send(Outbound::Event(Event::SearchResults {
-                                request,
-                                matches: std::mem::take(&mut pending),
-                            }));
-                        }
-                    }
-                    Ok(None) | Err(_) => break,
-                }
-            }
-        }
-    }
-    if !canceled && !pending.is_empty() {
-        streamed += pending.len() as u64;
-        let _ = out.send(Outbound::Event(Event::SearchResults {
-            request,
-            matches: std::mem::take(&mut pending),
-        }));
-    }
+    let cancel = Arc::new(AtomicBool::new(false));
+    let flag = cancel.clone();
+    let sink = out.clone();
+    let mut worker = tokio::task::spawn_blocking(move || {
+        crate::files::search(&root, &query, limit, &flag, &mut |matches| {
+            let _ = sink.send(Outbound::Event(Event::SearchResults { request, matches }));
+        })
+    });
 
-    let failure = if canceled || limit_hit {
-        let _ = child.kill().await;
-        None
-    } else {
-        // git grep exits 1 for "no matches" — a result, not a failure.
-        match child.wait().await {
-            Ok(status) if status.success() || status.code() == Some(1) => None,
-            Ok(status) => Some(format!("git grep exited with {status}")),
-            Err(e) => Some(format!("waiting for git grep: {e}")),
+    // Either end of the client's interest stops the walk: an explicit `cancel`,
+    // or the connection itself going away. The latter is not covered by
+    // `cancel_rx` — a search addressed by a request id parks its cancel sender
+    // in the shared map, and *this task* holds a reference to that map, so the
+    // sender outlives the connection that owned it and the receiver never
+    // resolves. Without this arm a client that hung up (a timeout, a keystroke
+    // abandoning the query) leaves its walk running to completion, writing into
+    // a channel nobody reads.
+    let outcome = tokio::select! {
+        finished = &mut worker => finished,
+        _ = &mut cancel_rx => {
+            cancel.store(true, Ordering::Relaxed);
+            worker.await
+        }
+        _ = out.closed() => {
+            cancel.store(true, Ordering::Relaxed);
+            worker.await
         }
     };
 
     cleanup(&searches);
-    let response = match failure {
-        Some(message) => error(seq, ErrorCode::Denied, message, false),
-        None => Control::FsSearched {
-            matches: streamed,
-            limit_hit,
-            canceled,
+    let response = match outcome {
+        Ok(outcome) => Control::FsSearched {
+            matches: outcome.matches,
+            limit_hit: outcome.limit_hit,
+            canceled: outcome.canceled,
             re: seq,
         },
+        // The search panicked. Nothing else on this connection is affected —
+        // that is what the separate thread bought — but the client is owed the
+        // failure rather than silence.
+        Err(e) => error(seq, ErrorCode::Internal, format!("search failed: {e}"), true),
     };
     let _ = out.send(Outbound::Control(response));
 }

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -729,16 +729,44 @@ fn resolve_global_excludes(
         // Absent, so git's own default applies.
         None => fallback(),
     }
+    // Both answers can come back relative — `git config --path` hands back what
+    // the config holds, and `XDG_CONFIG_HOME` may hold a relative path git will
+    // happily use. Relative to git's working directory, which is `root`: that
+    // is the `-C` this module runs git under. Anchoring it here is what keeps a
+    // relative path from resolving against wherever the daemon was launched.
+    // `join` leaves an absolute path alone, so this costs the normal case
+    // nothing.
+    .map(|path| root.join(path))
 }
 
 /// Where git looks when `core.excludesFile` is not set at all. A fixed path
 /// rather than a parsed value — naming it here reimplements nothing.
 fn default_excludes_file() -> Option<PathBuf> {
-    std::env::var_os("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .filter(|path| path.is_absolute())
-        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
-        .map(|base| base.join("git/ignore"))
+    excludes_default_from(
+        std::env::var_os("XDG_CONFIG_HOME"),
+        std::env::var_os("HOME"),
+    )
+}
+
+/// git's rule, with the environment handed in so it can be pinned without a
+/// test moving the process's own out from under every thread in it.
+///
+/// `XDG_CONFIG_HOME` wins whenever it is set and not empty — *including* when
+/// it holds a relative path, which the XDG spec says to ignore and git uses
+/// anyway (`path.c`, `xdg_config_home`: `if (config_home && *config_home)`,
+/// with no test for absoluteness). `HOME` is consulted only when it is not,
+/// and setting `XDG_CONFIG_HOME` to something relative therefore turns the
+/// `HOME` default off rather than falling back to it. Relative to what is the
+/// caller's problem: `resolve_global_excludes` anchors it where git had its
+/// working directory.
+fn excludes_default_from(
+    xdg_config_home: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    match xdg_config_home {
+        Some(base) if !base.is_empty() => Some(PathBuf::from(base).join("git/ignore")),
+        _ => Some(PathBuf::from(home?).join(".config/git/ignore")),
+    }
 }
 
 /// What git printed, trimmed of its trailing newline, or nothing if git
@@ -1822,6 +1850,105 @@ mod tests {
             resolve_global_excludes(&outside, fallback),
             None,
             "outside a repository git applies none, and neither does this"
+        );
+    }
+
+    /// A relative `XDG_CONFIG_HOME` must not fall through to `$HOME/.config`.
+    ///
+    /// The premise is checked against git rather than read off the spec,
+    /// because the two disagree: XDG says a relative base directory is invalid
+    /// and must be ignored, and git uses it anyway — `xdg_config_home` in
+    /// `path.c` tests only that the variable is set and non-empty. So the
+    /// fixture proves what git does before anything asserts what this matches.
+    #[test]
+    fn a_relative_xdg_config_home_is_used_and_does_not_fall_back_to_home() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = scratch("search-xdg-relative");
+        git(&root, &["init", "-q"]);
+        touch(&root.join("plain.txt"), b"needle\n");
+        touch(&root.join("named-by-xdg.txt"), b"needle\n");
+        touch(&root.join("named-by-home.txt"), b"needle\n");
+        // Reachable only by resolving "relative-xdg" against the repository,
+        // which is the working directory git runs with here.
+        std::fs::create_dir_all(root.join("relative-xdg/git")).unwrap();
+        touch(&root.join("relative-xdg/git/ignore"), b"named-by-xdg.txt\n");
+        let home = scratch("search-xdg-home");
+        std::fs::create_dir_all(home.join(".config/git")).unwrap();
+        touch(&home.join(".config/git/ignore"), b"named-by-home.txt\n");
+
+        let grep = |xdg: Option<&str>| {
+            let mut command = std::process::Command::new("git");
+            command
+                .arg("-C")
+                .arg(&root)
+                .args(["grep", "-l", "-I", "--untracked", "--fixed-strings", "-e", "needle"])
+                .env("HOME", &home)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env_remove("XDG_CONFIG_HOME");
+            if let Some(xdg) = xdg {
+                command.env("XDG_CONFIG_HOME", xdg);
+            }
+            let output = command.output().expect("run git grep");
+            let listed = String::from_utf8_lossy(&output.stdout);
+            let mut files: Vec<String> = listed.lines().map(str::to_string).collect();
+            files.sort();
+            files
+        };
+
+        assert_eq!(
+            grep(None),
+            vec!["named-by-xdg.txt", "plain.txt"],
+            "with no XDG set, git reads $HOME/.config/git/ignore"
+        );
+        assert_eq!(
+            grep(Some("relative-xdg")),
+            vec!["named-by-home.txt", "plain.txt"],
+            "a relative XDG_CONFIG_HOME is used, and it displaces the HOME default"
+        );
+
+        // And that is the rule this resolves by.
+        let relative = excludes_default_from(
+            Some("relative-xdg".into()),
+            Some(home.clone().into_os_string()),
+        );
+        assert_eq!(relative, Some(PathBuf::from("relative-xdg/git/ignore")));
+        assert_eq!(
+            resolve_global_excludes(&root, || relative.clone()),
+            Some(root.join("relative-xdg/git/ignore")),
+            "a relative answer anchors where git had its working directory"
+        );
+    }
+
+    /// The rest of the table, which needs no repository to be true.
+    #[test]
+    fn the_default_excludes_path_follows_gits_own_rule() {
+        let home = std::ffi::OsString::from("/home/someone");
+        assert_eq!(
+            excludes_default_from(None, Some(home.clone())),
+            Some(PathBuf::from("/home/someone/.config/git/ignore")),
+            "unset falls back to HOME"
+        );
+        assert_eq!(
+            excludes_default_from(Some("".into()), Some(home.clone())),
+            Some(PathBuf::from("/home/someone/.config/git/ignore")),
+            "empty counts as unset, which is git's own test"
+        );
+        assert_eq!(
+            excludes_default_from(Some("/xdg".into()), Some(home.clone())),
+            Some(PathBuf::from("/xdg/git/ignore")),
+            "set wins over HOME"
+        );
+        assert_eq!(
+            excludes_default_from(Some("relative".into()), Some(home)),
+            Some(PathBuf::from("relative/git/ignore")),
+            "and wins even when relative — no fall back to HOME"
+        );
+        assert_eq!(
+            excludes_default_from(None, None),
+            None,
+            "with neither, git has nowhere to look and neither does this"
         );
     }
 

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -636,8 +636,12 @@ pub fn search(
         // `.ignore` and `.rgignore` are ripgrep's own files, not git's.
         .ignore(false)
         .git_ignore(true)
-        .git_global(true)
+        // `.git/info/exclude` stays the crate's job: it resolves `.git` as a
+        // file too (a linked worktree's `commondir`), and its matcher is rooted
+        // at the repository, so an anchored `/target` still anchors.
         .git_exclude(true)
+        // The global excludes file is not: see `global_excludes`.
+        .git_global(false)
         .parents(true)
         .follow_links(false)
         // Deterministic order, which also means single-threaded. Results stream
@@ -645,6 +649,11 @@ pub fn search(
         // should not see a different pane on every keystroke.
         .sort_by_file_path(|a, b| a.cmp(b))
         .filter_entry(|entry| entry.file_name() != ".git");
+    // Lower precedence than every ignore file in the tree, which is where git
+    // puts it (`add_ignore` is the last matcher consulted).
+    if let Some(global) = global_excludes(root) {
+        walker.add_ignore(global);
+    }
 
     for entry in walker.build() {
         if cancel.load(Ordering::Relaxed) {
@@ -673,6 +682,60 @@ pub fn search(
     }
 
     collector.finish()
+}
+
+/// The global excludes file git would apply to `root`, or nothing.
+///
+/// Asked of git rather than parsed here, because `core.excludesFile` is not a
+/// value sitting in one file: it comes off a config stack — system, XDG,
+/// `~/.gitconfig`, the repository — that `[include]` and `[includeIf]` can
+/// redirect, and the value itself may be a quoted path with spaces in it
+/// (`"~/Library/Application Support/git/ignore"` is what a Mac writes). The
+/// `ignore` crate reads that with one regex and says so in its own source:
+/// "this is the lazy approach, and isn't technically correct". A path with a
+/// space in it comes back truncated, which silently drops every rule in the
+/// file. `git config --path` resolves the whole stack and expands `~`, and git
+/// is already the authority for the tree being searched.
+///
+/// A root outside a repository gets none: git applies no excludes to a
+/// directory it does not own, and neither does this. Same answer when git is
+/// missing altogether, which is a box this search still has to work on.
+fn global_excludes(root: &Path) -> Option<PathBuf> {
+    // Doubles as the repository test: outside one, `--git-path` fails.
+    git_says(root, &["rev-parse", "--git-dir"])?;
+    if let Some(configured) = git_says(root, &["config", "--path", "--get", "core.excludesFile"]) {
+        return Some(PathBuf::from(configured));
+    }
+    // git's documented default when the setting is absent. A fixed path, not a
+    // parsed value — naming it here reimplements nothing.
+    let home = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))?;
+    Some(home.join("git/ignore"))
+}
+
+/// One line of output from git run inside `root`, or nothing if git refused,
+/// is not installed, or had nothing to say.
+fn git_says(root: &Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        // Nothing here may sit waiting for a human: this runs on a search
+        // thread, and a credential prompt would park it until the client's
+        // idle bound gave up.
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let line = text.trim_end_matches(['\n', '\r']);
+    (!line.is_empty()).then(|| line.to_string())
 }
 
 /// Opens `path` only if it reads as text, positioned back at the start so the
@@ -1531,6 +1594,103 @@ mod tests {
         let paths: Vec<&str> = hits.iter().map(|hit| hit.path.as_str()).collect();
 
         assert_eq!(paths, vec![".hidden.txt", "keep.txt", "nested/keep.txt"]);
+    }
+
+    /// Runs `git grep --untracked` in a fixture repo and returns the files it
+    /// matched, or `None` when there is no git to ask.
+    fn git_grep_files(root: &Path, query: &str) -> Option<Vec<String>> {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["grep", "-l", "-I", "--no-color", "--untracked", "--fixed-strings", "-e", query])
+            .output()
+            .ok()?;
+        let listed = String::from_utf8_lossy(&output.stdout);
+        let mut files: Vec<String> = listed.lines().map(str::to_string).collect();
+        files.sort();
+        Some(files)
+    }
+
+    fn git(root: &Path, args: &[&str]) {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("run git");
+    }
+
+    /// The differential test: every ignore rule git honours, checked against
+    /// what git itself answers on the same tree rather than against what this
+    /// engine was expected to do.
+    ///
+    /// The global excludes file is the case that pays for the whole test. Its
+    /// path comes off a config stack with quoting rules, and the `ignore`
+    /// crate's own regex reads `excludesFile = "…/with a space/ignore"` as the
+    /// text up to the first space — dropping every rule in the file, silently.
+    /// The path here has spaces and is quoted for exactly that reason. Asking
+    /// git for the value is what makes both sides agree.
+    #[test]
+    fn the_ignore_rules_agree_with_git_grep_file_for_file() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = scratch("search-differential");
+        git(&root, &["init", "-q"]);
+
+        let excludes = root.join("config dir/global ignore");
+        std::fs::create_dir_all(excludes.parent().expect("a parent")).unwrap();
+        touch(&excludes, b"by-global.txt\n");
+        // Written straight into the config so the value keeps its quotes: this
+        // is the shape a Mac's `~/Library/Application Support/git/ignore` takes,
+        // and the shape the crate's parser truncates. Repo-local rather than
+        // global so the fixture cannot be perturbed by the machine it runs on.
+        let mut config = std::fs::OpenOptions::new()
+            .append(true)
+            .open(root.join(".git/config"))
+            .unwrap();
+        writeln!(
+            config,
+            "[core]\n\texcludesFile = \"{}\"",
+            excludes.display()
+        )
+        .unwrap();
+        drop(config);
+
+        touch(&root.join(".git/info/exclude"), b"by-info-exclude.txt\n");
+        touch(&root.join(".gitignore"), b"*.log\n!keep.log\nbuilt/\n");
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        touch(&root.join("sub/.gitignore"), b"*.tmp\n!ok.tmp\n");
+
+        for named in [
+            "plain.txt",
+            "by-global.txt",
+            "by-info-exclude.txt",
+            "drop.log",
+            "keep.log",
+            "sub/ok.tmp",
+            "sub/no.tmp",
+            ".dotfile.txt",
+        ] {
+            touch(&root.join(named), b"needle\n");
+        }
+        std::fs::create_dir_all(root.join("built")).unwrap();
+        touch(&root.join("built/out.txt"), b"needle\n");
+        // Tracked *and* ignored. `--untracked` implies `--exclude-standard`, so
+        // git skips it too — the case that looked like a divergence and is not.
+        git(&root, &["add", "-f", "drop.log"]);
+
+        let theirs = git_grep_files(&root, "needle").expect("git grep");
+        let (hits, _) = found(&root, "needle", 1000);
+        let mut ours: Vec<String> = hits.into_iter().map(|hit| hit.path).collect();
+        ours.dedup();
+
+        assert_eq!(ours, theirs, "the ignore rules must agree file for file");
+        assert_eq!(
+            theirs,
+            vec![".dotfile.txt", "keep.log", "plain.txt", "sub/ok.tmp"],
+            "and agree on the right answer, not on a shared mistake"
+        );
     }
 
     /// Where this parts ways with `git grep --untracked`, asserted against real

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -648,6 +648,12 @@ pub fn search(
         // as they are found, and a client that renders them in arrival order
         // should not see a different pane on every keystroke.
         .sort_by_file_path(|a, b| a.cmp(b))
+        // What `add_ignore` roots its matcher at. Without it the crate reaches
+        // for the *process's* working directory, and a global `/root-only.txt`
+        // would anchor wherever the daemon happened to be launched instead of
+        // at the tree being searched. git anchors it at the top of the working
+        // tree; so does this.
+        .current_dir(root)
         .filter_entry(|entry| entry.file_name() != ".git");
     // Lower precedence than every ignore file in the tree, which is where git
     // puts it (`add_ignore` is the last matcher consulted).
@@ -701,22 +707,45 @@ pub fn search(
 /// directory it does not own, and neither does this. Same answer when git is
 /// missing altogether, which is a box this search still has to work on.
 fn global_excludes(root: &Path) -> Option<PathBuf> {
-    // Doubles as the repository test: outside one, `--git-path` fails.
-    git_says(root, &["rev-parse", "--git-dir"])?;
-    if let Some(configured) = git_says(root, &["config", "--path", "--get", "core.excludesFile"]) {
-        return Some(PathBuf::from(configured));
-    }
-    // git's documented default when the setting is absent. A fixed path, not a
-    // parsed value — naming it here reimplements nothing.
-    let home = std::env::var_os("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .filter(|path| path.is_absolute())
-        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))?;
-    Some(home.join("git/ignore"))
+    resolve_global_excludes(root, default_excludes_file)
 }
 
-/// One line of output from git run inside `root`, or nothing if git refused,
-/// is not installed, or had nothing to say.
+/// `global_excludes` with git's default path handed in, so all three answers
+/// can be pinned without a test having to move the process's environment out
+/// from under every other thread in it.
+fn resolve_global_excludes(
+    root: &Path,
+    fallback: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    // Doubles as the repository test: outside one, `rev-parse` fails.
+    git_says(root, &["rev-parse", "--git-dir"])?;
+    match git_says(root, &["config", "--path", "--get", "core.excludesFile"]).as_deref() {
+        // Set to the empty string. git reads that as "no global excludes at
+        // all" and does *not* fall back to its default — the setting exists to
+        // be turned off. `git config` reports it as success with empty output,
+        // which is the only thing separating it from the key being absent.
+        Some("") => None,
+        Some(configured) => Some(PathBuf::from(configured)),
+        // Absent, so git's own default applies.
+        None => fallback(),
+    }
+}
+
+/// Where git looks when `core.excludesFile` is not set at all. A fixed path
+/// rather than a parsed value — naming it here reimplements nothing.
+fn default_excludes_file() -> Option<PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .map(|base| base.join("git/ignore"))
+}
+
+/// What git printed, trimmed of its trailing newline, or nothing if git
+/// refused, is not installed, or was not asked from inside a repository.
+///
+/// An empty string is a real answer here rather than an absence — see
+/// `resolve_global_excludes`, where the difference is the whole point.
 fn git_says(root: &Path, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new("git")
         .arg("-C")
@@ -734,8 +763,7 @@ fn git_says(root: &Path, args: &[&str]) -> Option<String> {
         return None;
     }
     let text = String::from_utf8(output.stdout).ok()?;
-    let line = text.trim_end_matches(['\n', '\r']);
-    (!line.is_empty()).then(|| line.to_string())
+    Some(text.trim_end_matches(['\n', '\r']).to_string())
 }
 
 /// Opens `path` only if it reads as text, positioned back at the start so the
@@ -1640,7 +1668,11 @@ mod tests {
 
         let excludes = root.join("config dir/global ignore");
         std::fs::create_dir_all(excludes.parent().expect("a parent")).unwrap();
-        touch(&excludes, b"by-global.txt\n");
+        // The anchored pattern is the second half of the point: git matches it
+        // against the top of the working tree, so `root-only.txt` goes and
+        // `sub/root-only.txt` stays. A matcher rooted at the daemon's own
+        // working directory would drop the rule instead.
+        touch(&excludes, b"by-global.txt\n/root-only.txt\n");
         // Written straight into the config so the value keeps its quotes: this
         // is the shape a Mac's `~/Library/Application Support/git/ignore` takes,
         // and the shape the crate's parser truncates. Repo-local rather than
@@ -1671,6 +1703,8 @@ mod tests {
             "sub/ok.tmp",
             "sub/no.tmp",
             ".dotfile.txt",
+            "root-only.txt",
+            "sub/root-only.txt",
         ] {
             touch(&root.join(named), b"needle\n");
         }
@@ -1688,8 +1722,106 @@ mod tests {
         assert_eq!(ours, theirs, "the ignore rules must agree file for file");
         assert_eq!(
             theirs,
-            vec![".dotfile.txt", "keep.log", "plain.txt", "sub/ok.tmp"],
+            vec![
+                ".dotfile.txt",
+                "keep.log",
+                "plain.txt",
+                "sub/ok.tmp",
+                "sub/root-only.txt",
+            ],
             "and agree on the right answer, not on a shared mistake"
+        );
+    }
+
+    /// `core.excludesFile` has three states, not two, and the difference is
+    /// invisible in `git config`'s output alone: absent exits non-zero, set to
+    /// a path exits zero with the path, set to the empty string exits zero with
+    /// nothing. The last one means "no global excludes", *not* "use the
+    /// default" — treating it as absent turns a setting someone deliberately
+    /// switched off back on.
+    #[test]
+    fn an_empty_excludes_setting_disables_global_excludes_like_git() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = scratch("search-excludes-off");
+        git(&root, &["init", "-q"]);
+        git(&root, &["config", "core.excludesFile", ""]);
+
+        // git's default location, populated. Neither side may reach it.
+        let xdg = root.join("xdg");
+        std::fs::create_dir_all(xdg.join("git")).unwrap();
+        touch(&xdg.join("git/ignore"), b"named-by-the-default-file.txt\n");
+        touch(&root.join("plain.txt"), b"needle\n");
+        touch(&root.join("named-by-the-default-file.txt"), b"needle\n");
+
+        let listed = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["grep", "-l", "-I", "--untracked", "--fixed-strings", "-e", "needle"])
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("run git grep");
+        let text = String::from_utf8_lossy(&listed.stdout);
+        let mut theirs: Vec<String> = text.lines().map(str::to_string).collect();
+        theirs.sort();
+
+        let (hits, _) = found(&root, "needle", 1000);
+        let ours: Vec<String> = hits.into_iter().map(|hit| hit.path).collect();
+
+        assert_eq!(ours, theirs);
+        assert_eq!(ours, vec!["named-by-the-default-file.txt", "plain.txt"]);
+        // The walk above cannot prove *why* it agreed: this daemon's own home
+        // is not the fixture's, so a wrong fallback would have reached a file
+        // with none of these names in it and the sets would have matched
+        // anyway. The rule itself is what has to be pinned.
+        assert_eq!(
+            resolve_global_excludes(&root, || Some(xdg.join("git/ignore"))),
+            None,
+            "an empty setting must not reach for the default git would skip"
+        );
+    }
+
+    /// The same three states, pinned at the resolver so the empty case cannot
+    /// be read as the absent one. The default is handed in rather than read
+    /// from the environment: a test that moved `HOME` would move it for every
+    /// other thread in the process too.
+    #[test]
+    fn the_three_states_of_the_excludes_setting_resolve_apart() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = scratch("search-excludes-states");
+        git(&root, &["init", "-q"]);
+        let default = PathBuf::from("/somewhere/git/ignore");
+        let fallback = || Some(default.clone());
+
+        assert_eq!(
+            resolve_global_excludes(&root, fallback),
+            Some(default.clone()),
+            "absent means git's own default"
+        );
+
+        git(&root, &["config", "core.excludesFile", "/named/ignore"]);
+        assert_eq!(
+            resolve_global_excludes(&root, fallback),
+            Some(PathBuf::from("/named/ignore")),
+            "a path means that path"
+        );
+
+        git(&root, &["config", "core.excludesFile", ""]);
+        assert_eq!(
+            resolve_global_excludes(&root, fallback),
+            None,
+            "empty means off, and must not reach for the default"
+        );
+
+        let outside = scratch("search-excludes-no-repo");
+        assert_eq!(
+            resolve_global_excludes(&outside, fallback),
+            None,
+            "outside a repository git applies none, and neither does this"
         );
     }
 

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -499,55 +499,352 @@ const SEARCH_TEXT_CAP: usize = 512;
 /// sit flush against the left edge of the window.
 const SEARCH_WINDOW_LEAD: usize = 64;
 
-/// One line of `git grep -n -C` output: a match (`path:lineno:text`), a context
-/// line (`path-lineno-text`), or the `--` that separates runs. Colons and
-/// hyphens inside the text are safe — only the first two separators split, and
-/// which separator it is decides the kind.
-pub enum GrepLine {
-    Match { path: String, line: u64, text: String },
-    Context { path: String, line: u64, text: String },
-    Separator,
+/// Matches per `search_results` event — small enough to render as they arrive,
+/// large enough that a big result set is not one event per line.
+pub const SEARCH_BATCH: usize = 50;
+
+/// Lines of context on each side of a hit. Two is what reads as an excerpt
+/// without the results pane turning into the file.
+pub const SEARCH_CONTEXT_LINES: usize = 2;
+
+/// How much of a file decides whether it is binary. `git grep -I` looks at the
+/// first 8000 bytes for a NUL and skips the whole file when it finds one; this
+/// search kept that rule rather than ripgrep's "stop at the first NUL", because
+/// stopping mid-file emits the text that preceded the NUL as ordinary hits.
+const BINARY_PROBE: usize = 8000;
+
+/// Ceiling on what one file may cost the searcher. A line longer than this is
+/// not searched at all — the file is skipped and the walk continues. Without it
+/// a single minified blob with no line terminator decides how much memory the
+/// daemon allocates, and the daemon hosts live sessions.
+const SEARCH_HEAP_LIMIT: usize = 32 * 1024 * 1024;
+
+/// What one `fs.search` run ended up doing. The counts are the daemon's — it
+/// reports them in the terminal `fs_searched` reply.
+pub struct SearchOutcome {
+    pub matches: u64,
+    pub limit_hit: bool,
+    pub canceled: bool,
 }
 
-/// Parses one output line, whichever kind it is.
-///
-/// `git grep` marks a matching line with colons and a context line with
-/// hyphens, which is the only thing that tells them apart — the line number
-/// alone cannot, and getting it wrong would paint context as a hit.
-pub fn parse_grep_output_line(line: &str) -> Option<GrepLine> {
-    if line == "--" {
-        return Some(GrepLine::Separator);
+/// A fixed-string matcher over the query, folded the same ASCII way the spans
+/// are. Fixed strings rather than a regex because that is what the wire has
+/// always promised: a query is text the user typed, not a pattern, so a stray
+/// `(` cannot turn a search into a syntax error.
+struct LiteralMatcher {
+    finder: aho_corasick::AhoCorasick,
+}
+
+impl grep_matcher::Matcher for LiteralMatcher {
+    type Captures = grep_matcher::NoCaptures;
+    type Error = grep_matcher::NoError;
+
+    fn find_at(
+        &self,
+        haystack: &[u8],
+        at: usize,
+    ) -> Result<Option<grep_matcher::Match>, grep_matcher::NoError> {
+        // A plain literal has no anchors and no look-around, so searching the
+        // suffix is the same answer as searching the whole line from `at`.
+        Ok(self
+            .finder
+            .find(&haystack[at..])
+            .map(|found| grep_matcher::Match::new(at + found.start(), at + found.end())))
     }
-    // A match first: a path containing a hyphen is ordinary, and trying the
-    // hyphen split first would tear one apart.
-    if let Some((path, rest)) = line.split_once(':') {
-        if let Some((number, text)) = rest.split_once(':') {
-            if let Ok(number) = number.parse::<u64>() {
-                return Some(GrepLine::Match {
-                    path: path.to_string(),
-                    line: number,
-                    text: text.to_string(),
-                });
+
+    fn new_captures(&self) -> Result<Self::Captures, grep_matcher::NoError> {
+        Ok(grep_matcher::NoCaptures::new())
+    }
+}
+
+/// Search `root` for `query`, handing finished batches to `emit` as they fill.
+///
+/// Blocking by construction — the daemon runs it on a blocking thread, which is
+/// also what keeps a pathological file off the runtime. `cancel` is read at
+/// every file and every reported line, so an abandoned search stops within one
+/// file rather than running the tree to completion.
+///
+/// The domain is what `git grep --untracked` covered: tracked and untracked
+/// files that no ignore rule excludes, `.git` never walked, binary files
+/// skipped. The rules come from the `ignore` crate reading `.gitignore`, the
+/// global excludes file and `.git/info/exclude` — the same inputs git reads,
+/// re-implemented rather than asked, so the two can disagree in corner cases.
+pub fn search(
+    root: &Path,
+    query: &str,
+    limit: u64,
+    cancel: &std::sync::atomic::AtomicBool,
+    emit: &mut dyn FnMut(Vec<crate::protocol::SearchMatch>),
+) -> SearchOutcome {
+    use std::sync::atomic::Ordering;
+
+    // An empty query has no literal to look for. `git grep -e ""` answered it
+    // by matching every line in the tree, which is the whole repo streamed back
+    // with nothing to highlight; no result is the more useful reading and the
+    // one clients already assume, since they refuse to send it.
+    // A query spanning lines has nothing a line-oriented literal search can
+    // match, which is also what ripgrep answers without `-U`.
+    if query.is_empty() || limit == 0 || query.contains(['\n', '\r']) {
+        return SearchOutcome { matches: 0, limit_hit: false, canceled: false };
+    }
+
+    // Smart case, the fzf/ripgrep default every client already expects: an
+    // all-lowercase query matches insensitively, and one uppercase letter opts
+    // back into exactness. Decided from the query itself rather than a flag on
+    // the wire, so a client cannot ask two hosts for the same search and get two
+    // different answers.
+    let insensitive = query == query.to_lowercase();
+    let finder = aho_corasick::AhoCorasickBuilder::new()
+        .ascii_case_insensitive(insensitive)
+        .build([query.as_bytes()]);
+    let Ok(finder) = finder else {
+        return SearchOutcome { matches: 0, limit_hit: false, canceled: false };
+    };
+    let matcher = LiteralMatcher { finder };
+
+    let mut searcher = grep_searcher::SearcherBuilder::new()
+        .line_number(true)
+        .before_context(SEARCH_CONTEXT_LINES)
+        .after_context(SEARCH_CONTEXT_LINES)
+        // The probe below already decided the file is text, so the searcher does
+        // not get a second, different opinion about it.
+        .binary_detection(grep_searcher::BinaryDetection::none())
+        // Also what turns memory maps off: a bounded buffer is the point.
+        .heap_limit(Some(SEARCH_HEAP_LIMIT))
+        .build();
+
+    let mut collector = Collector {
+        query,
+        insensitive,
+        limit,
+        cancel,
+        emit,
+        path: String::new(),
+        pending: Vec::new(),
+        before: std::collections::VecDeque::new(),
+        trailing: None,
+        streamed: 0,
+        limit_hit: false,
+        canceled: false,
+    };
+
+    let mut walker = ignore::WalkBuilder::new(root);
+    walker
+        // git has no notion of a hidden file: a tracked `.env` is searched and
+        // an untracked one is too. Only `.git` itself is off limits.
+        .hidden(false)
+        // `.ignore` and `.rgignore` are ripgrep's own files, not git's.
+        .ignore(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .parents(true)
+        .follow_links(false)
+        // Deterministic order, which also means single-threaded. Results stream
+        // as they are found, and a client that renders them in arrival order
+        // should not see a different pane on every keystroke.
+        .sort_by_file_path(|a, b| a.cmp(b))
+        .filter_entry(|entry| entry.file_name() != ".git");
+
+    for entry in walker.build() {
+        if cancel.load(Ordering::Relaxed) {
+            collector.canceled = true;
+            break;
+        }
+        // A directory that cannot be read, a file that vanished mid-walk: the
+        // rest of the tree is still worth searching. `git grep` skipped these
+        // onto a stderr nobody read.
+        let Ok(entry) = entry else { continue };
+        if !entry.file_type().is_some_and(|kind| kind.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        let Some(relative) = path.strip_prefix(root).ok().and_then(|p| p.to_str()) else {
+            continue;
+        };
+        let Some(file) = open_text(path) else { continue };
+        collector.begin_file(relative);
+        // A file the searcher refuses — a line past the heap limit, a read that
+        // failed — is one file, not the search.
+        let _ = searcher.search_file(&matcher, &file, &mut collector);
+        if collector.limit_hit || collector.canceled {
+            break;
+        }
+    }
+
+    collector.finish()
+}
+
+/// Opens `path` only if it reads as text, positioned back at the start so the
+/// searcher can have it. One open for both jobs: the probe is the same read the
+/// searcher would have done first anyway.
+fn open_text(path: &Path) -> Option<std::fs::File> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut probe = [0u8; BINARY_PROBE];
+    let mut filled = 0;
+    while filled < probe.len() {
+        match file.read(&mut probe[filled..]) {
+            Ok(0) => break,
+            Ok(read) => filled += read,
+            Err(_) => return None,
+        }
+    }
+    if probe[..filled].contains(&0) {
+        return None;
+    }
+    file.seek(SeekFrom::Start(0)).ok()?;
+    Some(file)
+}
+
+/// Turns the searcher's per-line callbacks into the batches the wire carries.
+///
+/// The state is the shape `git grep -C` output forced and the clients now
+/// expect: context banked before a hit belongs to it, the same lines after a
+/// hit belong to the hit above, and a break between runs retires both.
+struct Collector<'a> {
+    query: &'a str,
+    insensitive: bool,
+    limit: u64,
+    cancel: &'a std::sync::atomic::AtomicBool,
+    emit: &'a mut dyn FnMut(Vec<crate::protocol::SearchMatch>),
+    path: String,
+    pending: Vec<crate::protocol::SearchMatch>,
+    before: std::collections::VecDeque<String>,
+    trailing: Option<usize>,
+    streamed: u64,
+    limit_hit: bool,
+    canceled: bool,
+}
+
+impl Collector<'_> {
+    fn begin_file(&mut self, relative: &str) {
+        self.path.clear();
+        self.path.push_str(relative);
+        // Context never spans files, and the searcher has no break between them.
+        self.before.clear();
+        self.trailing = None;
+    }
+
+    fn keep_going(&mut self) -> bool {
+        if self.cancel.load(std::sync::atomic::Ordering::Relaxed) {
+            self.canceled = true;
+            return false;
+        }
+        true
+    }
+
+    fn take_match(&mut self, line: u64, text: &str) -> bool {
+        let mut found =
+            match_from_line(self.path.clone(), line, text, self.query, self.insensitive);
+        found.before = self.before.iter().cloned().collect();
+        self.before.clear();
+        self.trailing = Some(self.pending.len());
+        self.pending.push(found);
+        if self.streamed + self.pending.len() as u64 >= self.limit {
+            self.limit_hit = true;
+            return false;
+        }
+        if self.pending.len() >= SEARCH_BATCH {
+            self.flush();
+        }
+        true
+    }
+
+    fn take_context(&mut self, text: String) {
+        // Context after a match, and context before the next one, are the same
+        // lines — bank them once and let both sides read them.
+        if let Some(index) = self.trailing {
+            let match_at = &mut self.pending[index];
+            if match_at.after.len() < SEARCH_CONTEXT_LINES {
+                match_at.after.push(text.clone());
+            } else {
+                self.trailing = None;
             }
         }
+        self.before.push_back(text);
+        if self.before.len() > SEARCH_CONTEXT_LINES {
+            self.before.pop_front();
+        }
     }
-    let (path, rest) = line.split_once('-')?;
-    let (number, text) = rest.split_once('-')?;
-    Some(GrepLine::Context {
-        path: path.to_string(),
-        line: number.parse().ok()?,
-        text: text.to_string(),
-    })
+
+    fn flush(&mut self) {
+        if self.pending.is_empty() {
+            return;
+        }
+        self.streamed += self.pending.len() as u64;
+        // The batch leaves, so nothing in it can still be collecting its
+        // trailing context.
+        self.trailing = None;
+        (self.emit)(std::mem::take(&mut self.pending));
+    }
+
+    fn finish(mut self) -> SearchOutcome {
+        // A canceled search delivers nothing further: the client that abandoned
+        // it is not waiting for a last partial batch.
+        if !self.canceled {
+            self.flush();
+        }
+        SearchOutcome {
+            matches: self.streamed,
+            limit_hit: self.limit_hit,
+            canceled: self.canceled,
+        }
+    }
 }
 
-/// Kept for the shape its tests pin: one `-n` line into a match, with the
-/// window and spans a client needs to paint it.
-pub fn parse_grep_line(line: &str, query: &str, insensitive: bool) -> Option<crate::protocol::SearchMatch> {
-    match parse_grep_output_line(line)? {
-        GrepLine::Match { path, line, text } => {
-            Some(match_from_line(path, line, &text, query, insensitive))
+/// One line as the searcher hands it over: bytes including the terminator, and
+/// not necessarily UTF-8. Lossy rather than fatal — a single bad byte in one
+/// file used to end the whole search, because the old parser read the subprocess
+/// pipe as lines of `String`.
+fn line_text(bytes: &[u8]) -> String {
+    let mut end = bytes.len();
+    if end > 0 && bytes[end - 1] == b'\n' {
+        end -= 1;
+        if end > 0 && bytes[end - 1] == b'\r' {
+            end -= 1;
         }
-        _ => None,
+    }
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+impl grep_searcher::Sink for Collector<'_> {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _searcher: &grep_searcher::Searcher,
+        found: &grep_searcher::SinkMatch<'_>,
+    ) -> Result<bool, std::io::Error> {
+        if !self.keep_going() {
+            return Ok(false);
+        }
+        let line = found.line_number().unwrap_or(0);
+        let text = line_text(found.bytes());
+        Ok(self.take_match(line, &text))
+    }
+
+    fn context(
+        &mut self,
+        _searcher: &grep_searcher::Searcher,
+        context: &grep_searcher::SinkContext<'_>,
+    ) -> Result<bool, std::io::Error> {
+        if !self.keep_going() {
+            return Ok(false);
+        }
+        self.take_context(line_text(context.bytes()));
+        Ok(true)
+    }
+
+    fn context_break(
+        &mut self,
+        _searcher: &grep_searcher::Searcher,
+    ) -> Result<bool, std::io::Error> {
+        // A run ended: whatever context was banked belongs to nothing that
+        // follows it.
+        self.before.clear();
+        self.trailing = None;
+        Ok(true)
     }
 }
 
@@ -558,7 +855,7 @@ pub fn parse_grep_line(line: &str, query: &str, insensitive: bool) -> Option<cra
 /// is the whole point — a client that re-finds the query itself is running a
 /// second matcher, and two matchers eventually disagree (an uppercase query
 /// painting lowercase text, a canonically-equal-but-different byte sequence).
-pub fn match_from_line(
+fn match_from_line(
     path: String,
     line: u64,
     text: &str,
@@ -1114,88 +1411,229 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// Runs one search to completion, the way the daemon does minus the wire.
+    fn found(root: &Path, query: &str, limit: u64) -> (Vec<crate::protocol::SearchMatch>, SearchOutcome) {
+        let cancel = std::sync::atomic::AtomicBool::new(false);
+        let mut all = Vec::new();
+        let outcome = search(root, query, limit, &cancel, &mut |batch| all.extend(batch));
+        (all, outcome)
+    }
+
+    /// A repository marker, which is what makes the ignore rules apply at all —
+    /// outside a repo there is nothing to honour and everything is searched.
+    fn repo(name: &str) -> PathBuf {
+        let root = scratch(name);
+        std::fs::create_dir(root.join(".git")).unwrap();
+        root
+    }
+
+    /// Colons in the text used to be a parsing hazard, because the hit arrived
+    /// as `path:line:text` on a pipe. It arrives as three values now, and the
+    /// context around it arrives as its own callback rather than a `-` line.
     #[test]
-    fn grep_lines_parse_with_colons_in_the_text_and_cap_long_lines() {
-        let hit = parse_grep_line("src/main.rs:42:let url = \"http://x:8080\";", "url", true)
-            .unwrap();
-        assert_eq!(hit.path, "src/main.rs");
-        assert_eq!(hit.line, 42);
-        assert_eq!(hit.text, "let url = \"http://x:8080\";");
+    fn a_hit_carries_its_path_line_text_and_context() {
+        let root = repo("search-basics");
+        std::fs::create_dir(root.join("src")).unwrap();
+        touch(
+            &root.join("src/main.rs"),
+            b"one\ntwo\nlet url = \"http://x:8080\";\nfour\nfive\nsix\n",
+        );
 
-        let long = format!("a.txt:1:{}", "é".repeat(SEARCH_TEXT_CAP));
-        let capped = parse_grep_line(&long, "é", false).unwrap();
-        assert!(capped.text.len() <= SEARCH_TEXT_CAP);
-        assert!(capped.text.chars().all(|c| c == 'é'), "cut on a boundary");
+        let (hits, outcome) = found(&root, "url", 100);
 
-        assert!(parse_grep_line("no line number here", "x", true).is_none());
-        assert!(parse_grep_line("path:notanumber:text", "x", true).is_none());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "src/main.rs");
+        assert_eq!(hits[0].line, 3);
+        assert_eq!(hits[0].text, "let url = \"http://x:8080\";");
+        assert_eq!(hits[0].before, vec!["one", "two"]);
+        assert_eq!(hits[0].after, vec!["four", "five"]);
+        assert_eq!(outcome.matches, 1);
+        assert!(!outcome.limit_hit && !outcome.canceled);
     }
 
     /// The whole point of reporting spans: they come from the rule that decided
     /// the line matched, so an uppercase query cannot paint lowercase text.
     #[test]
-    fn spans_follow_the_search_case_rule() {
-        let line = "let Widget = widget();";
-        let exact = match_from_line("a.rs".into(), 1, line, "Widget", false);
-        assert_eq!(exact.spans, vec![[4, 10]], "case-sensitive marks one hit");
+    fn spans_follow_the_smart_case_rule() {
+        let root = repo("search-case");
+        touch(&root.join("a.rs"), b"let Widget = widget();\n");
 
-        let loose = match_from_line("a.rs".into(), 1, line, "widget", true);
-        assert_eq!(loose.spans, vec![[4, 10], [13, 19]], "insensitive marks both");
-        for span in &loose.spans {
-            let start = span[0] as usize;
-            let end = span[1] as usize;
-            assert_eq!(line[start..end].to_lowercase(), "widget");
+        let (exact, _) = found(&root, "Widget", 100);
+        assert_eq!(exact[0].spans, vec![[4, 10]], "an uppercase query is exact");
+
+        let (loose, _) = found(&root, "widget", 100);
+        assert_eq!(
+            loose[0].spans,
+            vec![[4, 10], [13, 19]],
+            "an all-lowercase query matches both cases"
+        );
+        for span in &loose[0].spans {
+            let range = span[0] as usize..span[1] as usize;
+            assert_eq!(loose[0].text[range].to_lowercase(), "widget");
         }
     }
 
     /// A hit far down a long line used to arrive with the line truncated in
     /// front of it — a result row with nothing highlighted. The window follows
-    /// the match instead.
+    /// the match instead, and says where it starts so columns still resolve.
     #[test]
-    fn a_long_line_is_windowed_around_its_first_hit() {
+    fn a_long_line_is_windowed_around_its_hit() {
+        let root = repo("search-long-line");
         let mut line = "x".repeat(900);
         line.push_str("needle");
         line.push_str(&"y".repeat(900));
+        line.push('\n');
+        touch(&root.join("bundle.js"), line.as_bytes());
 
-        let found = match_from_line("a.js".into(), 1, &line, "needle", false);
+        let (hits, _) = found(&root, "needle", 100);
 
-        assert!(found.text.len() <= SEARCH_TEXT_CAP);
-        assert!(!found.spans.is_empty(), "the hit survives the window");
-        let span = found.spans[0];
-        assert_eq!(&found.text[span[0] as usize..span[1] as usize], "needle");
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].text.len() <= SEARCH_TEXT_CAP);
+        let span = hits[0].spans[0];
+        assert_eq!(&hits[0].text[span[0] as usize..span[1] as usize], "needle");
+        assert_eq!(hits[0].text_offset as usize + span[0] as usize, 900);
+    }
+
+    /// A window that would cut a character in half must step back to a boundary
+    /// rather than produce a string the client cannot index into.
+    #[test]
+    fn a_long_line_of_multibyte_text_is_cut_on_a_boundary() {
+        let root = repo("search-multibyte");
+        let mut line = "é".repeat(SEARCH_TEXT_CAP);
+        line.push('\n');
+        touch(&root.join("accents.txt"), line.as_bytes());
+
+        let (hits, _) = found(&root, "é", 100);
+
+        assert!(hits[0].text.len() <= SEARCH_TEXT_CAP);
+        assert!(hits[0].text.chars().all(|c| c == 'é'));
+    }
+
+    /// The search domain: tracked and untracked files that no ignore rule
+    /// names, dotfiles included, `.git` never walked, binary files skipped.
+    #[test]
+    fn the_walk_honours_ignore_rules_and_skips_binaries() {
+        let root = repo("search-domain");
+        touch(&root.join(".gitignore"), b"ignored/\n*.log\n");
+        touch(&root.join("keep.txt"), b"needle\n");
+        touch(&root.join(".hidden.txt"), b"needle\n");
+        touch(&root.join("notes.log"), b"needle\n");
+        touch(&root.join("bundle.bin"), b"needle\0trailing\n");
+        touch(&root.join(".git/config"), b"needle\n");
+        std::fs::create_dir(root.join("ignored")).unwrap();
+        touch(&root.join("ignored/deep.txt"), b"needle\n");
+        std::fs::create_dir(root.join("nested")).unwrap();
+        touch(&root.join("nested/.gitignore"), b"skip.txt\n");
+        touch(&root.join("nested/skip.txt"), b"needle\n");
+        touch(&root.join("nested/keep.txt"), b"needle\n");
+
+        let (hits, _) = found(&root, "needle", 100);
+        let paths: Vec<&str> = hits.iter().map(|hit| hit.path.as_str()).collect();
+
+        assert_eq!(paths, vec![".hidden.txt", "keep.txt", "nested/keep.txt"]);
+    }
+
+    /// Where this parts ways with `git grep --untracked`, asserted against real
+    /// git so the day either side moves is not a silent one.
+    ///
+    /// The two mostly agree, and for a reason worth pinning: `--untracked`
+    /// implies `--exclude-standard`, so git was already deciding by the ignore
+    /// files rather than by the index — which is the only thing the `ignore`
+    /// crate can read. A file tracked *and* ignored is skipped by both.
+    ///
+    /// A nested repository is the case that differs. git never descends into
+    /// one without `--recurse-submodules`; this walk treats it as an ordinary
+    /// directory with ignore rules of its own. A vendored checkout becomes
+    /// searchable, and a submodule's working tree becomes something the walk
+    /// pays for. That is the accepted cost of dropping the index.
+    #[test]
+    fn a_nested_repository_is_where_this_parts_ways_with_git_grep() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = scratch("search-divergence");
+        let git = |at: &Path, args: &[&str]| {
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(at)
+                .args(args)
+                .output()
+                .unwrap()
+        };
+        git(&root, &["init", "-q"]);
+        touch(&root.join(".gitignore"), b"secrets.txt\n");
+        touch(&root.join("secrets.txt"), b"needle\n");
+        git(&root, &["add", "-f", "secrets.txt"]);
+        touch(&root.join("plain.txt"), b"needle\n");
+        std::fs::create_dir(root.join("vendor")).unwrap();
+        git(&root.join("vendor"), &["init", "-q"]);
+        touch(&root.join("vendor/inner.txt"), b"needle\n");
+
+        let grep = git(
+            &root,
+            &["grep", "-l", "-I", "--untracked", "--fixed-strings", "-e", "needle"],
+        );
+        let listed = String::from_utf8_lossy(&grep.stdout);
+        let git_saw: Vec<&str> = listed.lines().collect();
+        assert_eq!(git_saw, vec!["plain.txt"]);
+
+        let (hits, _) = found(&root, "needle", 100);
+        let paths: Vec<&str> = hits.iter().map(|hit| hit.path.as_str()).collect();
         assert_eq!(
-            found.text_offset as usize + span[0] as usize,
-            900,
-            "the window says where it starts, so columns still resolve"
+            paths,
+            vec!["plain.txt", "vendor/inner.txt"],
+            "the ignored file agrees with git; the nested repository does not"
         );
     }
 
-    /// Context lines are told apart from matches by their separator, not by
-    /// their line number — painting context as a hit is the failure this
-    /// prevents.
+    /// The limit is a cap on matches, not on files, and the run that hits it
+    /// says so — the pane draws "showing the first N" from that flag.
     #[test]
-    fn context_lines_are_not_matches() {
-        match parse_grep_output_line("src/a.rs-41-// above").unwrap() {
-            GrepLine::Context { path, line, text } => {
-                assert_eq!(path, "src/a.rs");
-                assert_eq!(line, 41);
-                assert_eq!(text, "// above");
-            }
-            _ => panic!("a hyphen line is context"),
-        }
-        assert!(matches!(
-            parse_grep_output_line("src/a.rs:42:hit").unwrap(),
-            GrepLine::Match { .. }
-        ));
-        assert!(matches!(
-            parse_grep_output_line("--").unwrap(),
-            GrepLine::Separator
-        ));
-        // A path with a hyphen in it is ordinary and must not be torn apart.
-        match parse_grep_output_line("my-crate/src/a.rs:7:hit").unwrap() {
-            GrepLine::Match { path, .. } => assert_eq!(path, "my-crate/src/a.rs"),
-            _ => panic!("still a match"),
-        }
+    fn the_limit_stops_the_walk_and_is_reported() {
+        let root = repo("search-limit");
+        touch(&root.join("many.txt"), "needle\n".repeat(20).as_bytes());
+
+        let (hits, outcome) = found(&root, "needle", 3);
+
+        assert_eq!(hits.len(), 3);
+        assert_eq!(outcome.matches, 3);
+        assert!(outcome.limit_hit);
+        assert!(!outcome.canceled);
+    }
+
+    /// Cancellation reaches inside a single file, not just between files: a
+    /// client that abandoned the query stops paying for it mid-walk, and gets
+    /// no further batch — including the partial one still in hand.
+    #[test]
+    fn cancelling_mid_file_stops_the_search_and_withholds_the_tail() {
+        let root = repo("search-cancel");
+        touch(&root.join("many.txt"), "needle\n".repeat(SEARCH_BATCH * 3).as_bytes());
+
+        let cancel = std::sync::atomic::AtomicBool::new(false);
+        let mut delivered = 0usize;
+        let outcome = search(&root, "needle", 10_000, &cancel, &mut |batch| {
+            delivered += batch.len();
+            cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+        });
+
+        assert_eq!(delivered, SEARCH_BATCH, "one batch left before the cancel");
+        assert_eq!(outcome.matches, SEARCH_BATCH as u64);
+        assert!(outcome.canceled);
+        assert!(!outcome.limit_hit);
+    }
+
+    /// Outside a repository there are no ignore files to honour, so everything
+    /// under the root is searched. `git grep` refused the same request with
+    /// "not a git repository"; answering it is the friendlier failure.
+    #[test]
+    fn a_root_that_is_not_a_repository_is_still_searched() {
+        let root = scratch("search-no-repo");
+        touch(&root.join("plain.txt"), b"needle\n");
+
+        let (hits, _) = found(&root, "needle", 100);
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "plain.txt");
     }
 
     /// The picker's ranking contract, asserted through the public entry point
@@ -1562,3 +2000,4 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 }
+

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -701,8 +701,9 @@ pub enum Control {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
     },
-    /// Content search (§C.12, capability `files`): the host runs `git grep`
-    /// and streams `search_results` events tagged with this request's `seq`,
+    /// Content search (§C.12, capability `files`): the host walks the root
+    /// itself — ripgrep's searcher over the ignore rules, no subprocess and no
+    /// git — and streams `search_results` events tagged with this request's `seq`,
     /// then closes with one `fs_searched` reply. Cancellable mid-stream with
     /// `cancel {request: <seq>}`.
     FsSearch {


### PR DESCRIPTION
`fs.search` shelled out to `git grep -n -I --untracked --fixed-strings` and parsed `path:line:text` back out of the pipe. This replaces the subprocess with ripgrep's own crates, used as libraries inside the daemon — no `rg` binary is spawned, because termiod ships as one static binary to boxes that have neither ripgrep nor, in a container, git.

- `ignore` — the gitignore-aware walk (`.gitignore`, the global excludes file, `.git/info/exclude`)
- `grep-searcher` — lines, context, encodings
- `grep-matcher` — the trait it searches through
- `aho-corasick` — the fixed-string matcher behind that trait; no regex engine, because the wire has always promised literals

**Nothing on the wire moves.** Same request and reply shapes, same fixed-strings semantics, same smart case decided from the query rather than a flag, same 512-byte window around the first hit, same two lines of context, same 50-match batches, same match cap, binary files still skipped by git's own rule (a NUL in the first 8000 bytes). The Swift and iOS clients needed no code change — only comments that described the host as running `git grep`.

Cancellation is now a flag the walker and the sink read, not a signal to a child: an abandoned search stops inside the file it is on. The walk runs on a blocking thread with a 32 MiB ceiling on one file, so a minified blob is skipped rather than allocated, and a panic reaches the client as a failure event instead of taking the daemon down.

## Ignore rules come from git, not from a re-parse

`ignore`'s `git_global` finds `core.excludesFile` with a single regex over the config files it guesses at, under a comment that reads "this is the lazy approach, and isn't technically correct". `\S+?` cannot cross a space, so a quoted path with one — `"~/Library/Application Support/git/ignore"`, which is what a Mac writes — comes back truncated and every rule in that file is dropped silently; `[include]` and `[includeIf]` are invisible to it.

The crate no longer reads git config. Inside a repository the path comes from `git config --path --get core.excludesFile`, which resolves the whole stack, follows includes and conditional includes, and expands `~`. **Nothing about the config format is reimplemented here** — resolving it through git is the point, and the one corner that is not asked of git is git's own documented default (`$XDG_CONFIG_HOME/git/ignore`) when the setting is absent, which is a fixed path rather than a parsed value. The file is handed to `WalkBuilder::add_ignore`, the last matcher `Ignore::matched` consults — below the `.gitignore` files and below `info/exclude`, which is git's order. A root outside a repository gets no global excludes, because git would apply none to a directory it does not own; a box with no git installed behaves the same.

The global matcher is rooted at the search root via `WalkBuilder::current_dir(root)`. Without it, `add_ignore` builds its matcher with `GitignoreBuilder::new(cwd)` — the *process's* working directory — so an anchored global `/root-only.txt` would anchor wherever termiod was launched rather than at the tree being searched. `current_dir` feeds only the global matcher's root, so precedence is untouched.

`core.excludesFile` has three states, and `git config` separates them only by exit code: absent exits non-zero, a path exits zero with the path, the empty string exits zero with empty output. Empty means *no global excludes* — it is how the setting is turned off — and git does not fall back to `$XDG_CONFIG_HOME/git/ignore` for it. All three are handled apart, with git's default path injected into the resolver so tests can pin the cases without moving `HOME` out from under the rest of the process.

When `core.excludesFile` is absent, git's default path follows git's own rule (`xdg_config_home` in `path.c`): `XDG_CONFIG_HOME` wins whenever it is set and non-empty — **relative paths included**, which the XDG spec says to ignore and git uses anyway — and `$HOME/.config` applies only when it is not. Any relative answer, from that default or from `git config --path`, is anchored at the search root, which is the `-C` this module runs git under and therefore the directory git resolved it against.

`.git/info/exclude` stays with the crate, against the review's suggestion, for a checked reason: `dir.rs` resolves it through `resolve_git_commondir`, which already handles `.git` being a *file* (a linked worktree, a submodule) and roots the resulting matcher at the repository, so an anchored `/target` still anchors. Routing it through `add_ignore` would root it at `""` and lose that. It reads no config, so the bug above never reached it.

## Searches queue instead of filling the blocking pool

One search took one `spawn_blocking` job with nothing rationing them. Once the pool filled with long walks, a queued search could not observe its own cancel flag until a worker freed — and the daemon awaited that job, which is a client's 90-second idle bound spent waiting out other people's queries.

Searches now queue on a daemon-wide semaphore sized to the machine (cores, floored at 2, capped at 8) and well below the blocking pool. A search cancelled while still queued answers immediately with `fs_searched { canceled: true }` rather than waiting for a slot it no longer needs — it has walked nothing, so there is nothing to report.

## The accepted tradeoff

The `ignore` crate re-implements git's ignore rules rather than asking git, so the two can disagree. Two behaviours do change, and both are pinned in tests:

- **A root that is not a git repository is searched** instead of refused.
- **A nested repository is walked** — a vendored checkout, a submodule's working tree — where `git grep` never descends without `--recurse-submodules`.

Everything else was checked against real `git grep` on a fixture tree and agrees: negation patterns, nested `.gitignore`, dotfiles, symlinks, CRLF, a BOM, latin-1, UTF-16, a NUL past the probe window, and a file both tracked and ignored (skipped by both — `--untracked` implies `--exclude-standard`). The Changes pane still reads git directly, so a file in one of the diverging cases can appear there and not in search results.

## Testing

`cargo build`, `cargo test` and `cargo clippy` green; `swift build` and `swift test` green. `parse_grep_output_line` / `parse_grep_line` are deleted and their tests now run the real search over fixture trees, asserting on the `SearchMatch` values it builds — colons in the text, long-line windowing, multibyte boundaries, span case rules, context vs match lines, the limit, and mid-file cancellation.

The equivalence test is now genuinely differential: one fixture repo with a nested `.gitignore`, a negation, `info/exclude`, a quoted `core.excludesFile` whose path contains spaces, a dotfile and a file both tracked and ignored — real `git grep --untracked` runs on it and the two file sets must match, and must match the right answer rather than a shared mistake. Reverting to `git_global` fails it on the global file; dropping `current_dir(root)` fails it on the anchored one. The `XDG_CONFIG_HOME` rule is asserted of real `git grep` before it is asserted of this code, since the spec and git disagree about relative paths. The empty-value case has its own real-git fixture with a populated default location neither side may reach, plus a direct assertion on the resolution — the walk alone could not prove *why* it agreed, since the test process's home is not the fixture's. The queued-cancel path has its own test: hold every permit, cancel the queued search, require the terminal reply. Also driven end to end against a real daemon over its socket: streaming batches, the limit, `cancel` mid-stream, a bad root, a non-repo root, and a client hanging up mid-search without taking the daemon with it.

Release Notes:
- Project search on a remote box no longer shells out to `git grep`: the daemon walks the tree itself with ripgrep's search engine built in. It now works on a root that is not a git repository, and on machines where git is not installed. Because the ignore rules are read directly rather than asked of git, a nested repository — a vendored checkout or a submodule — is searched where it used to be skipped.


