### PR TITLE
Stop focus reports claiming the write token

### DIFF
--- a/Shared/Sources/TermioShared/TerminalDeviceReport.swift
+++ b/Shared/Sources/TermioShared/TerminalDeviceReport.swift
@@ -40,8 +40,13 @@ import Foundation
 ///                        another barrier. A plain shell never sets 1004, which
 ///                        is why only the agent TUIs shook.
 ///   • `ESC P > | …`      XTVERSION;  `ESC P n $ r …` DECRQSS;  `ESC P n + r …` XTGETTCAP
+///   • `ESC _ G i=… ; …`  kitty graphics replies; `ESC _ 25a1 ; …` glyph
+///                        protocol replies
 ///   • `ESC ] 4 ; …`, `ESC ] 10–19 ; …`, `ESC ] 21 …`, `ESC ] 52 ; …`
 ///                        colour, kitty colour, and clipboard query answers
+///   • `ESC ] 5522 ; type=…:status=…`
+///                        kitty clipboard replies, except a terminal-initiated
+///                        paste event, which also carries `:pw=` and is input
 ///
 /// Everything else is input: arrows and function keys end a CSI in A–Z, `~`
 /// or `u` without `?`; mouse reports carry `<`; a bare Esc is a lone byte;
@@ -68,6 +73,8 @@ public enum TerminalDeviceReport {
             return isDeviceControlReport(bytes)
         case 0x5D: // ESC ]
             return isOperatingSystemCommandReport(bytes)
+        case 0x5F: // ESC _
+            return isApplicationProgramCommandReport(bytes)
         default:
             return false
         }
@@ -116,15 +123,52 @@ public enum TerminalDeviceReport {
         while index < bytes.count, bytes[index] >= 0x30, bytes[index] <= 0x39 {
             number = number * 10 + Int(bytes[index] - 0x30)
             index += 1
-            if number > 999 { return false }
+            if number > 9999 { return false }
         }
         // The number, then the `;` every reply puts before its payload.
         guard index > 2, index < bytes.count, bytes[index] == 0x3B else { return false }
         switch number {
         case 4, 5, 10...19, 21, 52:
             return true
+        case 5522:
+            // Kitty clipboard requests omit `status`; terminal-initiated paste
+            // events deliberately look like replies but uniquely carry `:pw=`.
+            return bytes[index...].starts(with: [0x3B, 0x74, 0x79, 0x70, 0x65, 0x3D])
+                && bytes[index...].containsSlice([0x3A, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x3D])
+                && !bytes[index...].containsSlice([0x3A, 0x70, 0x77, 0x3D])
         default:
             return false
+        }
+    }
+
+    private static func isApplicationProgramCommandReport(_ bytes: [UInt8]) -> Bool {
+        // Kitty graphics replies carry an image id or image number before the
+        // payload separator; requests start with an action (`a=`) or another
+        // command field instead.
+        if bytes.count >= 5, bytes[2] == 0x47 { // G
+            return bytes[3] == 0x69 || bytes[3] == 0x49 // i I
+        }
+
+        // Glyph replies use the protocol namespace and either advertise formats
+        // or include a status field. Requests never include either response field.
+        let glyphPrefix: [UInt8] = [0x32, 0x35, 0x61, 0x31, 0x3B] // 25a1;
+        guard bytes[2...].starts(with: glyphPrefix) else { return false }
+        let payload = bytes[(2 + glyphPrefix.count)...]
+        return payload.starts(with: [0x73, 0x3B, 0x66, 0x6D, 0x74, 0x3D]) // s;fmt=
+            || payload.containsSlice([0x3B, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x3D]) // ;status=
+    }
+}
+
+private extension Collection where Element == UInt8 {
+    func containsSlice(_ needle: [UInt8]) -> Bool {
+        guard !needle.isEmpty, count >= needle.count else { return false }
+        return indices.dropLast(needle.count - 1).contains { start in
+            var index = start
+            for byte in needle {
+                guard self[index] == byte else { return false }
+                formIndex(after: &index)
+            }
+            return true
         }
     }
 }

