### PR TITLE
Stage this Mac's daemon at launch

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -160,6 +160,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Sweep up session processes a previous instance stranded (crash,
         // force-quit, dev rebuild's kill -9) before this run adds its own.
         StraySessionReaper.reapStrayOrphans()
+        // The daemon on this Mac outlives the app, so an update leaves the old
+        // process running until something asks it to take on the new binary.
+        // Here — before the first control channel opens and long before a pane
+        // attaches — is the only moment that costs nobody their session. The
+        // probe can block behind a wedged daemon, so it must never delay making
+        // the first window.
+        DispatchQueue.global(qos: .utility).async {
+            TermioStore.reconcileLocalDaemon()
+        }
         store.refreshDeviceSessions()
         LaunchTrace.mark("store restored")
         // Task-completion notifications: the delegate must be installed before a

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -448,4 +448,12 @@ enum AppInfo {
         let build = info?["CFBundleVersion"] as? String ?? "0"
         return "\(version)+\(build)"
     }()
+
+    /// The same stamp, `nil` when the running binary is not a bundle. A bare
+    /// `swift build` executable carries no version at all, and the daemon it
+    /// finds in the checkout is stamped from the commit count — comparing the
+    /// two would report a mismatch on every launch that no update could settle.
+    static let bundledStamp: String? = {
+        Bundle.main.infoDictionary?["CFBundleVersion"] == nil ? nil : buildStamp
+    }()
 }

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1362,6 +1362,96 @@ extension TermioStore {
         }
     }
 
+    // MARK: - This Mac's own daemon
+
+    /// Puts the daemon on this Mac onto the binary this app ships.
+    ///
+    /// The daemon outlives the app deliberately: that is what makes a session
+    /// survive quit. The cost is that updating the app replaces the binary in
+    /// the bundle and leaves the *process* running whatever version it started
+    /// with, indefinitely — this Mac was observed a full release behind while
+    /// every box it talks to was current, because a remote is reconciled before
+    /// each terminal opens (`ensureRemoteReady`) and the machine the app runs on
+    /// was the one nobody asked.
+    ///
+    /// Launch is the right moment to stage the replacement: no pane has yet
+    /// asked to start this app's daemon, so a missing daemon will start from the
+    /// new binary. An existing daemon is deliberately left alone. The later swap
+    /// is deferred to an explicit deploy or the daemon's own restart, so launch
+    /// can never terminate an idle session without the user asking.
+    ///
+    /// The rule itself stays in one place. This asks what the daemon is running
+    /// and, when that is not what the bundled daemon carries, hands the decision to the
+    /// same `deploy` loop every device goes through. Whether a difference is an
+    /// upgrade at all is that loop's answer to give — a dev build must never
+    /// stage itself over a released daemon — so this side compares for equality
+    /// and nothing more.
+    nonisolated static func reconcileLocalDaemon() {
+        let binary = Termiod.daemonBinaryPath()
+        guard FileManager.default.isExecutableFile(atPath: binary),
+              let desired = daemonBuildStamp(at: binary),
+              // A release stamps the bundle and termiod together. The local
+              // build script leaves the plist's placeholder in place while the
+              // daemon reports its commit-count fallback, so refusing that
+              // mismatch keeps a dev app from deploying a binary the Rust loop
+              // will correctly decline to use.
+              AppInfo.bundledStamp == desired
+        else { return }
+        // No autostart on purpose: a daemon that is not running cannot be stale,
+        // and the one the first pane starts is this bundle's own.
+        guard let running = try? Termiod.probeExistingLocalDevice().daemonVersion,
+              running != desired
+        else { return }
+        Log.termiod.info("""
+        this Mac runs termiod \(running, privacy: .public) and this app ships \
+        \(desired, privacy: .public); staging it before any pane attaches
+        """)
+        guard let run = runProcess(binary, ["deploy", "--stage-only", "--json"]) else {
+            Log.termiod.error("couldn't run \(binary, privacy: .public) deploy")
+            return
+        }
+        guard let report = try? Termiod.LifecycleReport.decode(
+            Data(run.standardOutput.utf8))
+        else {
+            Log.termiod.error("""
+            the local termiod deploy ended without a report: \
+            \(run.standardError, privacy: .public)
+            """)
+            return
+        }
+        switch report.state {
+        case .staged:
+            Log.termiod.info("""
+            staged termiod \(report.version ?? desired, privacy: .public) for this Mac's daemon; \
+            it is still running \(report.daemon ?? running, privacy: .public)
+            """)
+        case .current:
+            Log.termiod.info(
+                "this Mac's termiod deploy reports current at \(report.version ?? desired, privacy: .public)")
+        default:
+            // Never an alert. Version skew is negotiated at the handshake,
+            // so a daemon that stays behind is a worse build, not a broken
+            // app, and launch is the wrong place to argue about it.
+            Log.termiod.error("""
+            left this Mac's termiod on \(running, privacy: .public): \
+            \(report.message ?? report.state.rawValue, privacy: .public)
+            """)
+        }
+    }
+
+    /// The bundled daemon's own build stamp. This is the source the deploy
+    /// command compares with the running daemon, so launch must use it too.
+    private nonisolated static func daemonBuildStamp(at binary: String) -> String? {
+        guard let output = runProcess(binary, ["--version"]), output.exitCode == 0 else {
+            return nil
+        }
+        return output.standardOutput
+            .split(whereSeparator: \.isWhitespace)
+            .dropFirst()
+            .first
+            .map(String.init)
+    }
+
     /// A captured subprocess result — exit code plus drained stdout/stderr.
     private struct ProcessOutput {
         let exitCode: Int32

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -496,6 +496,17 @@ extension Termiod {
                              route: .local, sshPid: nil)
         }
 
