### PR TITLE
Document the termio CLI exit codes and flag forms

### DIFF
--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -59,7 +59,9 @@ id-prefix works too).
   single-line payload arrives verbatim, exactly as typed; a multi-line one is
   wrapped in bracketed paste so a TUI takes it as one block instead of
   submitting each line as its own turn. Add `--no-enter` when a gate wants a
-  bare keypress and no Return — the lone `t` that trusts a folder.
+  bare keypress and no Return — the lone `t` that trusts a folder. Text that
+  itself begins with a dash goes after `--`, which ends the flags:
+  `termio sessions send <link> -- --force`.
 - `termio sessions send <link> --key <name>` — press a named key in that
   session: `--key escape` to back out of a menu, `--key up --key enter` to
   rerun its last entry, `--key ctrl-c` to interrupt. Repeatable and pressed
@@ -94,6 +96,10 @@ id-prefix works too).
 
 - Copy links verbatim from `list` or a `send` reply; never guess or
   construct one.
+- A flag it does not know is an error, never text: `--agnet codex` exits 2
+  with a suggestion instead of becoming part of the prompt. Exit 2 means the
+  command was malformed and never reached Termio — fix the command, do not
+  retry it. `--agent codex` and `--agent=codex` are both accepted.
 - One request, one target. Never send the same prompt to several siblings,
   and never run multiple `send` commands in parallel — delegate to ONE
   session.

--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -96,10 +96,9 @@ id-prefix works too).
 
 - Copy links verbatim from `list` or a `send` reply; never guess or
   construct one.
-- A flag it does not know is an error, never text: `--agnet codex` exits 2
-  with a suggestion instead of becoming part of the prompt. Exit 2 means the
-  command was malformed and never reached Termio — fix the command, do not
-  retry it. `--agent codex` and `--agent=codex` are both accepted.
+- An unknown flag is an error, never text. Exit 2 means the command was
+  malformed and never reached Termio — fix it rather than retry.
+  `--agent codex` and `--agent=codex` are both accepted.
 - One request, one target. Never send the same prompt to several siblings,
   and never run multiple `send` commands in parallel — delegate to ONE
   session.

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -59,7 +59,9 @@ id-prefix works too).
   single-line payload arrives verbatim, exactly as typed; a multi-line one is
   wrapped in bracketed paste so a TUI takes it as one block instead of
   submitting each line as its own turn. Add `--no-enter` when a gate wants a
-  bare keypress and no Return — the lone `t` that trusts a folder.
+  bare keypress and no Return — the lone `t` that trusts a folder. Text that
+  itself begins with a dash goes after `--`, which ends the flags:
+  `termio sessions send <link> -- --force`.
 - `termio sessions send <link> --key <name>` — press a named key in that
   session: `--key escape` to back out of a menu, `--key up --key enter` to
   rerun its last entry, `--key ctrl-c` to interrupt. Repeatable and pressed
@@ -94,6 +96,10 @@ id-prefix works too).
 
 - Copy links verbatim from `list` or a `send` reply; never guess or
   construct one.
+- A flag it does not know is an error, never text: `--agnet codex` exits 2
+  with a suggestion instead of becoming part of the prompt. Exit 2 means the
+  command was malformed and never reached Termio — fix the command, do not
+  retry it. `--agent codex` and `--agent=codex` are both accepted.
 - One request, one target. Never send the same prompt to several siblings,
   and never run multiple `send` commands in parallel — delegate to ONE
   session.

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -96,10 +96,9 @@ id-prefix works too).
 
 - Copy links verbatim from `list` or a `send` reply; never guess or
   construct one.
-- A flag it does not know is an error, never text: `--agnet codex` exits 2
-  with a suggestion instead of becoming part of the prompt. Exit 2 means the
-  command was malformed and never reached Termio — fix the command, do not
-  retry it. `--agent codex` and `--agent=codex` are both accepted.
+- An unknown flag is an error, never text. Exit 2 means the command was
+  malformed and never reached Termio — fix it rather than retry.
+  `--agent codex` and `--agent=codex` are both accepted.
 - One request, one target. Never send the same prompt to several siblings,
   and never run multiple `send` commands in parallel — delegate to ONE
   session.

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -232,14 +232,10 @@ supervisor reads the worker’s transcript, with `watch` as the backstop. A
 ### Fail loud
 
 The CLI is built for callers that trust exit codes, not prose. A command that
