### PR TITLE
Keep a machine's clones across a host identity change

### DIFF
--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -218,10 +218,10 @@ func newTerminalMenuItem(
     return .submenu(localized("New Terminal"), known.map { device in
         guard let alias = device.alias else { return .action(device.name, local) }
         // A project row says which machines already hold this repo, so the menu
-        // answers "where does this exist?" before you click. The checkout is keyed
-        // by device, so ask the registry for the identity learned earlier and let
-        // the lookup fall back to the alias when this box has never been reached.
-        let cloned = project?.remoteCheckout(device: device.deviceID, alias: alias) != nil
+        // answers "where does this exist?" before you click. Asked through the
+        // store rather than the project alone: a repo can be on a machine because
+        // it is filed under that machine's workspace, with no checkout recorded.
+        let cloned = project.map { store.remoteCheckout(for: $0, on: device) != nil } ?? false
         let label = project == nil || cloned ? device.name : "\(device.name) — not cloned yet"
         return .action(label) { store.addRemoteTerminal(host: alias, project: projectID) }
     })

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -512,6 +512,17 @@ extension TermioStore {
     /// case (a cloned VM carrying a duplicate `host_id`) has an answer.
     func adoptDevice(_ device: TermiodDevice, forRoute route: TermiodRoute) {
         let alias = route.sshAlias
+        // Identities this alias used to answer with. A machine that re-mints its
+        // `host_id` — a reboot that took a pre-0.48 `host.id` with it — comes back
+        // as a device nothing is keyed under, and every clone on it would read as
+        // "not cloned yet" while sitting right there. The alias reaching the same
+        // box is the same evidence the workspace loop below already re-keys on.
+        let superseded = alias.map { alias in
+            workspaces
+                .filter { $0.deviceAlias == alias }
+                .compactMap(\.deviceID)
+                .filter { $0 != device.id }
+        } ?? []
         for index in projects.indices {
             // A checkout recorded before checkouts were device-keyed sits under
             // the alias. Promote it the moment the alias resolves, so an old state
@@ -520,6 +531,13 @@ extension TermioStore {
                projects[index].remoteCheckouts[device.id] == nil {
                 projects[index].remoteCheckouts[device.id] = legacy
                 projects[index].remoteCheckouts[alias] = nil
+            }
+            for old in superseded {
+                guard let stale = projects[index].remoteCheckouts[old] else { continue }
+                if projects[index].remoteCheckouts[device.id] == nil {
+                    projects[index].remoteCheckouts[device.id] = stale
+                }
+                projects[index].remoteCheckouts[old] = nil
             }
             // What the checkout itself is sitting on is not recorded here: a
             // project takes its machine from the workspace that owns it, and the
@@ -1130,10 +1148,18 @@ extension TermioStore {
                 // you clicked and what you got is exactly the confusion this
                 // replaces.
                 if let projectID, let project = self.projects.first(where: { $0.id == projectID }) {
-                    guard let checkout = project.remoteCheckout(device: device.id, alias: host)
-                    else {
+                    let target = KnownDevice(alias: host, deviceID: device.id)
+                    guard let checkout = self.remoteCheckout(for: project, on: target) else {
                         self.presentRemoteCheckoutMissing(host: host, project: project.name)
                         return
+                    }
+                    // The identity that answered is the one the checkout is filed
+                    // under from here on, so a repo found by its workspace stops
+                    // depending on that fallback and the panes reading the raw
+                    // lookup agree with this terminal.
+                    if let index = self.projects.firstIndex(where: { $0.id == projectID }),
+                       self.projects[index].remoteCheckouts[device.id] != checkout {
+                        self.projects[index].remoteCheckouts[device.id] = checkout
                     }
                     cwd = checkout
                 }

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -537,7 +537,10 @@ extension TermioStore {
                 if projects[index].remoteCheckouts[device.id] == nil {
                     projects[index].remoteCheckouts[device.id] = stale
                 }
-                projects[index].remoteCheckouts[old] = nil
+                // An alias is only a route, not proof that its old device and the
+                // one answering now have the same filesystem. Keep the recorded
+                // fact under its old identity: it is inert for this device's
+                // lookup, while deleting it makes an alias repoint unrecoverable.
             }
             // What the checkout itself is sitting on is not recorded here: a
             // project takes its machine from the workspace that owns it, and the
@@ -1149,19 +1152,16 @@ extension TermioStore {
                 // replaces.
                 if let projectID, let project = self.projects.first(where: { $0.id == projectID }) {
                     let target = KnownDevice(alias: host, deviceID: device.id)
-                    guard let checkout = self.remoteCheckout(for: project, on: target) else {
+                    guard let checkout = self.remoteCheckoutReading(for: project, on: target) else {
                         self.presentRemoteCheckoutMissing(host: host, project: project.name)
                         return
                     }
-                    // The identity that answered is the one the checkout is filed
-                    // under from here on, so a repo found by its workspace stops
-                    // depending on that fallback and the panes reading the raw
-                    // lookup agree with this terminal.
-                    if let index = self.projects.firstIndex(where: { $0.id == projectID }),
-                       self.projects[index].remoteCheckouts[device.id] != checkout {
-                        self.projects[index].remoteCheckouts[device.id] = checkout
+                    if case .recorded(let path) = checkout,
+                       let index = self.projects.firstIndex(where: { $0.id == projectID }),
+                       self.projects[index].remoteCheckouts[device.id] != path {
+                        self.projects[index].remoteCheckouts[device.id] = path
                     }
-                    cwd = checkout
+                    cwd = checkout.path
                 }
                 self.createRemoteTerminalSession(
                     host: host, device: device.id, cwd: cwd, title: title, project: projectID

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -262,6 +262,27 @@ extension TermioStore {
         device(of: project) != .thisMac
     }
 
+    /// Where a project's files sit on `device`: the checkout recorded for that
+    /// machine, or — when the project is filed under a workspace *on* it — the
+    /// project's own `path`, which is already a path over there.
+    ///
+    /// The second reading is what keeps a machine that re-mints its `host_id` from
+    /// orphaning every repo on it. A checkout is keyed by the identity that
+    /// answered when it was recorded; a box that comes back with a different one
+    /// (a reboot that wiped a pre-0.48 `host.id`, which lived in the runtime dir)
+    /// no longer matches its own key, and the repo reads as "not on that machine
+    /// yet" while sitting right there. A workspace states the same fact more
+    /// durably — it is matched by alias, so it follows the box across identity
+    /// changes — and `adoptionProjectIndex` already reads roots this way.
+    func remoteCheckout(for project: Project, on device: KnownDevice) -> String? {
+        guard let alias = device.alias else { return nil }
+        if let recorded = project.remoteCheckout(device: device.deviceID, alias: alias) {
+            return recorded
+        }
+        guard workspace(owning: project)?.deviceAlias == alias else { return nil }
+        return project.path
+    }
+
     /// The project that already *is* the directory `path` on that machine — what
     /// "opening the same folder twice reopens the row you have" asks.
     ///

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -262,9 +262,20 @@ extension TermioStore {
         device(of: project) != .thisMac
     }
 
+    enum RemoteCheckoutReading: Equatable {
+        case recorded(String)
+        case workspacePath(String)
+
+        var path: String {
+            switch self {
+            case .recorded(let path), .workspacePath(let path): path
+            }
+        }
+    }
+
     /// Where a project's files sit on `device`: the checkout recorded for that
-    /// machine, or — when the project is filed under a workspace *on* it — the
-    /// project's own `path`, which is already a path over there.
+    /// machine, or — when the project is filed under an as-yet-unidentified
+    /// workspace on it — the project's own `path`.
     ///
     /// The second reading is what keeps a machine that re-mints its `host_id` from
     /// orphaning every repo on it. A checkout is keyed by the identity that
@@ -272,15 +283,23 @@ extension TermioStore {
     /// (a reboot that wiped a pre-0.48 `host.id`, which lived in the runtime dir)
     /// no longer matches its own key, and the repo reads as "not on that machine
     /// yet" while sitting right there. A workspace states the same fact more
-    /// durably — it is matched by alias, so it follows the box across identity
-    /// changes — and `adoptionProjectIndex` already reads roots this way.
-    func remoteCheckout(for project: Project, on device: KnownDevice) -> String? {
+    /// durably only until the workspace has identified a device. An alias can be
+    /// repointed, and an identity change cannot distinguish that from the same
+    /// box returning, so the soft reading is valid only before that fact exists.
+    func remoteCheckoutReading(for project: Project, on device: KnownDevice) -> RemoteCheckoutReading? {
         guard let alias = device.alias else { return nil }
         if let recorded = project.remoteCheckout(device: device.deviceID, alias: alias) {
-            return recorded
+            return .recorded(recorded)
         }
-        guard workspace(owning: project)?.deviceAlias == alias else { return nil }
-        return project.path
+        guard let workspace = workspace(owning: project),
+              workspace.deviceAlias == alias,
+              workspace.deviceID == nil
+        else { return nil }
+        return .workspacePath(project.path)
+    }
+
+    func remoteCheckout(for project: Project, on device: KnownDevice) -> String? {
+        remoteCheckoutReading(for: project, on: device)?.path
     }
 
     /// The project that already *is* the directory `path` on that machine — what

--- a/Tests/termioTests/TermiodDeviceAdoptionTests.swift
+++ b/Tests/termioTests/TermiodDeviceAdoptionTests.swift
@@ -189,9 +189,8 @@ final class TermiodDeviceAdoptionTests: XCTestCase {
     }
 
     /// A machine that re-mints its `host_id` keeps its clones. The alias still
-    /// reaches the same box — the evidence the workspace loop already re-keys on —
-    /// so a checkout filed under the identity that died moves to the live one
-    /// instead of reading as "not cloned yet" while sitting right there.
+    /// reaches the same box — enough to offer the new identity a reading — while
+    /// the old identity remains recorded in case the alias was repointed.
     func testCarriesCheckoutsAcrossAHostIdentityChange() {
         var remote = deviceWorkspace(alias: "vps")
         remote.deviceID = "h_old"
@@ -201,7 +200,10 @@ final class TermiodDeviceAdoptionTests: XCTestCase {
 
         store.adoptDevice(device("h_new"), forRoute: .ssh("vps"))
 
-        XCTAssertEqual(store.projects[0].remoteCheckouts, ["h_new": "/home/me/termio"])
+        XCTAssertEqual(store.projects[0].remoteCheckouts, [
+            "h_old": "/home/me/termio",
+            "h_new": "/home/me/termio",
+        ])
     }
 
     /// A project filed under a machine's workspace is already a path over there,
@@ -218,6 +220,49 @@ final class TermiodDeviceAdoptionTests: XCTestCase {
                                  on: KnownDevice(alias: "vps", deviceID: "h_new")),
             "/code/termio"
         )
+    }
+
+    /// An alias is not proof that the host behind it is the same filesystem. Once
+    /// the workspace identifies a different box, its path cannot be guessed for
+    /// the new one or promoted into a checkout record.
+    func testAnAliasRepointKeepsTheOldCheckoutAndDoesNotInventOneOnTheNewBox() {
+        var remote = deviceWorkspace(alias: "vps")
+        remote.deviceID = "h_old"
+        let checkout = project("termio", in: remote)
+        let store = makeStore(workspaces: [remote], projects: [checkout])
+
+        store.adoptDevice(device("h_new"), forRoute: .ssh("vps"))
+
+        XCTAssertNil(store.remoteCheckoutReading(
+            for: store.projects[0], on: KnownDevice(alias: "vps", deviceID: "h_new")))
+        XCTAssertTrue(store.projects[0].remoteCheckouts.isEmpty)
+    }
+
+    /// A project whose workspace still identifies the old box must not open its
+    /// old path after an alias is reused for a new one.
+    func testARepointedAliasRefusesTheWorkspacePath() {
+        var remote = deviceWorkspace(alias: "vps")
+        remote.deviceID = "h_old"
+        let checkout = project("termio", in: remote)
+        let store = makeStore(workspaces: [remote], projects: [checkout])
+
+        XCTAssertNil(store.remoteCheckout(for: checkout,
+                                          on: KnownDevice(alias: "vps", deviceID: "h_new")))
+    }
+
+    /// A workspace records only its latest identity. A checkout stranded under an
+    /// older one remains a fact and must not be discarded while adopting another.
+    func testKeepsCheckoutOlderThanTheWorkspacesCurrentIdentity() {
+        var remote = deviceWorkspace(alias: "vps")
+        remote.deviceID = "h_current"
+        var checkout = project("termio", in: Workspace(name: "Sessions"))
+        checkout.remoteCheckouts = ["h_older": "/home/me/termio"]
+        let store = makeStore(workspaces: [remote], projects: [checkout])
+
+        store.adoptDevice(device("h_new"), forRoute: .ssh("vps"))
+
+        XCTAssertEqual(store.projects[0].remoteCheckouts,
+                       ["h_older": "/home/me/termio"])
     }
 
     /// The fallback is scoped to the machine the project is filed on: a checkout

--- a/Tests/termioTests/TermiodDeviceAdoptionTests.swift
+++ b/Tests/termioTests/TermiodDeviceAdoptionTests.swift
@@ -188,6 +188,52 @@ final class TermiodDeviceAdoptionTests: XCTestCase {
         XCTAssertEqual(checkout.remoteCheckout(device: "h_aaaa", alias: "vps"), "/srv/termio")
     }
 
+    /// A machine that re-mints its `host_id` keeps its clones. The alias still
+    /// reaches the same box — the evidence the workspace loop already re-keys on —
+    /// so a checkout filed under the identity that died moves to the live one
+    /// instead of reading as "not cloned yet" while sitting right there.
+    func testCarriesCheckoutsAcrossAHostIdentityChange() {
+        var remote = deviceWorkspace(alias: "vps")
+        remote.deviceID = "h_old"
+        var checkout = project("termio", in: Workspace(name: "Sessions"))
+        checkout.remoteCheckouts = ["h_old": "/home/me/termio"]
+        let store = makeStore(workspaces: [remote], projects: [checkout])
+
+        store.adoptDevice(device("h_new"), forRoute: .ssh("vps"))
+
+        XCTAssertEqual(store.projects[0].remoteCheckouts, ["h_new": "/home/me/termio"])
+    }
+
+    /// A project filed under a machine's workspace is already a path over there,
+    /// so it needs no recorded checkout to open a terminal in. This is the reading
+    /// that survives an identity change even after the workspace has taken the new
+    /// one, which leaves nothing to re-key from.
+    func testAProjectFiledOnAMachineNeedsNoRecordedCheckout() {
+        let remote = deviceWorkspace(alias: "vps")
+        let checkout = project("termio", in: remote)
+        let store = makeStore(workspaces: [remote], projects: [checkout])
+
+        XCTAssertEqual(
+            store.remoteCheckout(for: checkout,
+                                 on: KnownDevice(alias: "vps", deviceID: "h_new")),
+            "/code/termio"
+        )
+    }
+
+    /// The fallback is scoped to the machine the project is filed on: a checkout
+    /// on this Mac still has to have been cloned before a terminal opens on a box,
+    /// or the shell would land in a directory that is not there.
+    func testAProjectOnThisMacStillNeedsARecordedCheckout() {
+        let home = Workspace(name: "Sessions")
+        let checkout = project("termio", in: home)
+        let store = makeStore(workspaces: [home, deviceWorkspace(alias: "vps")],
+                              projects: [checkout])
+
+        XCTAssertNil(
+            store.remoteCheckout(for: checkout,
+                                 on: KnownDevice(alias: "vps", deviceID: "h_new")))
+    }
+
     /// Workspace state survives a round trip through the state file, or the device
     /// would have to be re-learned on every launch.
     func testDeviceFieldsSurviveEncoding() throws {


### PR DESCRIPTION
A checkout is filed under the `host_id` that answered when it was recorded. A box that re-mints that id — a reboot that took a pre-0.48 `host.id` with it — comes back as a device nothing is keyed under. Every clone on it then reads as "not cloned yet" while sitting right there, and **New Terminal** refuses to open in a repo that exists.

Two readings recover it:

- `adoptDevice` re-keys checkouts from the identities the same alias used to answer with — the same evidence the workspace loop beside it already re-keys on.
- `remoteCheckout(for:on:)` falls back to the project's own path when the project is filed under a workspace *on* that machine. A workspace is matched by alias, so it follows the box across identity changes even after nothing is left to re-key from.

The fallback is deliberately scoped to the machine the project is filed on: a project on this Mac still needs a recorded clone before a terminal opens on a box, or the shell would land in a directory that is not there.

Three tests cover the re-key, the workspace fallback, and that scoping.

Release Notes:

- Fixed remote repositories reading as "not cloned yet" — and New Terminal refusing to open in them — after a machine changed its host identity.