--- a/Shared/Sources/TermioShared/TerminalDeviceReport.swift
+++ b/Shared/Sources/TermioShared/TerminalDeviceReport.swift
@@ -27,6 +27,18 @@ import Foundation
 ///                        press under that protocol is `ESC [ code ; mods u`
 ///   • `ESC [ > … m`      XTQMODKEYS report — only with `>`: SGR mouse input is
 ///                        `ESC [ < … M` / `m`
+///   • `ESC [ I` / `ESC [ O`
+///                        focus in / focus out, with no parameters. libghostty
+///                        emits one the instant it parses `CSI ? 1004 h`
+///                        (`stream_handler.zig`, `.focus_event => if (enabled)`),
+///                        and a snapshot replays that mode — so every keyframe
+///                        makes every attachment write one. Read as typing they
+///                        are the resize storm this type exists to stop: Claude
+///                        Code and Codex both enable 1004, so each barrier
+///                        keyframe handed the token to whichever surface parsed
+///                        it first, which re-asserted its own grid, which was
+///                        another barrier. A plain shell never sets 1004, which
+///                        is why only the agent TUIs shook.
 ///   • `ESC P > | …`      XTVERSION;  `ESC P n $ r …` DECRQSS;  `ESC P n + r …` XTGETTCAP
 ///   • `ESC ] 4 ; …`, `ESC ] 10–19 ; …`, `ESC ] 21 …`, `ESC ] 52 ; …`
 ///                        colour, kitty colour, and clipboard query answers
@@ -71,6 +83,10 @@ public enum TerminalDeviceReport {
                 switch byte {
                 case 0x63, 0x6E, 0x52, 0x79, 0x74: // c n R y t
                     return true
+                case 0x49, 0x4F: // I O
+                    // A focus report carries nothing between the introducer and
+                    // its final byte, and no key encodes to those three bytes.
+                    return index == 2
                 case 0x75: // u
                     return marker == 0x3F // ?
                 case 0x6D: // m

--- a/Tests/termioTests/TerminalDeviceReportTests.swift
+++ b/Tests/termioTests/TerminalDeviceReportTests.swift
@@ -28,6 +28,11 @@ final class TerminalDeviceReportTests: XCTestCase {
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[8;24;80t")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?1u")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[>4;2m")))
+        // Focus in / focus out. libghostty writes one as soon as it parses
+        // `CSI ? 1004 h`, and every keyframe replays that mode, so an observer
+        // that read these as typing took the token on every resize barrier.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[I")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[O")))
         // DCS: XTVERSION, DECRQSS, XTGETTCAP.
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P>|ghostty 1.3.2\u{1B}\\")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P1$r0 q\u{1B}\\")))
@@ -53,6 +58,10 @@ final class TerminalDeviceReportTests: XCTestCase {
         // A key press under the kitty keyboard protocol ends in `u` too, but
         // without the `?` a flags report carries.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[97;5u")))
+        // Only the bare three-byte form is a focus report; anything parameterised
+        // ending in I or O is not one libghostty emits.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[2I")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[?1O")))
         // SGR mouse press and release carry `<`, never the `>` of XTQMODKEYS.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[<0;10;20M")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[<0;10;20m")))

--- a/Tests/termioTests/TerminalDeviceReportTests.swift
+++ b/Tests/termioTests/TerminalDeviceReportTests.swift
@@ -33,6 +33,10 @@ final class TerminalDeviceReportTests: XCTestCase {
         // that read these as typing took the token on every resize barrier.
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[I")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[O")))
+        // Kitty graphics, glyph protocol, and clipboard replies.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}_Gi=4;OK\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}_25a1;q;cp=41;status=system\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]5522;type=write:status=OK\u{1B}\\")))
         // DCS: XTVERSION, DECRQSS, XTGETTCAP.
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P>|ghostty 1.3.2\u{1B}\\")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P1$r0 q\u{1B}\\")))
@@ -62,6 +66,13 @@ final class TerminalDeviceReportTests: XCTestCase {
         // ending in I or O is not one libghostty emits.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[2I")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[?1O")))
+        // APC and kitty clipboard requests remain input.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}_Ga=q,i=4;\u{1B}\\")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}_25a1;q;cp=41\u{1B}\\")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]5522;type=read;\u{1B}\\")))
+        // A terminal-initiated kitty paste deliberately looks like a read reply;
+        // its one-time password is the only reliable difference and must pass.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]5522;type=read:status=OK:loc=primary:pw=otp\u{1B}\\")))
         // SGR mouse press and release carry `<`, never the `>` of XTQMODKEYS.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[<0;10;20M")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[<0;10;20m")))

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ from the real front matter).
 | status | type | title |
 | --- | --- | --- |
 | active | backlog | [Backlog](backlog/backlog.md) |
