### PR TITLE
Wait on the socket when stopping a daemon, not on a pid and a filename

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -717,6 +717,26 @@ extension Termiod {
         guard status == 0 else {
             throw TermiodClientError.daemonSpawnFailed(status)
         }
+        reapWhenItExits(pid)
+    }
+
+    /// Collect the daemon's exit status whenever it comes.
+    ///
+    /// `POSIX_SPAWN_SETSID` detaches the session, not the parentage: the daemon
+    /// stays this app's child, and a child nobody waits on becomes a zombie the
+    /// moment it exits — one whose pid `kill(pid, 0)` keeps answering for. That
+    /// is what `termiod stop` used to read as a daemon refusing to leave (#571),
+    /// and it lasted as long as the app did. The daemon this waits on outlives
+    /// most launches, so the wait cannot be a parked thread.
+    private static func reapWhenItExits(_ pid: pid_t) {
+        let source = DispatchSource.makeProcessSource(
+            identifier: pid, eventMask: .exit, queue: .global(qos: .utility))
+        source.setEventHandler {
+            var ignored: Int32 = 0
+            _ = waitpid(pid, &ignored, WNOHANG)
+            source.cancel()
+        }
+        source.resume()
     }
 
     // MARK: - Handshake and control channel

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -88,7 +88,7 @@ pub async fn stdio() -> Result<()> {
 /// Whether a connect failure proves nothing is serving the socket. `ENOENT`
 /// (no file) and `ECONNREFUSED` (a file no listener backs) do; every other
 /// errno describes this client's situation, not the daemon's.
-fn absent_daemon(errno: Option<i32>) -> bool {
+pub(crate) fn absent_daemon(errno: Option<i32>) -> bool {
     matches!(errno, Some(libc::ENOENT) | Some(libc::ECONNREFUSED))
 }
 

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -121,10 +121,26 @@ fn spawn_daemon() -> Result<()> {
         cmd.pre_exec(|| {
             // Detach from the client's session so the daemon survives us.
             libc::setsid();
-            Ok(())
+            // Then fork once more, so the daemon's parent is pid 1 rather than
+            // whichever client happened to autostart it. Clients here outlive
+            // the daemon routinely — the app, and the long-lived `termiod
+            // stdio` an SSH attach runs — and none of them waits on it, so its
+            // exit used to leave a zombie whose pid still answered `kill(pid,
+            // 0)`. Supervised hosts never had this: systemd is the parent
+            // there, and it reaps (#571).
+            match libc::fork() {
+                -1 => Err(std::io::Error::last_os_error()),
+                0 => Ok(()),
+                _ => libc::_exit(0),
+            }
         });
     }
-    cmd.spawn().context("starting termiod daemon")?;
+    // Waits on the intermediate, which exits the instant it has forked — never
+    // on the daemon, which is no longer a child of this process at all.
+    cmd.spawn()
+        .context("starting termiod daemon")?
+        .wait()
+        .context("waiting for the daemon to detach")?;
     Ok(())
 }
 

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -88,15 +88,17 @@ pub async fn stdio() -> Result<()> {
 /// Whether a connect failure proves nothing is serving the socket. `ENOENT`
 /// (no file) and `ECONNREFUSED` (a file no listener backs) do; every other
 /// errno describes this client's situation, not the daemon's.
-/// Whether a failed connect means autostarting is the right recovery.
+/// Whether a failed connect licenses *acting on* the path: starting a daemon
+/// that will bind it, or — in [`crate::daemon`] — unlinking it first.
 ///
 /// Narrower than [`crate::lifecycle::nothing_is_serving`] by exactly one errno,
-/// and deliberately: `ENOTSOCK` says a *file* holds the path, which proves no
-/// daemon is serving but also that starting one cannot help — it would fail to
-/// bind over the file and the spawn would be noise on top of a state a human
-/// has to clear. The two questions are close enough to fold together and
-/// different enough that folding them would be wrong.
-fn absent_daemon(errno: Option<i32>) -> bool {
+/// and the difference is the point. `ENOTSOCK` says a plain file holds the
+/// path. That proves no daemon is serving, which is all a stop needs to
+/// conclude; it is not permission to delete a file this daemon did not create,
+/// nor to spawn one that would fail to bind over it. That state needs a human,
+/// and the two questions are different enough that folding them would answer
+/// one of them wrongly.
+pub(crate) fn absent_daemon(errno: Option<i32>) -> bool {
     matches!(errno, Some(libc::ENOENT) | Some(libc::ECONNREFUSED))
 }
 
@@ -916,6 +918,10 @@ mod autostart_tests {
     fn only_a_provably_absent_daemon_recovers_by_spawning() {
         assert!(super::absent_daemon(Some(libc::ENOENT)));
         assert!(super::absent_daemon(Some(libc::ECONNREFUSED)));
+        // Proof that nothing is serving, but not permission to unlink a file
+        // this daemon did not create or to spawn one that cannot bind over it.
+        assert!(!super::absent_daemon(Some(libc::ENOTSOCK)));
+        assert!(crate::lifecycle::nothing_is_serving(Some(libc::ENOTSOCK)));
         assert!(!super::absent_daemon(Some(libc::EPERM)));
         assert!(!super::absent_daemon(Some(libc::EACCES)));
         assert!(!super::absent_daemon(Some(libc::ETIMEDOUT)));

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -88,7 +88,15 @@ pub async fn stdio() -> Result<()> {
 /// Whether a connect failure proves nothing is serving the socket. `ENOENT`
 /// (no file) and `ECONNREFUSED` (a file no listener backs) do; every other
 /// errno describes this client's situation, not the daemon's.
-pub(crate) fn absent_daemon(errno: Option<i32>) -> bool {
+/// Whether a failed connect means autostarting is the right recovery.
+///
+/// Narrower than [`crate::lifecycle::nothing_is_serving`] by exactly one errno,
+/// and deliberately: `ENOTSOCK` says a *file* holds the path, which proves no
+/// daemon is serving but also that starting one cannot help — it would fail to
+/// bind over the file and the spawn would be noise on top of a state a human
+/// has to clear. The two questions are close enough to fold together and
+/// different enough that folding them would be wrong.
+fn absent_daemon(errno: Option<i32>) -> bool {
     matches!(errno, Some(libc::ENOENT) | Some(libc::ECONNREFUSED))
 }
 

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -889,7 +889,7 @@ pub async fn serve(
 
 /// Whether a failed probe connect proves no daemon is behind the socket file.
 fn socket_is_stale(errno: Option<i32>) -> bool {
-    crate::lifecycle::nothing_is_serving(errno)
+    crate::client::absent_daemon(errno)
 }
 
 /// The inode currently at `path`, or `None` when nothing is.

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -889,7 +889,7 @@ pub async fn serve(
 
 /// Whether a failed probe connect proves no daemon is behind the socket file.
 fn socket_is_stale(errno: Option<i32>) -> bool {
-    crate::client::absent_daemon(errno)
+    crate::lifecycle::nothing_is_serving(errno)
 }
 
 /// The inode currently at `path`, or `None` when nothing is.

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -584,7 +584,19 @@ pub async fn serve(
                     // here is a sandbox denying *this* process, not a dead
                     // daemon: unlinking on it displaced healthy daemons and
                     // left them as the unreachable orphans of #526.
+                    // A corpse is still a *socket*. Linux answers a connect to
+                    // a plain file with ECONNREFUSED where macOS says ENOTSOCK,
+                    // so without this the same mistyped `TERMIOD_SOCK` deletes
+                    // the file it names on one platform and is refused on the
+                    // other. What the errno licenses is replacing a socket
+                    // nobody serves, never destroying something else.
                     Err(error) if socket_is_stale(error.raw_os_error()) => {
+                        if !path_is_socket(&sock_path) {
+                            anyhow::bail!(
+                                "{} is not a socket — refusing to replace a file termiod did not create",
+                                sock_path.display()
+                            );
+                        }
                         let _ = std::fs::remove_file(&sock_path);
                     }
                     Err(error) => {
@@ -890,6 +902,16 @@ pub async fn serve(
 /// Whether a failed probe connect proves no daemon is behind the socket file.
 fn socket_is_stale(errno: Option<i32>) -> bool {
     crate::client::absent_daemon(errno)
+}
+
+/// Whether `path` is a socket. `false` for anything else, a path that cannot be
+/// stat'd included: the only caller is about to unlink, and it may act only on
+/// what it can positively identify.
+fn path_is_socket(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+    std::fs::metadata(path)
+        .map(|metadata| metadata.file_type().is_socket())
+        .unwrap_or(false)
 }
 
 /// The inode currently at `path`, or `None` when nothing is.

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -889,7 +889,7 @@ pub async fn serve(
 
 /// Whether a failed probe connect proves no daemon is behind the socket file.
 fn socket_is_stale(errno: Option<i32>) -> bool {
-    matches!(errno, Some(libc::ECONNREFUSED) | Some(libc::ENOENT))
+    crate::client::absent_daemon(errno)
 }
 
 /// The inode currently at `path`, or `None` when nothing is.

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -42,6 +42,10 @@ const SETTLE: Duration = Duration::from_secs(15);
 /// and the settle budget belongs to the next one.
 const PROBE: Duration = Duration::from_secs(1);
 
+/// How long to wait between probes. Sized from what is left of the deadline
+/// each time, so the last one never sleeps past it.
+const POLL: Duration = Duration::from_millis(100);
+
 /// Exit code for a stop the daemon declined because it holds work someone is
 /// using. Distinct from failure: the state is named, and running again after
 /// the sessions close is the whole recovery.
@@ -536,7 +540,8 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
                 message: format!("stopped pid {pid}"),
             });
         }
-        tokio::time::sleep(Duration::from_millis(100).min(remaining)).await;
+        let left = deadline.saturating_duration_since(Instant::now());
+        tokio::time::sleep(left.min(POLL)).await;
     }
 }
 
@@ -559,7 +564,7 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
 async fn connect_if_serving(socket: &Path) -> Result<Option<UnixStream>> {
     match tokio::time::timeout(Duration::from_secs(5), UnixStream::connect(socket)).await {
         Ok(Ok(stream)) => Ok(Some(stream)),
-        Ok(Err(error)) if crate::client::absent_daemon(error.raw_os_error()) => Ok(None),
+        Ok(Err(error)) if nothing_is_serving(error.raw_os_error()) => Ok(None),
         Ok(Err(error)) => Err(anyhow::Error::new(error)
             .context(format!("reaching the daemon at {}", socket.display()))),
         Err(_elapsed) => bail!(
@@ -569,19 +574,31 @@ async fn connect_if_serving(socket: &Path) -> Result<Option<UnixStream>> {
     }
 }
 
-/// Only two errnos prove nothing is behind the path, and they are the two
-/// [`absent_daemon`] already names for the client that is about to autostart
-/// one. Everything else is a daemon this process cannot reach rather than one
-/// that left: `EPERM` from a sandbox, or a connect that ran out of budget
-/// against a listener whose backlog is full. Reading either as "stopped" would
-/// hand the upgrade a daemon still holding every session it had, which is worse
-/// than the wait it replaced — so they keep waiting, and the deadline decides.
-/// A daemon that answers but whose pid the kernel will not name is treated the
-/// same way.
+/// Whether a failed connect proves nothing is behind the path.
+///
+/// Three errnos do. `ENOENT` and `ECONNREFUSED` are the socket gone and the
+/// socket unserved; `ENOTSOCK` is a plain file where the socket was, which is
+/// no daemon either. Everything else is a daemon this process could not reach
+/// rather than one that left — `EPERM` from a sandbox, `EAGAIN` from a listener
+/// whose backlog is full, `EINTR`, `ETIMEDOUT` — and reading any of those as
+/// absence is how a stop reports success over a daemon still holding every
+/// session it had.
+pub(crate) fn nothing_is_serving(errno: Option<i32>) -> bool {
+    matches!(
+        errno,
+        Some(libc::ENOENT) | Some(libc::ECONNREFUSED) | Some(libc::ENOTSOCK)
+    )
+}
+
+/// Whether `pid` is still the process behind `socket`, within `budget`.
+///
+/// Anything short of proof that the path is unserved keeps waiting, and the
+/// deadline decides — including a probe that ran out of budget, and a daemon
+/// that answers but whose pid the kernel will not name.
 async fn still_serving(socket: &Path, pid: i32, budget: Duration) -> bool {
     match tokio::time::timeout(budget, UnixStream::connect(socket)).await {
         Ok(Ok(stream)) => peer_pid(&stream).is_none_or(|serving| serving == pid),
-        Ok(Err(error)) => !crate::client::absent_daemon(error.raw_os_error()),
+        Ok(Err(error)) => !nothing_is_serving(error.raw_os_error()),
         Err(_elapsed) => true,
     }
 }
@@ -1280,6 +1297,12 @@ mod tests {
         // Nothing at the path at all: ENOENT.
         let missing = dir.join("missing.sock");
         assert!(!still_serving(&missing, ours, PROBE).await);
+
+        // A plain file where the socket was: no daemon, and one that cannot be
+        // autostarted over either — which is why the two rules differ.
+        let occupied = dir.join("occupied.sock");
+        std::fs::write(&occupied, b"not a socket").expect("occupying file");
+        assert!(!still_serving(&occupied, ours, PROBE).await);
 
         // Someone is serving it. The same pid means the daemon is still there
         // — mid-drain, which is what the settle budget is for — and a different

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -583,6 +583,9 @@ async fn connect_if_serving(socket: &Path) -> Result<Option<UnixStream>> {
 /// whose backlog is full, `EINTR`, `ETIMEDOUT` — and reading any of those as
 /// absence is how a stop reports success over a daemon still holding every
 /// session it had.
+///
+/// This licenses a conclusion, never an action on the path — see
+/// [`crate::client::absent_daemon`] for the narrower rule that does.
 pub(crate) fn nothing_is_serving(errno: Option<i32>) -> bool {
     matches!(
         errno,

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -36,6 +36,12 @@ pub const BUILD_VERSION: &str = env!("TERMIOD_VERSION");
 /// after `SIGTERM` has to bury every session first.
 const SETTLE: Duration = Duration::from_secs(15);
 
+/// How long one liveness probe may take. A connect to a Unix socket on the same
+/// machine either completes at once or is queued behind a listener that is not
+/// accepting; a probe that outlives this has learned what it is going to learn,
+/// and the settle budget belongs to the next one.
+const PROBE: Duration = Duration::from_secs(1);
+
 /// Exit code for a stop the daemon declined because it holds work someone is
 /// using. Distinct from failure: the state is named, and running again after
 /// the sessions close is the whole recovery.
@@ -452,7 +458,7 @@ pub struct StopOutcome {
 /// it is success rather than an error.
 pub async fn stop(force: bool) -> Result<StopOutcome> {
     let socket = paths::socket_path()?;
-    let Some(mut stream) = connect_existing(&socket).await else {
+    let Some(mut stream) = connect_if_serving(&socket).await? else {
         return Ok(StopOutcome {
             stopped: true,
             busy: Vec::new(),
@@ -514,14 +520,8 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
     // stop that had already worked into a failed upgrade (#571).
     let deadline = Instant::now() + SETTLE;
     loop {
-        if !still_serving(&socket, pid).await {
-            return Ok(StopOutcome {
-                stopped: true,
-                busy: Vec::new(),
-                message: format!("stopped pid {pid}"),
-            });
-        }
-        if Instant::now() >= deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             bail!(
                 "pid {pid} was asked to stop and is still serving {} after {}s; \
                  its log says what it is waiting on",
@@ -529,7 +529,14 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
                 SETTLE.as_secs()
             );
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        if !still_serving(&socket, pid, remaining.min(PROBE)).await {
+            return Ok(StopOutcome {
+                stopped: true,
+                busy: Vec::new(),
+                message: format!("stopped pid {pid}"),
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(100).min(remaining)).await;
     }
 }
 
@@ -542,13 +549,41 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
 /// socket go — which is the postcondition, whatever became of its process
 /// table entry afterwards.
 ///
-/// A daemon that answers but whose pid the kernel will not name is not evidence
-/// that it left, so that case keeps waiting rather than claiming success.
-async fn still_serving(socket: &Path, pid: i32) -> bool {
-    let Some(stream) = connect_existing(socket).await else {
-        return false;
-    };
-    peer_pid(&stream).is_none_or(|serving| serving == pid)
+/// Connect to a daemon that may not be there.
+///
+/// `Ok(None)` is the one answer that proves nothing is: a connection this
+/// process was denied, or one that never completed, is a daemon it could not
+/// reach. Reporting that as "no daemon is running" would answer a stop that
+/// never happened with success, and the caller would go on to replace a binary
+/// under a daemon still serving every session it had.
+async fn connect_if_serving(socket: &Path) -> Result<Option<UnixStream>> {
+    match tokio::time::timeout(Duration::from_secs(5), UnixStream::connect(socket)).await {
+        Ok(Ok(stream)) => Ok(Some(stream)),
+        Ok(Err(error)) if crate::client::absent_daemon(error.raw_os_error()) => Ok(None),
+        Ok(Err(error)) => Err(anyhow::Error::new(error)
+            .context(format!("reaching the daemon at {}", socket.display()))),
+        Err(_elapsed) => bail!(
+            "the daemon at {} did not accept a connection within 5s",
+            socket.display()
+        ),
+    }
+}
+
+/// Only two errnos prove nothing is behind the path, and they are the two
+/// [`absent_daemon`] already names for the client that is about to autostart
+/// one. Everything else is a daemon this process cannot reach rather than one
+/// that left: `EPERM` from a sandbox, or a connect that ran out of budget
+/// against a listener whose backlog is full. Reading either as "stopped" would
+/// hand the upgrade a daemon still holding every session it had, which is worse
+/// than the wait it replaced — so they keep waiting, and the deadline decides.
+/// A daemon that answers but whose pid the kernel will not name is treated the
+/// same way.
+async fn still_serving(socket: &Path, pid: i32, budget: Duration) -> bool {
+    match tokio::time::timeout(budget, UnixStream::connect(socket)).await {
+        Ok(Ok(stream)) => peer_pid(&stream).is_none_or(|serving| serving == pid),
+        Ok(Err(error)) => !crate::client::absent_daemon(error.raw_os_error()),
+        Err(_elapsed) => true,
+    }
 }
 
 // MARK: Node side — `termiod handoff`
@@ -1223,6 +1258,49 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
     use std::collections::VecDeque;
+
+    /// Which answers a liveness probe is allowed to end the wait on. An
+    /// unserved path is the daemon having let it go; a path this process merely
+    /// could not reach is not, and ending a stop on that would report an
+    /// upgrade over a daemon still holding every session it had.
+    ///
+    /// The other unserved shape — a socket file the daemon could not unlink on
+    /// the way out, which answers `ECONNREFUSED` — is the one #571 was reported
+    /// on, and `stop_succeeds_when_the_daemon_left_its_socket_and_its_pid_behind`
+    /// covers it end to end against a real daemon.
+    #[tokio::test]
+    async fn only_an_unserved_socket_ends_the_wait() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let ours = std::process::id() as i32;
+        let dir = std::path::PathBuf::from(format!("/tmp/tss-{ours}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir(&dir).expect("test directory");
+
+        // Nothing at the path at all: ENOENT.
+        let missing = dir.join("missing.sock");
+        assert!(!still_serving(&missing, ours, PROBE).await);
+
+        // Someone is serving it. The same pid means the daemon is still there
+        // — mid-drain, which is what the settle budget is for — and a different
+        // pid means it went and something else took the path over.
+        let live = dir.join("live.sock");
+        let listener = tokio::net::UnixListener::bind(&live).expect("bind");
+        assert!(still_serving(&live, ours, PROBE).await);
+        assert!(!still_serving(&live, ours + 1, PROBE).await);
+        drop(listener);
+
+        // Denied, not absent. The daemon may be serving perfectly well behind a
+        // sandbox this process cannot cross, so the wait continues.
+        let denied = dir.join("denied.sock");
+        let listener = tokio::net::UnixListener::bind(&denied).expect("bind");
+        std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o000))
+            .expect("deny the socket");
+        assert!(still_serving(&denied, ours + 1, PROBE).await);
+        drop(listener);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn versions_order_by_release_then_build() {

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -505,12 +505,16 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
             std::io::Error::last_os_error()
         );
     }
-    // The daemon removes its socket last, after burying every session, so the
-    // socket going away is the drain having finished — not merely begun.
+    // What was asked for is that `pid` stop serving this socket, and that is
+    // what is waited on. The two proxies this loop used to read instead each
+    // answer a different question: `kill(pid, 0)` succeeds for a *zombie*, so a
+    // daemon nobody reaped reads as one that refuses to leave, and the socket
+    // file existing says only that a path is occupied — a client autostarting
+    // its replacement re-creates it in milliseconds. Together they turned a
+    // stop that had already worked into a failed upgrade (#571).
     let deadline = Instant::now() + SETTLE;
     loop {
-        let process_gone = unsafe { libc::kill(pid, 0) } != 0;
-        if process_gone || !socket.exists() {
+        if !still_serving(&socket, pid).await {
             return Ok(StopOutcome {
                 stopped: true,
                 busy: Vec::new(),
@@ -518,10 +522,33 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
             });
         }
         if Instant::now() >= deadline {
-            bail!("pid {pid} was asked to stop and is still holding {} after {}s", socket.display(), SETTLE.as_secs());
+            bail!(
+                "pid {pid} was asked to stop and is still serving {} after {}s; \
+                 its log says what it is waiting on",
+                socket.display(),
+                SETTLE.as_secs()
+            );
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+/// Whether `pid` is still the process behind `socket`.
+///
+/// The daemon holds its listener bound through the whole drain, on purpose, so
+/// that nothing can place a replacement over state still being buried: while it
+/// answers here it really is still working, and waiting is right. Nothing
+/// answering, or a different pid answering, both mean this daemon let the
+/// socket go — which is the postcondition, whatever became of its process
+/// table entry afterwards.
+///
+/// A daemon that answers but whose pid the kernel will not name is not evidence
+/// that it left, so that case keeps waiting rather than claiming success.
+async fn still_serving(socket: &Path, pid: i32) -> bool {
+    let Some(stream) = connect_existing(socket).await else {
+        return false;
+    };
+    peer_pid(&stream).is_none_or(|serving| serving == pid)
 }
 
 // MARK: Node side — `termiod handoff`

--- a/termiod/tests/lifecycle.rs
+++ b/termiod/tests/lifecycle.rs
@@ -4,6 +4,7 @@
 
 use serde_json::Value;
 use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -153,6 +154,45 @@ fn stop_takes_an_idle_daemon_down() {
     let again = termiod(&socket, &["stop", "--json"]);
     assert!(again.status.success());
     assert_eq!(json(&again)["stopped"], true);
+}
+
+/// The stop that #571 reported as a failure: the daemon left, but its socket
+/// file stayed on disk and its process table entry stayed with it.
+///
+/// Both halves are reproduced without any timing to lose. The directory is
+/// made unwritable so the daemon's own `remove_file` fails on the way out,
+/// leaving the same file-still-there state a client autostarting a replacement
+/// produces. And the daemon is this test's child, never waited on before the
+/// stop runs — the shape of every client that autostarts a daemon and outlives
+/// it, and the reason `kill(pid, 0)` kept answering for a process that had
+/// already exited.
+///
+/// `--force` only skips the roster round trip, which the sealed directory would
+/// break; the wait this is about is the same in both paths.
+#[test]
+fn stop_succeeds_when_the_daemon_left_its_socket_and_its_pid_behind() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("d.sock");
+    let mut daemon = Daemon::start(&socket);
+
+    // Owner without write permission cannot unlink from its own directory.
+    let sealed = std::fs::Permissions::from_mode(0o500);
+    std::fs::set_permissions(&dir.0, sealed).expect("seal the daemon's directory");
+
+    let stopped = termiod(&socket, &["stop", "--force", "--json"]);
+    std::fs::set_permissions(&dir.0, std::fs::Permissions::from_mode(0o700))
+        .expect("unseal the daemon's directory");
+
+    assert!(stopped.status.success(), "{}", String::from_utf8_lossy(&stopped.stderr));
+    assert_eq!(json(&stopped)["stopped"], true);
+    // The two states that used to be read as "still running", asserted so the
+    // test fails if it stops reproducing them rather than passing vacuously.
+    assert!(socket.exists(), "the daemon removed the socket; this no longer reproduces #571");
+    assert!(
+        unsafe { libc::kill(daemon.child.id() as i32, 0) } == 0,
+        "the daemon's pid was already reaped; this no longer reproduces #571"
+    );
+    assert!(daemon.wait_exit(), "daemon still running after stop");
 }
 
 /// A session whose agent reports `working` keeps the daemon up, and the

--- a/termiod/tests/lifecycle.rs
+++ b/termiod/tests/lifecycle.rs
@@ -195,6 +195,40 @@ fn stop_succeeds_when_the_daemon_left_its_socket_and_its_pid_behind() {
     assert!(daemon.wait_exit(), "daemon still running after stop");
 }
 
+/// A daemon this process cannot reach is not a daemon that stopped.
+///
+/// The socket is denied rather than removed, which is what a sandbox does — and
+/// what the fix for #571 must not mistake for absence, since answering a stop
+/// with success here would let an upgrade replace the binary under a daemon
+/// still serving every session it holds. The daemon must survive, and the
+/// refusal must say the connection was denied.
+#[test]
+fn stop_refuses_to_call_an_unreachable_daemon_stopped() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("d.sock");
+    let mut daemon = Daemon::start(&socket);
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o000))
+        .expect("deny the socket");
+
+    let refused = termiod(&socket, &["stop", "--json"]);
+    assert!(!refused.status.success(), "an unreachable daemon was reported stopped");
+    let complaint = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        complaint.contains("reaching the daemon"),
+        "the refusal does not name what went wrong: {complaint}"
+    );
+    assert!(
+        daemon.child.try_wait().expect("poll").is_none(),
+        "the daemon exited on a stop that never reached it"
+    );
+
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))
+        .expect("restore the socket");
+    let stopped = termiod(&socket, &["stop", "--json"]);
+    assert!(stopped.status.success(), "{}", String::from_utf8_lossy(&stopped.stderr));
+    assert!(daemon.wait_exit(), "daemon still running after stop");
+}
+
 /// A session whose agent reports `working` keeps the daemon up, and the
 /// refusal names it: the decision is the user's, and a count cannot inform
 /// it. `--force` overrides.

--- a/termiod/tests/lifecycle.rs
+++ b/termiod/tests/lifecycle.rs
@@ -240,6 +240,37 @@ fn serve_refuses_to_replace_a_file_it_did_not_create() {
     );
 }
 
+/// The other half of the same rule: a socket the daemon really did leave behind
+/// is still cleaned up. A kill -9 runs no shutdown, so the file survives with
+/// nothing serving it, and the next start must replace it rather than refuse —
+/// otherwise one crash would leave the machine unable to start a daemon at all.
+#[test]
+fn serve_replaces_a_socket_its_daemon_died_holding() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("d.sock");
+    let mut dead = Daemon::start(&socket);
+    let killed = dead.child.kill().and_then(|()| dead.child.wait());
+    assert!(killed.is_ok(), "could not kill the first daemon");
+    assert!(socket.exists(), "kill -9 should leave the socket file behind");
+
+    // Not `Daemon::start`'s wait: that watches for the socket file, which the
+    // dead daemon already left. Serving is the thing being asserted, so serving
+    // is what this waits for.
+    let _replacement = Daemon::start(&socket);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let running = loop {
+        let status = termiod(&socket, &["status", "--json"]);
+        if status.status.success() && json(&status)["daemon"]["running"] == true {
+            break true;
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert!(running, "no daemon came up over the socket its predecessor died holding");
+}
+
 /// A daemon this process cannot reach is not a daemon that stopped.
 ///
 /// The socket is denied rather than removed, which is what a sandbox does — and

--- a/termiod/tests/lifecycle.rs
+++ b/termiod/tests/lifecycle.rs
@@ -195,6 +195,51 @@ fn stop_succeeds_when_the_daemon_left_its_socket_and_its_pid_behind() {
     assert!(daemon.wait_exit(), "daemon still running after stop");
 }
 
+/// `serve` never deletes a file it did not create.
+///
+/// A plain file where the socket should be proves no daemon is serving — which
+/// is enough for a stop to conclude it stopped, and deliberately not enough to
+/// unlink the file and bind over its name. `TERMIOD_SOCK` can name anywhere,
+/// so the file that would be destroyed is whatever the user pointed it at.
+#[test]
+fn serve_refuses_to_replace_a_file_it_did_not_create() {
+    let dir = TestDir::new();
+    let occupied = dir.0.join("d.sock");
+    std::fs::write(&occupied, b"someone else's file").expect("occupy the socket path");
+
+    // Spawned rather than run to completion: a `serve` that wrongly accepts the
+    // path does not exit, and a test that proves a regression by hanging is not
+    // a test. It gets a bounded window to refuse, and is killed if it does not.
+    let mut child = Command::new(BIN)
+        .arg("serve")
+        .env("TERMIOD_SOCK", &occupied)
+        .env("TERMIOD_KEEP_AWAKE", "off")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("run termiod serve");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let refused = loop {
+        match child.try_wait().expect("poll serve") {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    };
+
+    let refused = refused.expect("serve bound over a file that was not its socket");
+    assert!(!refused.success(), "serve accepted a socket path that held a plain file");
+    assert_eq!(
+        std::fs::read(&occupied).expect("the file must still be there"),
+        b"someone else's file",
+        "serve destroyed a file it did not create"
+    );
+}
+
 /// A daemon this process cannot reach is not a daemon that stopped.
 ///
 /// The socket is denied rather than removed, which is what a sandbox does — and


### PR DESCRIPTION
Fixes #571 — a remote Mac reports `pid N was asked to stop and is still holding termiod.sock after 15s`, and `Cmd+T` fails on a machine whose daemon is fine.

`lifecycle::stop` decided the daemon had gone by two proxies, and each answers a different question than the one asked:

- **`kill(pid, 0)` succeeds for a zombie.** A daemon nobody reaps becomes one the instant it exits, and every client that autostarts a daemon and outlives it left that shape — the app, and the long-lived `termiod stdio` an SSH attach runs on the far end. Supervised Linux hosts never saw this: `spawn_daemon` delegates to systemd there, so systemd is the parent and reaps.
- **The socket file existing says a path is occupied, not who owns it.** The next client contact autostarts a replacement that re-creates it in milliseconds.

Both hold for the full 15s, so a stop that had already succeeded aborted the upgrade behind it.

Now `stop` waits on the postcondition it actually wants — is `pid` still the process behind this socket — by asking the socket. Nobody answering, or a different pid answering, both mean this daemon let it go. The daemon keeps its listener bound through the whole drain on purpose, so while it answers there it genuinely is still working and waiting is correct.

The zombie is removed too, rather than only tolerated: the autostarted daemon forks once more so its parent is pid 1, the parentage supervised hosts always had, and the app collects the exit status when it comes — `POSIX_SPAWN_SETSID` detaches the session, not the parentage.

### One rule per question

Three call sites ask about a failed connect, and they do not all license the same thing:

- `lifecycle::nothing_is_serving` — `ENOENT | ECONNREFUSED | ENOTSOCK`. Licenses a **conclusion**: a stop reading whether the daemon let the socket go.
- `client::absent_daemon` — `ENOENT | ECONNREFUSED`. Licenses **acting on the path**: autostarting over it, and the daemon's own unlink-then-rebind. One errno narrower, because proof that nothing serves a path is not permission to destroy what is on it.

Everything else — `EPERM` from a sandbox, `EAGAIN` from a full backlog, a probe out of budget — keeps waiting and lets the deadline decide. `stop`'s entry path made the same false-absence inference before any SIGTERM and now refuses instead of answering "no daemon is running" to a question it never got to ask. Each probe is bounded by what is left of the settle budget, so the deadline the error names is the one it keeps.

### Verification

Every test below was checked against the pre-fix code and fails there:

- `stop_succeeds_when_the_daemon_left_its_socket_and_its_pid_behind` reproduces both halves of #571 with no timing to lose — the state directory is sealed so the daemon's own `remove_file` fails, and the daemon is the test's unreaped child. Against the old predicate it fails with the reporter's exact message. It asserts both conditions still hold after the stop, so it cannot pass vacuously.
- `stop_refuses_to_call_an_unreachable_daemon_stopped` denies a live daemon's socket and asserts the stop fails, names why, and leaves the daemon running.
- `serve_refuses_to_replace_a_file_it_did_not_create` asserts `serve` pointed at a path holding a plain file leaves its bytes untouched. Bounded, so a regression fails rather than hangs.
- `only_an_unserved_socket_ends_the_wait` covers the probe classification: ENOENT, ENOTSOCK, same-pid-serving, different-pid-serving, EACCES-denied.

`cargo test` — 18 suites, 0 failures, run repeatedly. `swift build`, `swift test` — 959 tests, 0 failures. End to end: an autostarted daemon reports `ppid=1`, and `stop` returns `stopped: true`.

Reviewed adversarially over four rounds, which found and fixed: a false "stopped" on any probe failure, a settle deadline the loop did not enforce, `ENOTSOCK` misclassified as a live daemon, and — worst — a first attempt at sharing the predicate that would have let `serve` delete whatever file `TERMIOD_SOCK` pointed at.

### Not in this change

- macOS has no `launchd_agent_owns_daemon()` to match `systemd_unit_owns_daemon()`, so a client forks the daemon even where a launchd agent is installed.
- The agent's `KeepAlive: true` is `Restart=always`; the systemd unit is correctly `Restart=on-failure`, whose launchd spelling is `KeepAlive: {SuccessfulExit: false}`.
- `paths::serve_lock_tests::the_serve_lock_is_exclusive_and_released_on_drop` flakes under the full lib suite (~3 in 10 runs) and never in isolation. It reproduces on unmodified `main` and is unrelated to this change.

Release Notes: Fixed setting up a remote Mac failing with "termiod is still holding termiod.sock" when the daemon had in fact stopped.