### PR TITLE
Trace the launch from process start to idle

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -14,6 +14,9 @@ import TermioShared
 enum Termio {
     @MainActor
     static func main() {
+        // First line of Swift in the process: stamps the launch timeline, whose
+        // zero is `exec` (see `LaunchTrace`).
+        LaunchTrace.mark("main")
         let application = NSApplication.shared
         let delegate = AppDelegate()
         application.delegate = delegate
@@ -139,6 +142,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var paneDragRearrange: PaneDragRearrange?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        LaunchTrace.mark("delegate ready")
         // Dev-only: `TERMIO_TERMINAL_DEBUG=1` turns on the GhosttyTerminal
         // wrapper's own lifecycle + metrics diagnostics, printed to stdout.
         if AppChannel.isDev,
@@ -152,10 +156,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Sweep up session processes a previous instance stranded (crash,
         // force-quit, dev rebuild's kill -9) before this run adds its own.
         StraySessionReaper.reapStrayOrphans()
-        // Ask the device the last run ended on what is running on it, before any
-        // pane mounts — the sidebar draws that answer, and a session that did not
-        // survive is a tombstone rather than a silently missing row.
         store.refreshDeviceSessions()
+        LaunchTrace.mark("store restored")
         // Task-completion notifications: the delegate must be installed before a
         // notification click can arrive, so wire it before any session runs.
         TaskNotificationCenter.shared.activate(store: store)
@@ -219,10 +221,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // representable with no connection to the title bar, so the sidebar can never
         // reach behind the traffic lights. SwiftUI still renders each pane's contents.
         window.contentViewController = makeContentSplitViewController()
+        LaunchTrace.mark("content installed")
         window.delegate = self
         window.center()
         window.setFrameAutosaveName(Self.mainWindowFrameAutosaveName)
         window.makeKeyAndOrderFront(nil)
+        LaunchTrace.mark("window front")
         applyWindowTransparency()
         applyChromeAppearance()
         updateInspectorMaxThickness()
@@ -449,6 +453,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
 
         maybePromptForSessionControl()
+        LaunchTrace.mark("launched")
+        LaunchTrace.whenLaunchSettles {}
     }
 
     /// Start whichever server the Mobile pane's Direct Attach switch selects.

--- a/Sources/termio/App/Log.swift
+++ b/Sources/termio/App/Log.swift
@@ -45,6 +45,8 @@ struct Trace: Sendable {
     static let workspace = Trace(Log.app)
     /// Asking a device what is running on it, and landing the answer.
     static let device = Trace(Log.termiod)
+    /// The launch a user watches the Dock icon through (see `LaunchTrace`).
+    static let launch = Trace(Log.app)
 
     private let logger: Logger
     private let signposter: OSSignposter
@@ -91,13 +93,88 @@ struct Trace: Sendable {
     /// Reports a span whose start was recorded elsewhere and whose two ends sit
     /// on different queues, so no interval can bracket it.
     func report(_ name: StaticString, _ detail: String = "", since started: ContinuousClock.Instant) {
+        mark(name, detail, elapsed: started.duration(to: .now))
+    }
+
+    /// Reports a point on a timeline whose zero is not a `ContinuousClock`
+    /// instant. The launch is the case that needs it: it starts at `exec`,
+    /// before any Swift runs, so its origin can only arrive as a `Duration`.
+    func mark(_ name: StaticString, _ detail: String = "", elapsed: Duration) {
         let label = "\(name)"
-        let elapsed = started.duration(to: .now)
         let milliseconds = Double(elapsed.components.seconds) * 1000
             + Double(elapsed.components.attoseconds) / 1e15
+        signposter.emitEvent(name, id: signposter.makeSignpostID())
         logger.info("""
         \(label, privacy: .public) \(detail, privacy: .public) \
         elapsed_ms=\(String(format: "%.2f", milliseconds), privacy: .public)
         """)
+    }
+}
+
+/// Launch timing, measured from when the kernel created this process rather
+/// than from `main`, so the numbers cover what a user watching the Dock icon
+/// actually waits through. Everything before `main` — dyld, the Swift runtime,
+/// static initializers — is invisible to a clock started in Swift, so the
+/// origin comes from the kernel's own `p_starttime`. That is process-creation
+/// metadata, not an `execve` timestamp: near enough to frame a launch of
+/// several hundred milliseconds, and not the tool to settle an argument about
+/// a few of them.
+///
+///     log show --last 5m --predicate 'subsystem BEGINSWITH "sh.termio" && category == "app"'
+///
+/// The marks name the phases a launch is actually spent in, so a regression
+/// says *where* rather than only *how much*.
+enum LaunchTrace {
+    /// The launch's origin, resolved once, the first time this type is touched
+    /// — which is the first line of `main`.
+    ///
+    /// `age` is how long the process had already been alive by then: dyld, the
+    /// Swift runtime, and static initializers, none of which a clock started in
+    /// Swift can see. `stamped` is the monotonic instant that reading took, and
+    /// every later mark is an offset from it.
+    ///
+    /// Both halves are resolved in one closure, adjacently, because they are
+    /// two ends of the same measurement: split across separate lazy properties,
+    /// whichever Swift happens to force second leaves the `sysctl` between them
+    /// counted in neither term.
+    private static let origin: (age: Duration, stamped: ContinuousClock.Instant) = {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, ProcessInfo.processInfo.processIdentifier]
+        guard sysctl(&mib, 4, &info, &size, nil, 0) == 0 else { return (.zero, .now) }
+        let started = Double(info.kp_proc.p_starttime.tv_sec)
+            + Double(info.kp_proc.p_starttime.tv_usec) / 1_000_000
+        let now = Date().timeIntervalSince1970
+        let stamped = ContinuousClock.now
+        // Both ends are wall clock, so a clock adjustment mid-launch could in
+        // principle land this negative; report zero rather than a lie.
+        return (.seconds(max(0, now - started)), stamped)
+    }()
+
+    /// Records `name` as a point on the launch timeline. Cheap enough to leave
+    /// in: one `os_log` line and one signpost event per phase, seven in all.
+    static func mark(_ name: StaticString, _ detail: String = "") {
+        Trace.launch.mark(name, detail, elapsed: origin.age + origin.stamped.duration(to: .now))
+    }
+
+    /// Runs `work` the first time the run loop is about to sleep, and marks
+    /// that instant as the end of the launch.
+    ///
+    /// Ordering the window front does not end a launch: AppKit still owes the
+    /// window layout and a commit, and the observers wired up here keep
+    /// answering for a good while after the first frame reaches the screen.
+    /// The first `beforeWaiting` is the first moment nothing is owed — the
+    /// real end of the launch, and the only safe place to start work that
+    /// would otherwise re-render everything before the user has seen it once.
+    @MainActor static func whenLaunchSettles(_ work: @escaping @MainActor () -> Void) {
+        let observer = CFRunLoopObserverCreateWithHandler(
+            nil, CFRunLoopActivity.beforeWaiting.rawValue, false, 0
+        ) { _, _ in
+            MainActor.assumeIsolated {
+                mark("idle")
+                work()
+            }
+        }
+        CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
     }
 }


### PR DESCRIPTION
The launch had no number. Every claim about it was a guess, and the run-to-run
spread is wider than most of the changes worth arguing about, so a guess could
not be checked.

`LaunchTrace` marks the phases a launch is actually spent in — `main`,
`delegate ready`, `store restored`, `content installed`, `window front`,
`launched`, `idle` — as `os_signpost` events plus `elapsed_ms` lines, the shape
`Trace` already uses for the workspace and device paths:

```
log show --last 5m --info \
  --predicate 'subsystem BEGINSWITH "sh.termio" AND category == "app"'
```

Its origin is the kernel's `p_starttime` rather than the first line of Swift,
because dyld and the Swift runtime both run before any clock a program can
start. That is process-creation metadata, not an `execve` timestamp — near
enough to frame a launch of several hundred milliseconds, and not the tool to
settle an argument about a few of them.

`idle` is the first `beforeWaiting` after the window is up. It marks the end of
the launch, not the first frame: the window reaches the screen well before it.

## What it already found

Dev channel, warm, 8 projects / 17 sessions, median of 12:

| phase | at | delta |
|---|---|---|
| `main` | 17 | — |
| `delegate ready` | 106 | +89 |
| `store restored` | 157 | +51 |
| `content installed` | 221 | +63 |
| `window front` | 426 | +205 |
| `launched` | 447 | +21 |
| `idle` | 1917 | +1471 |

- **Pre-main is 17ms.** Dyld is not where this launch goes, which retires
  making frameworks lazy as a line of work rather than leaving it on a list.
- **The run loop does not settle until ~1.4s** — roughly a second after the
  window is on screen. Largest number in the launch, and invisible to any
  time-to-first-window measurement.
- **The noise floor is ±200ms.** Three plausible pre-frame optimizations
  (sidebar `sizingOptions`, restoring the window frame before installing
  content, deferring the roster ask past first paint) measured a median paired
  delta of +3ms over 28 interleaved pairs, faster in 15 of 28. Measured
  unpaired, half an hour apart, the same three read as a 190ms win. They are
  not in this PR.

## Release Notes:

No user-facing change. Adds launch timing to the unified log so a slow start
can be attributed to a phase rather than guessed at.