+        /// Local Unix socket without starting a daemon. Startup reconciliation
+        /// only has work to do when a previous daemon is already running; the
+        /// first pane starts a missing one from this app's bundled binary.
+        static func existingLocal() throws -> Transport {
+            guard let descriptor = openSocket() else {
+                throw TermiodClientError.daemonUnreachable(socketPath())
+            }
+            return Transport(readDescriptor: descriptor, writeDescriptor: descriptor,
+                             route: .local, sshPid: nil)
+        }
+
         /// Opens whichever kind of pipe the route names — the one place local and
         /// SSH differ, so no caller above this line has to branch on it.
         static func open(_ route: TermiodRoute) throws -> Transport {
@@ -834,6 +845,19 @@ extension Termiod {
     @discardableResult
     static func probeDevice(route: TermiodRoute) throws -> TermiodDevice {
         let transport = try Transport.open(route)
+        defer { transport.close() }
+        do {
+            return try performHello(transport, role: "control").device
+        } catch let error as TermiodClientError {
+            throw transport.explained(error)
+        }
+    }
+
+    /// Asks an already-running local daemon who it is, without the normal
+    /// connect path's autostart side effect.
+    @discardableResult
+    static func probeExistingLocalDevice() throws -> TermiodDevice {
+        let transport = try Transport.existingLocal()
         defer { transport.close() }
         do {
             return try performHello(transport, role: "control").device


### PR DESCRIPTION
The daemon outlives the app deliberately — that is what makes a session survive quit. The cost is that updating the app replaces the binary in the bundle and leaves the *process* running whatever version it started with, indefinitely. Every remote is reconciled before each terminal opens (`ensureRemoteReady`); the machine the app runs on was the one nobody asked, and it was observed a full release behind while every box it talked to was current.

**Launch stages the replacement and stops there.** `--stage-only` puts the new binary in place and leaves the running daemon alone; the swap happens at an explicit deploy or the daemon's own restart. That matters because the deploy loop falls back to `stop` when a daemon is too old to hand off, and `stop` ends every session it does not consider busy — an idle shell, an agent that reported `done`. Launch is the wrong place to spend that without the user asking.

Three things this gets right:

- **It runs off the main thread.** `performHello` reads a frame with no socket timeout, so a daemon that accepts a connection and never answers would hang launch before the window exists.
- **It does not autostart.** `Transport.existingLocal` connects without the spawn-and-poll `connectWithAutostart` performs — a daemon that is not running cannot be stale, and the one the first pane starts is this bundle's own.
- **It compares what the deploy loop compares.** The bundled daemon's own `--version` is the desired stamp, not the app's `CFBundleVersion`. An unstamped dev bundle carries the plist placeholder while its daemon reports a commit count, so reading the wrong one made every dev launch run a deploy that could do nothing and then log that it had.

Not verified against a real update yet: the path only engages on a bundle whose app and daemon were stamped together by the release workflow, so a dev build takes the skip branch by design.

Release Notes:

- termio now stages a newer session daemon for this Mac at launch, so the machine the app runs on stops falling behind the machines it connects to. Running sessions are never interrupted; the new daemon takes over at the next explicit deploy or restart.