-runs and fails — an error reply, an empty one — exits `1`. A command that was
-typed wrong never reaches the app at all and exits `2`.
-
-That second code is what makes a mistyped flag safe. `--agnet codex` is refused
-with a suggestion rather than folded into the prompt, so a wrong flag can no
-longer read as a successful spawn. Flags take either spelling, `--agent codex`
-or `--agent=codex`, and `--` ends them — which is how text beginning with a
-dash reaches a session:
+runs and fails — an error reply, an empty one — exits `1`; a command it cannot
+parse exits `2` without contacting the app. Flags take either spelling,
+`--agent codex` or `--agent=codex`, and `--` ends them, which is how text
+beginning with a dash reaches a session:
 
 ```sh
 termio sessions send <session> -- --force

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -231,11 +231,24 @@ supervisor reads the worker’s transcript, with `watch` as the backstop. A
 
 ### Fail loud
 
-The CLI is built for callers that trust exit codes, not prose. Every one-shot
-command exits `1` on an error or an empty reply, and gives up after a
-15-second client timeout rather than hanging on a busy app (override with the
-`TERMIO_CLI_TIMEOUT` environment variable; a `--wait` call widens the client
-timeout automatically to outlive the server-side wait).
+The CLI is built for callers that trust exit codes, not prose. A command that
+runs and fails — an error reply, an empty one — exits `1`. A command that was
+typed wrong never reaches the app at all and exits `2`.
+
+That second code is what makes a mistyped flag safe. `--agnet codex` is refused
+with a suggestion rather than folded into the prompt, so a wrong flag can no
+longer read as a successful spawn. Flags take either spelling, `--agent codex`
+or `--agent=codex`, and `--` ends them — which is how text beginning with a
+dash reaches a session:
+
+```sh
+termio sessions send <session> -- --force
+```
+
+One-shot commands give up after a 15-second client timeout rather than hanging
+on a busy app (override with the `TERMIO_CLI_TIMEOUT` environment variable; a
+`--wait` call widens the client timeout automatically to outlive the
+server-side wait).
 
 ## JSON contract
 

--- a/web/landing/content/docs/session-control.zh-CN.mdx
+++ b/web/landing/content/docs/session-control.zh-CN.mdx
@@ -3,7 +3,7 @@ title: 会话控制与命令行
 description: Termio 的编排 API——让 Agent 汇报自己在做什么的状态 hooks，以及让你（或另一个 Agent）从 shell 里派生、驱动和监督会话的 termio sessions 命令行。
 x-i18n:
   source_path: session-control.mdx
-  source_hash: aee6cd59c94753760b5e56a2721e63748a839419f837107823c1603563d394a1
+  source_hash: d8f45e181eaceaf156197e86596db197400f29e4b4fcda4ddb44d8d644a93984
   generated_at: 2026-09-01
 ---
 
@@ -192,11 +192,9 @@ termio sessions spawn "summarize the failing CI job" --wait --timeout 120000
 ### 大声失败
 
 这个命令行是为信任退出码、而不是信任散文的调用方设计的。跑起来又失败的命令——错误回复、空
-回复——以 `1` 退出；写错的命令根本到不了应用，以 `2` 退出。
-
-正是第二个退出码让写错的选项不再危险。`--agnet codex` 会被拒绝并给出拼写建议，而不是被并进
-提示里，所以一个写错的选项不会再看起来像一次成功的 spawn。选项两种写法都收，`--agent codex`
-和 `--agent=codex`；`--` 结束选项解析——以短横线开头的文本就是这样送进会话的：
+回复——以 `1` 退出；解析不了的命令不会联系应用，以 `2` 退出。选项两种写法都收，
+`--agent codex` 和 `--agent=codex`；`--` 结束选项解析——以短横线开头的文本就是这样送进
+会话的：
 
 ```sh
 termio sessions send <session> -- --force

--- a/web/landing/content/docs/session-control.zh-CN.mdx
+++ b/web/landing/content/docs/session-control.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 会话控制与命令行
 description: Termio 的编排 API——让 Agent 汇报自己在做什么的状态 hooks，以及让你（或另一个 Agent）从 shell 里派生、驱动和监督会话的 termio sessions 命令行。
 x-i18n:
   source_path: session-control.mdx
-  source_hash: 56acf1ab65cf19cb4894ab70c524c20ea429225458e84adcff20422f72168ec8
-  generated_at: 2026-08-30
+  source_hash: aee6cd59c94753760b5e56a2721e63748a839419f837107823c1603563d394a1
+  generated_at: 2026-09-01
 ---
 
 你在侧栏看到的实时状态背后，是两个相关的可选功能：让 Agent 汇报自己在做什么的**状态
@@ -191,8 +191,18 @@ termio sessions spawn "summarize the failing CI job" --wait --timeout 120000
 
 ### 大声失败
 
