### PR TITLE
Serve the docs to agents by content negotiation

### DIFF
--- a/web/landing/src/app/docs-md/[...slug]/route.ts
+++ b/web/landing/src/app/docs-md/[...slug]/route.ts
@@ -2,8 +2,10 @@ import { source } from "@/lib/source";
 import { i18n, isDocsLanguage } from "@/lib/i18n";
 
 // Serves a doc page's raw Markdown. Reached as /docs/<slug>.md — and
-// /<locale>/docs/<slug>.md — via the rewrites in next.config.ts; a route handler
-// can't sit beside the docs page.tsx, so the real path is /docs-md/[<locale>/]<slug>.
+// /<locale>/docs/<slug>.md — via the rewrites in next.config.ts, and at the plain
+// page URL for a client that asked for Markdown in its Accept header (src/proxy.ts).
+// A route handler can't sit beside the docs page.tsx, so the real path is
+// /docs-md/[<locale>/]<slug>.
 // The docs index answers to /docs/index.md.
 // Every page prerenders at build time: getText("raw") reads the content/docs
 // sources from disk, which aren't in the serverless bundle at request time.

--- a/web/landing/src/app/docs-og/[...slug]/route.tsx
+++ b/web/landing/src/app/docs-og/[...slug]/route.tsx
@@ -1,0 +1,140 @@
+import { ImageResponse } from "next/og";
+import { i18n } from "@/lib/i18n";
+import { source } from "@/lib/source";
+
+// The social card for a doc page. Every docs link used to share the landing page's
+// picture, so fifteen different pages arrived in a chat as the same image; this
+// gives each one its own title, which is the only thing a reader can act on when a
+// link lands in Slack or a thread. `docPageMetadata` points og:image here.
+//
+// It is a route handler rather than the `opengraph-image` file convention because
+// the docs page is an optional catch-all, and Next refuses a metadata route under
+// one. Same reason `/docs/<slug>.md` is served from /docs-md.
+//
+// English only: the card is drawn with the default font next/og ships, which has
+// no CJK coverage, and a Chinese title would render as boxes. The translated pages
+// keep the site card until a subset font is worth carrying.
+//
+// Prerendered at build time — the docs sources aren't in the serverless bundle.
+export const dynamic = "force-static";
+export const dynamicParams = false;
+
+export const size = { width: 1200, height: 630 };
+
+export function generateStaticParams() {
+  return source
+    .getPages(i18n.defaultLanguage)
+    .map((page) => ({ slug: page.slugs.length ? page.slugs : ["index"] }));
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string[] }> },
+) {
+  const { slug } = await params;
+  const path = slug.join("/") === "index" ? [] : slug;
+  const page = source.getPage(path, i18n.defaultLanguage);
+  const title = drawable(page?.data.title ?? "Documentation");
+  const description = drawable(page?.data.description ?? "");
+  const trail = ["termio.sh", "docs", ...path].join("/");
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#08080a",
+          color: "#fafafa",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            height: 8,
+            width: "100%",
+            backgroundImage:
+              "linear-gradient(90deg, #00d3c7 0%, #0088ff 55%, #b855e7 100%)",
+          }}
+        />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            justifyContent: "space-between",
+            padding: "68px 76px 60px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            <div style={{ display: "flex", fontSize: 30, letterSpacing: -0.5 }}>
+              termio
+            </div>
+            <div
+              style={{
+                display: "flex",
+                borderRadius: 8,
+                border: "1px solid #2a2a30",
+                padding: "3px 10px",
+                fontSize: 20,
+                color: "#9b9ba4",
+              }}
+            >
+              Docs
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 74,
+                lineHeight: 1.08,
+                letterSpacing: -2,
+                maxWidth: 960,
+              }}
+            >
+              {title}
+            </div>
+            {description ? (
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 30,
+                  lineHeight: 1.4,
+                  color: "#9b9ba4",
+                  maxWidth: 900,
+                }}
+              >
+                {clamp(description, 150)}
+              </div>
+            ) : null}
+          </div>
+
+          <div style={{ display: "flex", fontSize: 24, color: "#6d6d78" }}>
+            {trail}
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}
+
+// The bundled font has no glyph for the ▸ this site uses for menu paths, and
+// satori draws a missing glyph as an empty box — "Settings ▸ Keyboard" arrived on
+// the card as "Settings ☐ Keyboard". The single-angle quote says the same thing
+// and is in the font.
+function drawable(text: string): string {
+  return text.replace(/▸/g, "›");
+}
+
+/** Keeps a long description from pushing the title off the card. */
+function clamp(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const cut = text.slice(0, limit);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > limit * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}