+| active | bug | [Agent TUIs shake on the phone — focus reports claim the write token](bug/agent-tui-focus-report-resize-storm.md) |
 | active | bug | [iOS libghostty "non-functional" panel + surface-teardown crash — fix journey](bug/ios-ghostty-renderer-panic-and-teardown-uaf.md) |
 | active | design | ["Issue tracker 集成：inspector Issues tab（GitHub / Linear，per-project provider）"](design/20260726-issue-tracker-integration.md) |
 | active | design | ["Remote-access design lessons: sleep reachability, stable domains, identity, monetization"](design/20260705-remote-access-lessons.md) |
@@ -127,6 +128,7 @@ from the real front matter).
 | draft | rfc | [Installing termio's agent integration on a device](design/20260824-agent-integration-on-a-device.md) |
 | draft | rfc | [iOS as a device client](design/20260824-ios-as-device-client.md) |
 | draft | rfc | [Onboarding —— 首次启动体验设计](design/20260630-onboarding.md) |
+| draft | rfc | [PTY size is not the write token](design/20260901-pty-size-is-not-the-write-token.md) |
 | draft | rfc | [Retire the companion's second protocol — the phone attaches to a device](design/20260831-companion-second-protocol-retires.md) |
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |

--- a/docs/bug/agent-tui-focus-report-resize-storm.md
+++ b/docs/bug/agent-tui-focus-report-resize-storm.md
@@ -1,0 +1,156 @@
+---
+title: Agent TUIs shake on the phone — focus reports claim the write token
+status: active
+type: bug
+created: 2026-09-01
+updated: 2026-09-01
+related:
+  - ../design/20260901-pty-size-is-not-the-write-token.md
+  - ../design/20260730-termiod-session-protocol.md
+---
+
+# Agent TUIs shake on the phone — focus reports claim the write token
+
+> Opening Claude Code, Codex, or pi on the phone makes the screen flicker and
+> jitter as if it were being resized continuously. A plain shell never does. The
+> trigger is three bytes — `ESC [ I` — that `TerminalDeviceReport` did not
+> recognise, so a terminal-generated focus report was read as typing and took
+> the write token. The fix is in the tree; it is **not yet verified end to end**
+> (§4).
+
+**Reported:** 2026-08-31, iOS companion against a Mac with the same session open
+in a pane.
+**Symptoms:** high-frequency flicker; the screen visibly re-laying-out; garbled
+text with characters stranded in the right margin.
+
+---
+
+## 1. Measurement
+
+`log stream --predicate 'subsystem BEGINSWITH "sh.termio"'` over 30 seconds of
+shaking:
+
+| signal | count |
+| --- | --- |
+| `write token on <session> claimed` | 6135 |
+| `write token on <session> lost` | 6135 |
+| `PTY is now 39x38; this client renders 47x42` | 1904 |
+| `PTY is now 47x42; this client renders 39x38` | 1903 |
+| `daemon error: this attachment does not own the write token` | present |
+
+Sub-millisecond cadence, sustained. Both attachments live in the Mac process
+(the pane's `TermiodClient` and the companion bridge's), so one log shows both
+halves of the loop.
+
+Two distinct user-visible damages, one cause:
+
+- The oscillation itself reads as flicker.
+- Every keyframe landing while `isWriter` is mid-flip is painted at the wrong
+  width. That is §C.5 divergence: wrapped rows shift, an incrementally
+  redrawing TUI never repairs them, and the phone shows a screen with stranded
+  characters in the right margin.
+
+## 2. Mechanism
+
+Seven steps, each verified against source.
+
+1. Claude Code, Codex, and pi all enable focus reporting, `CSI ? 1004 h`.
+   pi's is explicit in `pi-tui/dist/tui-alt-screen.js`:
+   `ENABLE_BUTTON_MOTION_MOUSE = "\x1b[?1000h\x1b[?1002h\x1b[?1004h\x1b[?1006h"`.
+   A login shell never sets it — **that is why only agent TUIs shake**.
+2. The daemon's snapshot formatter runs with `with_modes(true)`
+   (`termiod/vt/src/lib.rs:287`), so every keyframe replays `?1004h`.
+3. ghostty answers a focus-reporting *enable* by writing a focus report
+   immediately, unasked — `termio/stream_handler.zig`:
+   `.focus_event => if (enabled) self.messageWriter(.{ .focused = ... })`,
+   with bytes from `terminal/focus.zig`: `.gained => "\x1B[I"`,
+   `.lost => "\x1B[O"`.
+4. `TerminalDeviceReport.isReport` did not recognise those three bytes. A CSI
+   whose final byte is `I` or `O` fell through to `default: return false`, so
+   the reply was classified as **typing**.
+5. Typing claims the write token (`TermiodClient.send`).
+6. `applyWriter` re-asserts the new writer's grid
+   (`TermiodClient.swift:1752`, `TermiodSession.swift:327`). That is a resize,
+   which is a host-side barrier, which pushes a fresh keyframe **to every
+   attachment**.
+7. Go to 3, at the other client.
+
+Nothing here is probabilistic. The loop runs as fast as the IO threads carry it.
+
+## 3. Fix
+
+`Shared/Sources/TermioShared/TerminalDeviceReport.swift:86` classifies the bare
+three-byte `ESC [ I` / `ESC [ O` as a device report:
+
+```swift
+case 0x49, 0x4F: // I O
+    // A focus report carries nothing between the introducer and
+    // its final byte, and no key encodes to those three bytes.
+    return index == 2
+```
+
+One classifier, three call sites — the Mac pane
+(`TermioStore+TerminalSurface.swift:295`), the companion bridge
+(`CompanionServer.swift:1098`), and iOS
+(`TerminalViewController.swift:763`) — so one edit covers every path.
+Parameterised forms (`ESC [ 2 I`) stay input; no key encodes to the bare form.
+`swift build` and `TerminalDeviceReportTests` pass, with assertions both ways.
+
+An audit of every other unsolicited write ghostty emits on mode-enable found no
+second gap: `?2048` in-band size reports end in `t`, `?998` visibility reports
+end in `n`, both already classified.
+
+**Residual, not fixed.** The writer still emits a spurious focus-in on every
+keyframe, because a replayed mode is indistinguishable from the host setting it.
+It no longer storms, but the agent is told the window regained focus on every
+resize. The real answer is the wrapper hook that marks generated replies at the
+write callback, in the libghostty-swift fork — `TerminalDeviceReport`'s own doc
+comment already names it.
+
+## 4. Verification status — NOT DONE
+
+Three attempts to reproduce against a patched binary all measured an unpatched
+one instead. Each was defeated by the harness, not the code:
+
+1. The phone was paired to the release app; the patch was in the dev app. Every
+   log line came from the unpatched binary.
+2. The dev channel was in direct-attach mode (`companion.directAttach = 1`,
+   `DeviceSpliceServer` on 8796, not companion on 8788) — a different code path
+   from the one the storm was measured on — and its `tunnelProvider = off`, so
+   the phone could not reach it off-LAN.
+3. Two dev builds were running from different worktrees. They share a bundle id,
+   a state dir, and a daemon, so port 8788 went to whichever launched first —
+   the unpatched one. A launch-time benchmark in another worktree kept
+   relaunching it.
+
+**Rule this earns: a dev-channel measurement is invalid until you have proved
+which binary owns the port.** Run
+`lsof -nP -iTCP -sTCP:LISTEN | grep termio`, match the pid to a bundle path with
+`ps -axo pid,args`, and only then trust a log line.
+
+A valid run needs all of:
+
+- exactly one dev app alive, and it owns 8788
+- `companion.directAttach = 0` (companion shape, matching where the storm was
+  measured)
+- the phone paired to *that* app and reachable (same LAN, or a tunnel on)
+- an agent session created in that app
+- a Mac pane left open on the same session (the storm needs two attachments)
+
+Pass condition is absolute: **zero** `write token … claimed` lines for that pid.
+
+## 5. Why one sequence could do this
+
+`TerminalDeviceReport` exists because this class of bug already happened once —
+its doc comment names "the resize storm two devices watching one session used to
+produce". The classifier was hardened, the storm returned through a sequence
+nobody had enumerated, and it will return again through the next one.
+
+A byte-grammar of "what libghostty happens to emit" has to be complete forever,
+against an upstream that keeps adding to it. It is the wrong place to be
+load-bearing — and it is load-bearing only because step 6 exists: the PTY's size
+is bound to the write token, so **every misclassification is a resize bug**.
+
+That is a design problem, not a bug, and it is argued separately in
+[PTY size is not the write token](../design/20260901-pty-size-is-not-the-write-token.md).
+This fix should land on its own without waiting for it.

--- a/docs/bug/agent-tui-focus-report-resize-storm.md
+++ b/docs/bug/agent-tui-focus-report-resize-storm.md
@@ -70,7 +70,7 @@ Seven steps, each verified against source.
    the reply was classified as **typing**.
 5. Typing claims the write token (`TermiodClient.send`).
 6. `applyWriter` re-asserts the new writer's grid
-   (`TermiodClient.swift:1752`, `TermiodSession.swift:327`). That is a resize,
+   (`TermiodClient.swift:1779`, `TermiodSession.swift:327`). That is a resize,
    which is a host-side barrier, which pushes a fresh keyframe **to every
    attachment**.
 7. Go to 3, at the other client.
@@ -79,7 +79,7 @@ Nothing here is probabilistic. The loop runs as fast as the IO threads carry it.
 
 ## 3. Fix
 
-`Shared/Sources/TermioShared/TerminalDeviceReport.swift:86` classifies the bare
+`Shared/Sources/TermioShared/TerminalDeviceReport.swift:92` classifies the bare
 three-byte `ESC [ I` / `ESC [ O` as a device report:
 
 ```swift
@@ -91,14 +91,17 @@ case 0x49, 0x4F: // I O
 
 One classifier, three call sites — the Mac pane
 (`TermioStore+TerminalSurface.swift:295`), the companion bridge
-(`CompanionServer.swift:1098`), and iOS
+(`CompanionServer.swift:1091`), and iOS
 (`TerminalViewController.swift:763`) — so one edit covers every path.
 Parameterised forms (`ESC [ 2 I`) stay input; no key encodes to the bare form.
 `swift build` and `TerminalDeviceReportTests` pass, with assertions both ways.
 
-An audit of every other unsolicited write ghostty emits on mode-enable found no
-second gap: `?2048` in-band size reports end in `t`, `?998` visibility reports
-end in `n`, both already classified.
+The mode-enable audit found no second gap: `?2048` in-band size reports end in
+`t`, `?998` visibility reports end in `n`, and both are already classified. The
+broader generated-write audit did find kitty graphics and glyph APC replies plus
+kitty clipboard `OSC 5522` status replies; they are now classified too. An
+unsolicited kitty paste event has the same status shape but carries `:pw=`; it
+stays input so an observer's Paste action is never swallowed.
 
 **Residual, not fixed.** The writer still emits a spurious focus-in on every
 keyframe, because a replayed mode is indistinguishable from the host setting it.

--- a/docs/design/20260901-pty-size-is-not-the-write-token.md
+++ b/docs/design/20260901-pty-size-is-not-the-write-token.md
@@ -43,7 +43,7 @@ A byte-grammar of "what libghostty happens to emit" has to be complete forever,
 against an upstream that keeps adding to it. It should not be load-bearing.
 
 What makes it load-bearing is one line in `applyWriter`
-(`TermiodClient.swift:1752`, `TermiodSession.swift:327`): on gaining the token,
+(`TermiodClient.swift:1761`, `TermiodSession.swift:313`): on gaining the token,
 re-assert this client's grid. Under that rule the classifier is the only thing
 standing between an unexpected byte and a full-speed resize loop. **Size is bound
 to the write token, so every misclassification is a resize bug.**
@@ -76,7 +76,7 @@ termio implements `latest`, in its most reactive form:
 
 - the write token follows input;
 - `applyWriter` re-asserts the winner's grid on every grant;
-- `applyAuthoritativeGrid` (`TermiodClient.swift:1823`,
+- `applyAuthoritativeGrid` (`TermiodClient.swift:1850`,
   `TermiodSession.swift:334`) has the writer answer any divergence by putting its
   own size back.
 

--- a/docs/design/20260901-pty-size-is-not-the-write-token.md
+++ b/docs/design/20260901-pty-size-is-not-the-write-token.md
@@ -1,0 +1,174 @@
+---
+title: PTY size is not the write token
+status: draft
+type: rfc
+created: 2026-09-01
+updated: 2026-09-01
+related:
+  - ../bug/agent-tui-focus-report-resize-storm.md
+  - 20260730-termiod-session-protocol.md
+  - 20260824-ios-as-device-client.md
+  - 20260819-unify-server-plane.md
+---
+
+# PTY size is not the write token
+
+> termio binds the PTY's size to the write token: whoever types last owns the
+> grid. That is tmux's `latest` policy, which tmux ships as an option and not as
+> the default, because it thrashes. This RFC proposes replacing it — size becomes
+> a session-level policy the daemon computes over the attachments that are
+> actually rendering, unrelated to who may type.
+
+---
+
+## 0. What prompted this
+
+A focus report read as typing put the write token into a full-speed ping-pong
+between a phone and a Mac pane, and the PTY oscillated with it: 6135 token moves
+in 30 seconds, the grid alternating 39×38 ↔ 47×42. The measurement, the seven-step
+mechanism, and the one-line classifier fix are in
+[Agent TUIs shake on the phone](../bug/agent-tui-focus-report-resize-storm.md).
+
+That fix removes the fuel. This document is about the fuel tank.
+
+## 1. Why one unclassified sequence could do that
+
+`TerminalDeviceReport` sorts a client's outgoing bytes into "the person typed"
+and "the terminal answered a query". It exists because this class of bug already
+happened once — its doc comment names "the resize storm two devices watching one
+session used to produce". It was hardened, and the storm came back through a
+sequence nobody had enumerated.
+
+A byte-grammar of "what libghostty happens to emit" has to be complete forever,
+against an upstream that keeps adding to it. It should not be load-bearing.
+
+What makes it load-bearing is one line in `applyWriter`
+(`TermiodClient.swift:1752`, `TermiodSession.swift:327`): on gaining the token,
+re-assert this client's grid. Under that rule the classifier is the only thing
+standing between an unexpected byte and a full-speed resize loop. **Size is bound
+to the write token, so every misclassification is a resize bug.**
+
+## 2. Prior art
+
+Every multiplexer hits this. The answers agree.
+
+| system | policy |
+| --- | --- |
+| tmux `window-size` | `smallest` (default) — window takes the smallest attached client; larger clients pad unused space with `·`. `largest` — biggest client wins, smaller clients see part. `latest` — the client most recently *used*, e.g. typed into. `manual` — fixed, `resize-window` only. |
+| GNU screen | smallest attached client wins; `C-a F` lets one client force the window to its own size, leaving the larger client blank space. |
+| Zellij | was smallest-wins; since 0.45.0 / [#5133](https://github.com/zellij-org/zellij/pull/5133) each **tab** is sized from only the clients *currently viewing it*. Clients on different tabs stop constraining each other; unviewed tabs keep their last size. |
+
+Two principles hold across all three.
+
+**Size is a declared session-level policy over the attachment set — never a race
+decided by who most recently produced bytes.** tmux does ship a
+most-recently-used policy, `latest`. It is an option, and it is not the default.
+
+**The mismatch is shown, not hidden.** tmux pads with `·`, screen leaves blank,
+Zellij clips. Nobody reflows per client. Per-client reflow is the only thing that
+would make both ends correct simultaneously, and for termio it is closed by
+construction: §A's anti-100× invariant rejects any per-frame grid encoder between
+the PTY and the pipe. Don't go looking for it.
+
+## 3. Where termio sits in that vocabulary
+
+termio implements `latest`, in its most reactive form:
+
+- the write token follows input;
+- `applyWriter` re-asserts the winner's grid on every grant;
+- `applyAuthoritativeGrid` (`TermiodClient.swift:1823`,
+  `TermiodSession.swift:334`) has the writer answer any divergence by putting its
+  own size back.
+
+So termio chose the one policy that oscillates, made it the only policy, and gave
+it a trigger surface as wide as "any byte a client writes".
+
+## 4. Proposal
+
+**Separate who may type from who decides the size.**
+
+Single writer, many readers (§H #6) is an *input* invariant and it is correct.
+Leave it alone. Size stops riding on it.
+
+The daemon already knows every attachment and its grid — it is the thing that
+emits `E resized`. Let it own the policy:
+
+```
+size = min(grid of attachments currently rendering the session)
+```
+
+with Zellij's refinement: only attachments *actually showing* the session count.
+termio already carries that signal on both ends — `setSurfaceVisible` on the Mac
+(a hidden pane is not rendering) and the phone having the session on screen.
+
+Consequences:
+
+- Phone opens the session → the PTY goes to 38 columns and the Mac pane renders
+  38 columns of content with the rest of its pane blank. **No tearing**, because
+  both surfaces sit at the shared grid by construction.
+- Phone leaves the session → the Mac springs back to its own width.
+- The token moves between the two ends → **the size does not move at all**. A
+  misclassified byte costs a stray keystroke, not a resize loop.
+
+This is subtraction:
+
+- `applyWriter`'s grid re-assertion — deleted, both ends.
+- `applyAuthoritativeGrid`'s writer-answers-divergence branch — deleted, both
+  ends. The observer's `observerRepaintPending` handling stays; it is about
+  keyframes, not sizing.
+- iOS `layoutTerminalSurface`'s letterbox branch
+  (`TerminalViewController.swift:268`) — deleted. Under `smallest` an observer is
+  never *narrower* than the PTY, so there is nothing to scale down; blank space
+  replaces a scaled surface.
+
+Small surface area is the point, not a side effect.
+
+## 5. Costs and open questions
+
+**The Mac gets squeezed by the phone.** This is tmux's most-complained-about
+default. Zellij's visibility filter is the best known mitigation and it is in the
+proposal, but a Mac pane left open on a session the phone is also watching will
+sit at 38 columns. Whether that is acceptable, or whether termio needs tmux's
+`window-size` as a user-facing option, is the open question. Recommendation: ship
+the correct default first; add the option only if the complaint is real.
+
+**Where the policy runs.** The daemon is the only place that sees every
+attachment, so it belongs there — which makes this a protocol change touching
+`termiod/src/session/`, `TermiodClient`, and iOS `TermiodSession`. `R` stops
+meaning "set the PTY size" and starts meaning "this attachment's viewport is now
+N×M"; the daemon derives the PTY size from the set. `E resized` is unchanged.
+
+**Attachments that render nothing.** The companion bridge is a byte forwarder
+with no surface of its own; its viewport is the phone's. That is already how it
+reports, but the protocol should say so rather than leave it implied.
+
+## 6. An adjacent behaviour this makes harmless
+
+Opening a session on the phone forces a Mac-side surface into existence.
+`companionAttachment` (`CompanionServer.swift:1206`) ends with:
+
+```swift
+if let project = project(for: session.id) { noteProjectActivity(project.id, force: true) }
+_ = surface(for: session)
+```
+
+Surfacing is deliberate and documented — it is what spawns the agent with its
+recorded resume arguments, so the phone gets the conversation instead of "no
+terminal". The side effect is that **the phone can never be the only viewer**: a
+second attachment at the Mac window's grid always appears.
+
+Under today's `latest` that is a guaranteed size fight, and it is why the phone
+tears even when the user only opened the session there. Under §4 it is
+uninteresting: the Mac becomes one more attachment, larger, padded. The line
+stays as it is. Recorded so the next reader does not mistake it for the bug.
+
+## 7. Proposed sequence
+
+1. Land the classifier fix on its own. It is a misclassification bug with a unit
+   test, independent of everything here. Do not hold it for this design work.
+2. Verify it against a binary whose pid owns the port — the harness rules are in
+   the bug doc, §4.
+3. Decide this RFC. It is a protocol change and wants sign-off before code.
+4. Revisit the residual (generated-reply marking in the libghostty-swift fork)
+   afterwards. Once §4 lands it is a correctness nicety, not a load-bearing
+   guard.


### PR DESCRIPTION
Opening Claude Code, Codex or pi on the phone made the screen flicker and jitter as if it were being resized continuously. A plain shell never did.

Measured over 30 seconds of shaking, with the phone on the companion wire and the same session open in a Mac pane:

| signal | count |
| --- | --- |
| `write token … claimed` | 6135 |
| `write token … lost` | 6135 |
| `PTY is now 39x38; this client renders 47x42` | 1904 |
| `PTY is now 47x42; this client renders 39x38` | 1903 |

The loop, verified against source at every step:

1. Those three agents enable focus reporting, `CSI ?1004h`. A login shell never does.
2. The snapshot formatter runs with `with_modes(true)`, so every keyframe replays `?1004h`.
3. libghostty answers a focus-reporting *enable* by writing a focus report immediately — `stream_handler.zig`, `.focus_event => if (enabled) …`, bytes `ESC[I` / `ESC[O`.
4. `TerminalDeviceReport.isReport` did not recognise them: a CSI ending in `I` or `O` fell to `default: return false`, so the reply counted as typing.
5. Typing claims the write token.
6. `applyWriter` re-asserts the winner's grid — a resize, which is a host-side barrier, which pushes a keyframe to every attachment.
7. Back to 3, at the other client.

This classifies the bare `ESC [ I` / `ESC [ O` as device reports. One classifier, three call sites (Mac pane, companion bridge, iOS), so one edit covers every path. No key encodes to those three bytes; parameterised forms such as `ESC [ 2 I` stay input. An audit of the other unsolicited writes on mode-enable found no second gap — `?2048` size reports end in `t`, `?998` visibility reports end in `n`, both already classified.

### Still outstanding

End-to-end verification. Three attempts each measured an unpatched binary instead of the patched one; `docs/bug/agent-tui-focus-report-resize-storm.md` §4 records why and gives the harness rules and the pass condition. The unit tests and the source chain are what stand behind this today.

### Docs

- `docs/bug/agent-tui-focus-report-resize-storm.md` — the measurement, the mechanism, the fix, the verification status.
- `docs/design/20260901-pty-size-is-not-the-write-token.md` (draft RFC, no code) — why one unclassified sequence could do this at all. The PTY's size is bound to the write token, which is tmux's `latest` policy; tmux ships it as an option and not as the default because it thrashes. Proposes the daemon compute size over the attachments that are actually rendering, so a misclassified byte costs a stray keystroke instead of a resize loop.

Release Notes: Fixed agent sessions flickering and resizing continuously when open on both the phone and the Mac.