### PR TITLE
Say the dev channel disables Sparkle rather than strips it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ lifecycle. Run it from a macOS GUI session.
 
 Use the dev channel whenever a released termio is installed: it gets its own
 bundle id (`sh.termio.app.dev`), state dir (`~/.termio-dev`), companion port
-(8788), and `termio-dev` CLI, with Sparkle stripped so it can never auto-update
-itself onto the release channel.
+(8788), and `termio-dev` CLI, with no Sparkle update feed, so it can never
+auto-update itself onto the release channel.
 
 The `macos-rebuild-dev` and `ios-rebuild-dev` skills wrap the rebuild-and-
 relaunch loop; prefer them over hand-rolling the commands.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ open ./termio-dev.app
 ```
 
 The dev channel gets its own bundle id (`sh.termio.app.dev`), its own state dir
-(`~/.termio-dev`), its own companion port (8788), a `termio-dev` CLI, and has
-Sparkle stripped so it can never auto-update itself onto the release channel.
+(`~/.termio-dev`), its own companion port (8788), a `termio-dev` CLI, and no
+Sparkle update feed, so it can never auto-update itself onto the release channel.
 
 ### iOS companion
 

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -22,9 +22,9 @@
 #   TERMIO_CHANNEL   which identity to build; only two values exist. Unset (or
 #                    "release") builds ./termio.app. "dev" builds a side-by-side
 #                    termio-dev.app (bundle id ….dev, its own ~/.termio-dev state +
-#                    companion port 8788, Sparkle stripped) so it runs beside an
-#                    installed release build. Any other value is rejected — see
-#                    the channel check below for why.
+#                    companion port 8788, Sparkle's update feed removed) so it runs
+#                    beside an installed release build. Any other value is rejected —
+#                    see the channel check below for why.
 #   TERMIO_VERSION   CFBundleShortVersionString to stamp (default: keep Info.plist's)
 #   TERMIO_BUILD     CFBundleVersion to stamp; must increase across shipped builds
 #                    because Sparkle compares it (default: keep Info.plist's)
@@ -43,7 +43,7 @@ configuration="release"
 # wrapper and identity change per channel.
 product_name="termio"
 # TERMIO_CHANNEL=dev builds a side-by-side dev app (termio-dev.app, id ….dev, its
-# own state dir + port, Sparkle stripped) so it can run beside an installed release.
+# own state dir + port, no Sparkle update feed) so it can run beside an installed release.
 # Unset or "release" builds the shipped identity. Lower-cased the way AppChannel
 # lower-cases it at runtime, so the two agree on what a channel name is.
 channel="$(printf '%s' "${TERMIO_CHANNEL:-release}" | tr '[:upper:]' '[:lower:]')"
@@ -363,11 +363,13 @@ if [[ -n "${TERMIO_BUILD:-}" ]]; then
 fi
 
 # Dev channel: suffix the bundle id (so LaunchServices, UserDefaults, and
-# AppChannel's paths/port all diverge from the release build), rename it, and strip
-# Sparkle so the dev app can never auto-update itself onto the release channel.
+# AppChannel's paths/port all diverge from the release build), rename it, and delete
+# Sparkle's update feed so the dev app can never auto-update itself onto the release
+# channel. The framework itself still ships: the binary links it on both channels, so
+# a bundle without it fails to launch. What changes is that there is no feed to check.
 if [[ "$channel" == "dev" ]]; then
     base_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")"
-    echo "==> Dev channel: bundle id ${base_id}.dev, Sparkle stripped"
+    echo "==> Dev channel: bundle id ${base_id}.dev, Sparkle update feed removed"
     /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${base_id}.dev" "$plist"
     /usr/libexec/PlistBuddy -c "Set :CFBundleName termio dev" "$plist"
     /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName termio dev" "$plist"

--- a/skills/macos-rebuild-dev/SKILL.md
+++ b/skills/macos-rebuild-dev/SKILL.md
@@ -24,10 +24,12 @@ release one, so both can run at the same time:
 | Daemon launchd job | `sh.termio.termiod` | `sh.termio.termiod.dev` |
 | Companion port | 8787 | 8788 |
 | CLI on PATH | `termio` | `termio-dev` |
-| Sparkle auto-update | on | **stripped** (dev never self-updates) |
+| Sparkle auto-update | on | **no update feed** (dev never self-updates) |
 
 All of this falls out of the `.dev` bundle-id suffix via `Sources/termio/Companion/AppChannel.swift`
-(paths + port) and `scripts/build-app.sh` (id, name, Sparkle strip, CLI rebind).
+(paths + port) and `scripts/build-app.sh` (id, name, `SUFeedURL` deletion, CLI rebind).
+Sparkle.framework itself is embedded on both channels — the binary links it either
+way — so a dev bundle still carries it; it just has nothing to check.
 
 termio is a plain SwiftPM executable (`Package.swift` → `executableTarget` named
 `termio`); `swift build` alone produces a bare binary with **no Dock icon**. So this


### PR DESCRIPTION
`build-app.sh`'s dev branch deletes `SUFeedURL` and sets `SUEnableAutomaticChecks false`. It does not remove Sparkle.framework — `cp -R "$sparkle_src" "$frameworks_dir/"` runs on both channels, and it has to: the binary links `@rpath/Sparkle.framework` either way, so a bundle without it fails to launch in dyld.

Four places said "Sparkle stripped": the script's header, its channel comment, the dev block plus the line it prints, `AGENTS.md`, `CONTRIBUTING.md`, and the `macos-rebuild-dev` table. That wording made a real dev-build crash — `Library not loaded: @rpath/Sparkle.framework` — read as impossible, and sent the diagnosis down the wrong path.

Comments and copy only; no behavior change.

Release Notes:
- None (internal docs).