--- a/web/landing/src/app/llms.txt/route.ts
+++ b/web/landing/src/app/llms.txt/route.ts
@@ -30,6 +30,7 @@ export function GET() {
     `- [iPhone companion beta](${testflightUrl}): TestFlight — mirrors Mac sessions live on the phone`,
     `- [Full docs in one file](${siteUrl}/llms-full.txt): every page above, concatenated`,
     `- [Agent skill](${siteUrl}/skill.md): the termio skill the Mac app installs into ~/.claude/skills and ~/.codex/skills — save it there yourself to drive sibling sessions from an agent Termio doesn't auto-configure`,
+    `- Any docs page also answers with Markdown at its own URL when the request carries \`Accept: text/markdown\` — the \`.md\` links above are the explicit form of the same thing`,
     `- Programmatic docs search: \`GET ${siteUrl}/api/search?query=<terms>\` returns JSON results with page URLs`,
   ].join("\n");
 

--- a/web/landing/src/components/docs/ask-ai-menu.tsx
+++ b/web/landing/src/components/docs/ask-ai-menu.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Menu } from "@base-ui/react/menu";
+
+// Hands the page to an assistant instead of an "Ask AI" chat panel. A panel means
+// a hosted model, an API key, and a bill; this costs nothing, works for the reader
+// who is already in a conversation with one of these, and points the assistant at
+// the page's raw Markdown rather than a scrape of the rendered HTML.
+export function AskAIMenu({
+  labels,
+}: {
+  labels: {
+    trigger: string;
+    aria: string;
+    claude: string;
+    chatgpt: string;
+    /** Already resolved against the page's Markdown URL by the server. */
+    prompt: string;
+  };
+}) {
+  const prompt = encodeURIComponent(labels.prompt);
+  const destinations = [
+    { name: labels.claude, href: `https://claude.ai/new?q=${prompt}` },
+    {
+      name: labels.chatgpt,
+      href: `https://chatgpt.com/?hints=search&q=${prompt}`,
+    },
+  ];
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        aria-label={labels.aria}
+        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[12px] font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground data-[popup-open]:bg-fd-accent data-[popup-open]:text-fd-accent-foreground"
+      >
+        <SparkIcon className="h-3.5 w-3.5" />
+        {labels.trigger}
+        <ChevronIcon className="h-3 w-3 opacity-70" />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner sideOffset={6} align="end" className="z-50">
+          <Menu.Popup className="min-w-[11rem] rounded-xl border border-fd-border bg-fd-popover p-1 text-fd-popover-foreground shadow-lg outline-none">
+            {destinations.map((destination) => (
+              <Menu.Item
+                key={destination.name}
+                className="flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] no-underline outline-none data-[highlighted]:bg-fd-accent data-[highlighted]:text-fd-accent-foreground"
+                render={
+                  <a
+                    href={destination.href}
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                }
+              >
+                {destination.name}
+                <ExternalIcon className="ml-auto h-3 w-3 opacity-50" />
+              </Menu.Item>
+            ))}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+function SparkIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={className}>
+      <path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z" />
+      <path d="M18 16.5l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8z" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={className}>
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function ExternalIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={className}>
+      <path d="M7 17 17 7M9 7h8v8" />
+    </svg>
+  );
+}

