### PR TITLE
Track libghostty-swift 1.0.24 in the iOS project

### DIFF
--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.22;
+				minimumVersion = 1.0.24;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "84af6e4a766110efa7ceb09a2a02cac4c2ad684f",
-        "version" : "1.0.22"
+        "revision" : "7f9687529e1f998aa4df882defc3e7abcd4f88c8",
+        "version" : "1.0.24"
       }
     },
     {


### PR DESCRIPTION
The Mac target moved to 1.0.24 and the Xcode project stayed pinned at 1.0.22, so the two ends of one dependency disagreed. `Package.swift` already says `from: "1.0.24"`; this is the iOS project catching up to the same revision the root `Package.resolved` records.

Not built on device here — it is a pin bump, and the Mac target already builds and tests against this revision.

Release Notes:

- The iOS companion now builds against the same libghostty revision as the Mac app.