### PR TITLE
Add space above fullscreen content

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -72,8 +72,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var pendingOpenURLs: [URL] = []
     // The split controller (sidebar + terminal + inspector). The navigator toggle reaches its
     // `toggleSidebar(_:)` through the responder chain, so this is just a weak handle on the
-    // window's content view controller.
+    // window content controller's child.
     private weak var splitViewController: NSSplitViewController?
+    // The split normally meets the window edge, but fullscreen keeps a small breathing room above
+    // both the sidebar and terminal. Held so fullscreen transitions can adjust it without
+    // rebuilding panes or their terminal surfaces.
+    private var splitTopInsetConstraint: NSLayoutConstraint?
     // The trailing file-browser inspector item, retained so the toolbar button and the
     // View menu can collapse/expand it. Starts collapsed (see `makeContentSplitViewController`).
     private var filesInspectorItem: NSSplitViewItem?
@@ -233,6 +237,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // The autosaved frame can restore straight into fullscreen, so seed the mirror rather
         // than waiting for a transition that already happened.
         store.windowIsFullScreen = window.styleMask.contains(.fullScreen)
+        updateSplitTopInset()
         installToolbar()
         // Empty the sidebar's toolbar region (sort + new-terminal) whenever the navigator collapses
         // and restore it when it reopens — the sidebar's own buttons ride with the sidebar, the way
@@ -567,7 +572,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// lights and the title-bar tracking separator. The panes no longer bridge their toolbars —
     /// the window owns a real `NSToolbar` (see `installToolbar`) so it can carry the native
     /// `.toggleSidebar` item. The standard `toggleSidebar(_:)` responder action collapses the item.
-    private func makeContentSplitViewController() -> NSSplitViewController {
+    private func makeContentSplitViewController() -> NSViewController {
         let sidebar = NSHostingController(rootView: SidebarView()
             .environmentObject(store)
             .environmentObject(settings))
@@ -637,7 +642,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         splitViewController.addSplitViewItem(inspectorItem)
         splitViewController.splitView.autosaveName = "TermioContentSplit"
         self.splitViewController = splitViewController
-        return splitViewController
+
+        let container = NSViewController()
+        container.addChild(splitViewController)
+        let splitView = splitViewController.view
+        splitView.translatesAutoresizingMaskIntoConstraints = false
+        container.view.addSubview(splitView)
+        let topInset = splitView.topAnchor.constraint(equalTo: container.view.topAnchor)
+        NSLayoutConstraint.activate([
+            splitView.leadingAnchor.constraint(equalTo: container.view.leadingAnchor),
+            splitView.trailingAnchor.constraint(equalTo: container.view.trailingAnchor),
+            splitView.bottomAnchor.constraint(equalTo: container.view.bottomAnchor),
+            topInset,
+        ])
+        splitTopInsetConstraint = topInset
+        return container
     }
 
     /// Keeps the native window title in step with the selected session's working directory.
@@ -759,6 +778,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// `windowDidEnterFullScreen` corrects it.
     func windowWillEnterFullScreen(_ notification: Notification) {
         window?.titlebarAppearsTransparent = false
+        updateSplitTopInset(fullScreen: true)
         // Flip before the animation, so a maximized detail's header drops its traffic-light gap
         // as the window grows rather than snapping inward once it lands.
         store.windowIsFullScreen = true
@@ -767,6 +787,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// The twin of `windowWillEnterFullScreen` for the maximized detail's header: the buttons come
     /// back with the window, so the gap that clears them is restored before the animation ends.
     func windowWillExitFullScreen(_ notification: Notification) {
+        updateSplitTopInset(fullScreen: false)
         store.windowIsFullScreen = false
     }
 
@@ -777,14 +798,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func windowDidEnterFullScreen(_ notification: Notification) {
         applyChromeAppearance()
         applyWindowTransparency()
+        updateSplitTopInset(fullScreen: true)
         store.windowIsFullScreen = true
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
         applyChromeAppearance()
         applyWindowTransparency()
+        updateSplitTopInset(fullScreen: false)
         updateInspectorMaxThickness()
         store.windowIsFullScreen = false
+    }
+
+    /// Fullscreen's hidden toolbar otherwise lets the split touch the screen's top edge. The same
+    /// inset applies to every split item, keeping the sidebar and terminal visually aligned.
+    private func updateSplitTopInset(fullScreen: Bool? = nil) {
+        guard let splitTopInsetConstraint else { return }
+        let isFullScreen = fullScreen ?? window?.styleMask.contains(.fullScreen) == true
+        splitTopInsetConstraint.constant = isFullScreen ? 8 : 0
     }
 
     /// View ▸ Toggle Full Screen (⌃⌘F).

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -85,7 +85,7 @@ private struct SidebarSectionHeader: View {
         // Generous top padding is the separator between sections — whitespace, not a
         // rule — so each group reads as its own block without a hairline. The first
         // section has no group above it to separate from, so it stays tight.
-        .padding(.top, isFirstSection ? 2 : 12)
+        .padding(.top, isFirstSection ? 0 : 12)
         .padding(.bottom, 2)
         // No `listRowInsets` override — the header keeps the rows' default inset so both
         // share one left baseline. The small leading then lands the label's left edge on
@@ -320,6 +320,7 @@ struct SidebarView: View {
         // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
         // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
         .listStyle(.sidebar)
+        .contentMargins(.vertical, 12, for: .scrollContent)
         .environment(\.defaultMinListRowHeight, 1)
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
     }


### PR DESCRIPTION
Adds a small top inset to the fullscreen split so the sidebar and terminal no longer meet the top edge. Also balances the sidebar list’s vertical margins.

Verified with `swift build` and `swift test`.

Release Notes:
- Add breathing room above the sidebar and terminal in fullscreen.