### PR TITLE
Judge only complete lines in the join invariant

### DIFF
--- a/termiod/tests/join_invariant.rs
+++ b/termiod/tests/join_invariant.rs
@@ -210,12 +210,48 @@ fn parse_counter(line: &str) -> Option<u64> {
 
 /// Counters in a byte stream, split on line endings with `\r` removed so a
 /// boundary landing inside a `\r\n` pair does not read as a missing line.
+///
+/// Only *complete* lines are returned. Both readers stop mid-flood, so the
+/// bytes they hold almost always end part-way through a line, and a counter
+/// truncated between its digits still parses — as a much smaller number. Left
+/// in, `JOIN 25` sliced out of `JOIN 25484` reads as the stream jumping
+/// backwards, and `assert_consecutive` reports a replay the daemon never
+/// performed. Dropping the final element removes it: after a trailing newline
+/// that element is the empty string, and otherwise it is the partial line.
 fn stream_lines(bytes: &[u8]) -> Vec<String> {
-    String::from_utf8_lossy(bytes)
+    let mut lines: Vec<String> = String::from_utf8_lossy(bytes)
         .replace('\r', "")
         .split('\n')
         .map(str::to_string)
-        .collect()
+        .collect();
+    lines.pop();
+    lines
+}
+
+/// The truncation that made this test call the daemon a liar: a counter cut
+/// between its digits is a proper prefix of the line being written, so it
+/// parses, and it is smaller than the counter before it.
+#[test]
+fn a_line_cut_mid_counter_is_not_a_counter() {
+    let cut = b"JOIN 25482\r\nJOIN 25483\r\nJOIN 25";
+    assert_eq!(
+        stream_lines(cut),
+        vec!["JOIN 25482".to_string(), "JOIN 25483".to_string()],
+        "the partial line survived and would parse as counter 25"
+    );
+
+    let whole = b"JOIN 25482\r\nJOIN 25483\r\n";
+    assert_eq!(
+        stream_lines(whole),
+        vec!["JOIN 25482".to_string(), "JOIN 25483".to_string()],
+        "a stream ending on a line terminator lost a complete line"
+    );
+
+    let counters: Vec<u64> = stream_lines(cut)
+        .iter()
+        .filter_map(|line| parse_counter(line))
+        .collect();
+    assert_consecutive(&counters, "the fixture");
 }
 
 fn assert_consecutive(counters: &[u64], who: &str) {


### PR DESCRIPTION
`termiod` has been red on `main` since [#559](https://github.com/termio-sh/termio/pull/559) merged — [run 33435653921](https://github.com/termio-sh/termio/actions/runs/33435653921/job/99631306771), macos job:

```
thread 'attaching_mid_flood_joins_the_stream_exactly_once' panicked at tests/join_invariant.rs:223:9:
assertion `left == right` failed: the late client saw 25 after 25483 — the byte stream replayed bytes
  left: 25
 right: 25484
```

The daemon replayed nothing. `25` is a strict prefix of `25484`.

## What actually happened

Both readers stop mid-flood, so the bytes they hold end part-way through a line. `stream_lines` split on `\n` and kept that trailing fragment, and `parse_counter` accepts it, because a counter cut between its digits is a proper prefix of the line being written. `JOIN 25` sliced out of `JOIN 25484` therefore entered `late_counters` as `25`, after `25483`, and `assert_consecutive` reported a replay.

Reproduced by feeding the two helpers verbatim a stream that ends mid-counter — the panic is byte-identical to CI's, `left: 25` / `right: 25484`.

`highest_counter` already documents this exact hazard for the snapshot path ("A truncated counter is always a proper prefix of the next one"). The byte-stream path never got the same guard.

## The fix

Drop the final element of the split. After a line terminator it is the empty string; otherwise it is the partial line. Either way no complete line is lost, and it covers both readers, since the early client's counters come through the same helper.

## Why it only ever failed in CI

Instrumenting `stream_lines` locally shows all 51 calls in a run dropping an **empty** tail: on an idle machine each PTY read returns one whole line, so `lines.pop()` is a no-op and the bug is invisible. A loaded runner coalesces reads and lands the tail mid-counter. That is the whole of the load-dependence — nothing about the barrier, the sidecar FIFO, or attach ordering is involved.

## Verification

The new `a_line_cut_mid_counter_is_not_a_counter` fails on the unfixed helper with `left: ["JOIN 25482", "JOIN 25483", "JOIN 25"]` and passes with it, so it pins the actual defect rather than restating the fix. Full `cargo test`: 225 unit plus every integration test green, `join_invariant` included.

Release Notes:
- No user-facing change. Fixes a false failure in the `termiod` join-invariant test that was blocking CI on `main`.