--- a/web/landing/src/components/docs/doc-page.tsx
+++ b/web/landing/src/components/docs/doc-page.tsx
@@ -9,6 +9,7 @@ import {
 import { source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
 import { CopyMarkdownButton } from "@/components/docs/copy-markdown-button";
+import { AskAIMenu } from "@/components/docs/ask-ai-menu";
 import { docsChrome } from "@/lib/docs-ui";
 import { siteUrl } from "@/lib/docs-llms";
 import { i18n, languageTags, type DocsLanguage } from "@/lib/i18n";
@@ -17,6 +18,11 @@ import { i18n, languageTags, type DocsLanguage } from "@/lib/i18n";
 export function docUrl(lang: string, slug: string[]): string {
   const path = ["docs", ...slug].join("/");
   return lang === i18n.defaultLanguage ? `/${path}` : `/${lang}/${path}`;
+}
+
+/** The page's social card, drawn by the /docs-og handler. English only. */
+function cardUrl(slug: string[]): string {
+  return `/docs-og/${slug.length ? slug.join("/") : "index"}`;
 }
 
 /** The raw-Markdown twin of a page — /docs/<slug>.md, rewritten to /docs-md. */
@@ -39,18 +45,42 @@ export async function docPageMetadata(
     languages[languageTags[language] ?? language] = docUrl(language, slug);
   }
 
+  // One card per page, so a docs link in a thread carries the page's own name
+  // instead of the landing hero every other link already showed. It is drawn from
+  // the English title — see the note in the /docs-og handler — so a translated
+  // page shares the English card rather than a boxes-for-glyphs one.
+  const english = source.getPage(slug, i18n.defaultLanguage);
+  const card = {
+    url: cardUrl(english ? slug : []),
+    width: 1200,
+    height: 630,
+    type: "image/png",
+    alt: `${english?.data.title ?? title} — Termio documentation`,
+  };
+
   return {
     title,
     description,
-    alternates: { canonical: docUrl(lang, slug), languages },
-    openGraph: { title, description, url: docUrl(lang, slug) },
+    alternates: {
+      canonical: docUrl(lang, slug),
+      languages,
+      // The Markdown twin, named in the page's own head. An agent that reads the
+      // HTML once can find the clean copy without guessing at a `.md` suffix.
+      types: {
+        "text/markdown": [
+          { url: markdownUrl(docUrl(lang, slug)), title: page.data.title },
+        ],
+      },
+    },
+    openGraph: { title, description, url: docUrl(lang, slug), images: [card] },
+    twitter: { card: "summary_large_image", title, description, images: [card] },
   };
 }
 
 // The page frame — table of contents, breadcrumbs, prev/next, the edit link —
-// is fumadocs-ui's. What stays ours are the two page actions, because they exist
-// for a readership that is driving coding agents: copy the page as Markdown, or
-// open its raw `.md` twin.
+// is fumadocs-ui's. What stays ours are the page actions, because they exist for a
+// readership that is driving coding agents: copy the page as Markdown, hand it to
+// an assistant, or open its raw `.md` twin.
 export async function DocPage({
   lang,
   slug,
@@ -167,6 +197,18 @@ export async function DocPage({
               aria: chrome.copyAriaLabel,
             }}
           />
+          <AskAIMenu
+            labels={{
+              trigger: chrome.askAI,
+              aria: chrome.askAIAriaLabel,
+              claude: chrome.askClaude,
+              chatgpt: chrome.askChatGPT,
+              prompt: chrome.askPrompt.replace(
+                "{url}",
+                `${siteUrl}${markdownUrl(page.url)}`,
+              ),
+            }}
+          />
           <a
             href={markdownUrl(page.url)}
             aria-label={chrome.markdownAriaLabel}
@@ -177,7 +219,9 @@ export async function DocPage({
           </a>
         </div>
       </div>
-      <DocsBody>
+      {/* The skip link in the docs frame lands here — the library's page has no
+          anchor of its own, and the frame and the page always render together. */}
+      <DocsBody id="docs-content" tabIndex={-1}>
         <MDX components={getMDXComponents()} />
       </DocsBody>
       <script

--- a/web/landing/src/components/docs/docs-frame.tsx
+++ b/web/landing/src/components/docs/docs-frame.tsx
@@ -48,6 +48,16 @@ export function DocsFrame({
           translations: docsLibraryChrome(lang),
         }}
       >
+        {/* Every docs page opens with a header, a sidebar tree and a search field
+            before the prose starts. A keyboard or screen-reader user should not have
+            to walk them on every page — the first thing the tab order offers is the
+            way past them. Invisible until focused. */}
+        <a
+          href="#docs-content"
+          className="sr-only z-[100] focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:inline-flex focus:h-9 focus:items-center focus:rounded-lg focus:bg-primary focus:px-3 focus:text-[13px] focus:font-semibold focus:text-primary-foreground focus:no-underline focus:outline-2 focus:outline-offset-2 focus:outline-ring"
+        >
+          {chrome.skipToContent}
+        </a>
         <DocsHeader lang={lang} />
         <DocsLayout
           tree={source.getPageTree(lang)}

--- a/web/landing/src/lib/docs-ui.ts
+++ b/web/landing/src/lib/docs-ui.ts
@@ -18,8 +18,17 @@ export type DocsChrome = {
   copyAriaLabel: string;
   markdown: string;
   markdownAriaLabel: string;
+  askAI: string;
+  askAIAriaLabel: string;
+  askClaude: string;
+  askChatGPT: string;
+  /** The prompt handed to the assistant. `{url}` becomes the page's `.md` URL.
+      A template rather than a function: this record crosses into client
+      components, and a function can't. */
+  askPrompt: string;
   editPage: string;
   language: string;
+  skipToContent: string;
   docsLabel: string;
   download: string;
   theme: string;
@@ -43,8 +52,15 @@ const en: DocsChrome = {
   copyAriaLabel: "Copy this page as Markdown",
   markdown: "Markdown",
   markdownAriaLabel: "Open this page as raw Markdown",
+  askAI: "Ask AI",
+  askAIAriaLabel: "Ask an assistant about this page",
+  askClaude: "Ask Claude",
+  askChatGPT: "Ask ChatGPT",
+  askPrompt:
+    "Read {url} — it is a page of the Termio documentation. Answer my questions about it, and say when something isn't covered there.",
   editPage: "Edit this page on GitHub",
   language: "Language",
+  skipToContent: "Skip to content",
   docsLabel: "Docs",
   download: "Download",
   theme: "Appearance",
@@ -68,8 +84,15 @@ const zhCN: DocsChrome = {
   copyAriaLabel: "以 Markdown 拷贝本页",
   markdown: "Markdown",
   markdownAriaLabel: "以 Markdown 原文打开本页",
+  askAI: "问 AI",
+  askAIAriaLabel: "就本页提问",
+  askClaude: "问 Claude",
+  askChatGPT: "问 ChatGPT",
+  askPrompt:
+    "请阅读 {url}，这是 Termio 文档的一页。请据此回答我的问题；文档里没写到的地方，直接说明。",
   editPage: "在 GitHub 上编辑本页",
   language: "语言",
+  skipToContent: "跳到正文",
   docsLabel: "文档",
   download: "下载",
   theme: "外观",

--- a/web/landing/src/proxy.ts
+++ b/web/landing/src/proxy.ts
@@ -1,0 +1,75 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { i18n, isDocsLanguage } from "@/lib/i18n";
+
+// A doc page has two representations at one address: the HTML a reader sees, and
+// the Markdown an agent wants. `/docs/<slug>.md` names the Markdown explicitly —
+// this serves the same bytes at the plain page URL when the client asked for
+// Markdown in its `Accept` header, so an agent handed a docs link out of a search
+// result or a chat message never has to know about the suffix or parse the shell.
+//
+// Browsers are unaffected: they send `text/html,…,*/*;q=0.8` and never name
+// Markdown, and `*/*` deliberately doesn't count as a request for it.
+export const config = {
+  matcher: ["/docs/:path*", "/:lang/docs/:path*"],
+};
+
+const MARKDOWN_TYPES = new Set(["text/markdown", "text/x-markdown"]);
+
+/** True when the client ranks Markdown at or above HTML in its `Accept` header. */
+function prefersMarkdown(accept: string | null): boolean {
+  if (!accept) return false;
+
+  let markdown = 0;
+  let html = 0;
+  for (const range of accept.split(",")) {
+    const [type, ...parameters] = range.trim().split(";");
+    const quality = parameters
+      .map((parameter) => parameter.trim().match(/^q=([0-9.]+)$/i))
+      .find(Boolean);
+    const weight = quality ? Number.parseFloat(quality[1]) : 1;
+    if (Number.isNaN(weight)) continue;
+
+    const media = type.trim().toLowerCase();
+    if (MARKDOWN_TYPES.has(media)) markdown = Math.max(markdown, weight);
+    else if (media === "text/html") html = Math.max(html, weight);
+  }
+
+  return markdown > 0 && markdown >= html;
+}
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  // Already the Markdown twin — next.config's rewrite takes it from here.
+  if (pathname.endsWith(".md")) return NextResponse.next();
+  if (!prefersMarkdown(request.headers.get("accept"))) {
+    return varyOnAccept(NextResponse.next());
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+  const head = segments[0];
+  // The default language has no prefix of its own, so `/en/docs` is not a route.
+  const localized =
+    isDocsLanguage(head) && head !== i18n.defaultLanguage && segments[1] === "docs";
+  if (!localized && head !== "docs") return NextResponse.next();
+
+  const slug = segments.slice(localized ? 2 : 1);
+  const path = [
+    ...(localized ? [head] : []),
+    ...(slug.length ? slug : ["index"]),
+  ];
+
+  return varyOnAccept(
+    NextResponse.rewrite(new URL(`/docs-md/${path.join("/")}`, request.url)),
+  );
+}
+
+// Two representations answer to one URL, so a downstream cache that keyed on the
+// URL alone would hand one client the other's. It sticks to the Markdown branch;
+// on the HTML branch Next writes its own `Vary` onto the prerendered response and
+// drops this one — configuring it in next.config's `headers` loses the same way.
+// The consequence is contained: this proxy runs ahead of the CDN's own lookup, so
+// the cache is keyed on the rewritten path rather than on `/docs/<slug>`.
+function varyOnAccept(response: NextResponse): NextResponse {
+  response.headers.append("Vary", "Accept");
+  return response;
+}


### PR DESCRIPTION
A doc page has two representations at one address. Until now only the `.md` suffix named the Markdown one, so an agent handed a plain docs URL parsed the HTML shell instead.

`src/proxy.ts` answers the page URL with the raw Markdown when the request's Accept header ranks `text/markdown` at or above `text/html`, and every page names its Markdown twin in its own head with a `rel="alternate"` link. Browsers and `*/*` clients are unchanged.

Three things the docs were missing land beside it:

- **Ask AI**, next to Copy for LLM, handing the page's `.md` URL to Claude or ChatGPT. A link rather than a chat panel: a panel means a hosted model, a key, and a bill.
- **A social card per page**, drawn by `/docs-og`. Every docs link used to share the landing hero, so fifteen pages arrived in a thread as one picture. English only — the font next/og bundles has no CJK glyphs.
- **A skip-to-content link**, first in the tab order, so a keyboard reader does not walk the header, the tree and the search field on every page.

Release Notes:

- Docs pages now serve Markdown to clients that ask for it, so an agent given a docs URL reads the page instead of its HTML shell.
- Added an Ask AI action beside Copy for LLM on every docs page.
- Each docs page now has its own social card instead of sharing the landing hero.
- Added a skip-to-content link for keyboard navigation.