-这个命令行是为信任退出码、而不是信任散文的调用方设计的。每条一次性命令在出错或收到空回复时
-都以 `1` 退出，并在 15 秒的客户端超时后放弃，而不是在应用繁忙时一直挂着（可用
+这个命令行是为信任退出码、而不是信任散文的调用方设计的。跑起来又失败的命令——错误回复、空
+回复——以 `1` 退出；写错的命令根本到不了应用，以 `2` 退出。
+
+正是第二个退出码让写错的选项不再危险。`--agnet codex` 会被拒绝并给出拼写建议，而不是被并进
+提示里，所以一个写错的选项不会再看起来像一次成功的 spawn。选项两种写法都收，`--agent codex`
+和 `--agent=codex`；`--` 结束选项解析——以短横线开头的文本就是这样送进会话的：
+
+```sh
+termio sessions send <session> -- --force
+```
+
+一次性命令会在 15 秒的客户端超时后放弃，而不是在应用繁忙时一直挂着（可用
 `TERMIO_CLI_TIMEOUT` 环境变量覆盖；带 `--wait` 的调用会自动放宽客户端超时，让它活得比服务端
 的等待更久）。
 

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -59,7 +59,9 @@ id-prefix works too).
   single-line payload arrives verbatim, exactly as typed; a multi-line one is
   wrapped in bracketed paste so a TUI takes it as one block instead of
   submitting each line as its own turn. Add `--no-enter` when a gate wants a
-  bare keypress and no Return — the lone `t` that trusts a folder.
+  bare keypress and no Return — the lone `t` that trusts a folder. Text that
+  itself begins with a dash goes after `--`, which ends the flags:
+  `termio sessions send <link> -- --force`.
 - `termio sessions send <link> --key <name>` — press a named key in that
   session: `--key escape` to back out of a menu, `--key up --key enter` to
   rerun its last entry, `--key ctrl-c` to interrupt. Repeatable and pressed
@@ -94,6 +96,10 @@ id-prefix works too).
 
 - Copy links verbatim from `list` or a `send` reply; never guess or
   construct one.
+- A flag it does not know is an error, never text: `--agnet codex` exits 2
+  with a suggestion instead of becoming part of the prompt. Exit 2 means the
+  command was malformed and never reached Termio — fix the command, do not
+  retry it. `--agent codex` and `--agent=codex` are both accepted.
 - One request, one target. Never send the same prompt to several siblings,
   and never run multiple `send` commands in parallel — delegate to ONE
   session.

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -96,10 +96,9 @@ id-prefix works too).
 
 - Copy links verbatim from `list` or a `send` reply; never guess or
   construct one.
-- A flag it does not know is an error, never text: `--agnet codex` exits 2
-  with a suggestion instead of becoming part of the prompt. Exit 2 means the
-  command was malformed and never reached Termio — fix the command, do not
-  retry it. `--agent codex` and `--agent=codex` are both accepted.
+- An unknown flag is an error, never text. Exit 2 means the command was
+  malformed and never reached Termio — fix it rather than retry.
+  `--agent codex` and `--agent=codex` are both accepted.
 - One request, one target. Never send the same prompt to several siblings,
   and never run multiple `send` commands in parallel — delegate to ONE
   session.


### PR DESCRIPTION
The `termio` CLI parses argv with clap as of [#565](https://github.com/termio-sh/termio/pull/565). Two things in the docs need to match it.

**The exit codes.** `session-control.mdx` said every one-shot command exits `1` on an error. A command the CLI cannot parse exits `2` without contacting the app. That page's premise is "built for callers that trust exit codes", so the number has to be right.

**The flag forms.** `--agent codex` and `--agent=codex` are both accepted, and `--` ends the flags — the only way to send text that begins with a dash:

```sh
termio sessions send <session> -- --force
```

## Where

- `content/docs/session-control.mdx` — the **Fail loud** section.
- `content/docs/session-control.zh-CN.mdx` — retranslated and re-stamped, keeping the page's own vocabulary: `spawn` stays in English as it does throughout, 提示 for the prompt, 选项 for a flag.
- The agent skill, in all three byte-identical copies — `skills/termio/SKILL.md` (source of truth), `Sources/termio/Resources/skills/termio/SKILL.md` (embedded by `termiod` via `include_str!`), and `web/landing/public/skill.md` (served by termio.sh). Agents drive the CLI from this file, so it gets the `--` form on the `send` bullet and, under the targeting rules, that exit 2 means the command was malformed and should be fixed rather than retried.

Unchanged on purpose: the `--wait` triple (0 settled, 1 error, 3 timed out) and `watch`'s 0/2 are runtime codes and still correct. The READMEs only show invocations whose syntax did not change.

`pnpm docs:check` passes — keybindings match the catalog, 17 pages × 1 locale in step, 122 links resolve.

Note for review: `pnpm docs:stamp` re-dates every translation it touches, so it also bumped `generated_at` on 16 unrelated zh-CN pages. Those are reverted here; only the page actually retranslated carries a new stamp.

Release Notes:
- Documented the `termio` CLI's exit codes and its `--flag=value` and `--` forms.