### PR TITLE
Add per-agent startup arguments

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -882,6 +882,16 @@
         }
       }
     },
+    "Arguments": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数"
+          }
+        }
+      }
+    },
     "Asking %@ what it has.": {
       "localizations": {
         "zh-Hans": {
@@ -4843,6 +4853,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "窗格"
+          }
+        }
+      }
+    },
+    "Passed to %@ every time a session starts.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每次开启会话时传给 %@。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -188,6 +188,8 @@
 	<string>Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh %@` too.</string>
 	<key>Apply</key>
 	<string>Apply</string>
+	<key>Arguments</key>
+	<string>Arguments</string>
 	<key>Asking %@ what it has.</key>
 	<string>Asking %@ what it has.</string>
 	<key>Asking %@…</key>
@@ -984,6 +986,8 @@
 	<string>Pairs your iPhone straight to this Mac's session host. Projects with nothing running don't appear yet.</string>
 	<key>Panes</key>
 	<string>Panes</string>
+	<key>Passed to %@ every time a session starts.</key>
+	<string>Passed to %@ every time a session starts.</string>
 	<key>Password</key>
 	<string>Password</string>
 	<key>Paste</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -188,6 +188,8 @@
 	<string>将 Host 块追加到 ~/.ssh/config，该别名也可直接用于 `ssh %@`。</string>
 	<key>Apply</key>
 	<string>应用</string>
+	<key>Arguments</key>
+	<string>参数</string>
 	<key>Asking %@ what it has.</key>
 	<string>正在询问 %@ 上有什么。</string>
 	<key>Asking %@…</key>
@@ -984,6 +986,8 @@
 	<string>让 iPhone 直接连到这台 Mac 的会话宿主。没有会话在跑的项目暂时不会出现。</string>
 	<key>Panes</key>
 	<string>窗格</string>
+	<key>Passed to %@ every time a session starts.</key>
+	<string>每次开启会话时传给 %@。</string>
 	<key>Password</key>
 	<string>密码</string>
 	<key>Paste</key>

--- a/Sources/termio/Resources/agents/opencode.json
+++ b/Sources/termio/Resources/agents/opencode.json
@@ -4,6 +4,7 @@
   "name": "OpenCode",
   "wire": "opencode",
   "command": "opencode",
+  "permissionBypassFlag": "--auto",
   "resume": {
     "resume": "--session {id}",
     "discover": {

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -549,6 +549,25 @@ private struct AgentDetailPane: View {
                         namesItsMachine: devices.count > 1)
                 }
                 LabeledContent {
+                    TextField(
+                        "",
+                        text: Binding(
+                            get: { settings.arguments(for: preset) ?? "" },
+                            set: { settings.setArguments($0, for: preset) }
+                        ),
+                        prompt: Text(localized("None"))
+                    )
+                    .multilineTextAlignment(.trailing)
+                    .labelsHidden()
+                    .frame(minWidth: 180)
+                } label: {
+                    SettingsLabel(
+                        title: localized("Arguments"),
+                        subtext: localized("Passed to \(preset.displayName) every time a session starts."),
+                        titleFont: .headline
+                    )
+                }
+                LabeledContent {
                     if let url = preset.installURL {
                         Link(localized("Install Page"), destination: url)
                     } else {

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -91,7 +91,7 @@ final class AppSettings: ObservableObject {
         Key.scrollbackMegabytes, Key.copyOnSelect,
         Key.interfaceFontFamily, Key.interfaceFontSize, Key.interfaceRowPadding,
         Key.agentCommands, Key.devices,
-        Key.bypassPermissionAgents, Key.disabledAgents,
+        Key.bypassPermissionAgents, Key.agentArguments, Key.disabledAgents,
         Key.addedAgents, Key.agentOrder, Key.agentHooksEnabled,
         Key.sessionControlEnabled, Key.githubIntegrationEnabled,
         Key.notifyTaskCompletion, Key.notificationSound,
@@ -132,6 +132,10 @@ final class AppSettings: ObservableObject {
         /// machine identities, which are discovered, not enumerable up front.
         static let devices = "devices"
         static let bypassPermissionAgents = "agents.bypassPermissions"
+        /// Extra arguments the user wants every session of an agent to start
+        /// with, by `rawValue`. Flat rather than nested under `devices` because
+        /// they describe the agent, not the box it runs on.
+        static let agentArguments = "agents.arguments"
         static let disabledAgents = "agents.disabled"
         static let addedAgents = "agents.added"
         static let agentOrder = "agents.order"
@@ -368,6 +372,16 @@ final class AppSettings: ObservableObject {
     /// the default (nothing stored) means every agent keeps its prompts.
     @Published var bypassPermissionAgents: Set<String> {
         didSet { store.set(Array(bypassPermissionAgents), forKey: Key.bypassPermissionAgents) }
+    }
+
+    /// Extra arguments appended to an agent's command on every launch, by
+    /// `rawValue` — `--model opus`, a project flag, the agent's own bypass flag
+    /// when it has one termio does not know about. Held once for the app rather
+    /// than per machine for the same reason the bypass switch is: how you want an
+    /// agent to run is a standing decision about that agent, while a command path
+    /// is a fact about a box (RFC §The model).
+    @Published var agentArguments: [String: String] {
+        didSet { store.set(agentArguments.isEmpty ? nil : agentArguments, forKey: Key.agentArguments) }
     }
 
     /// Agent presets hidden from the sidebar quick-add row, by `rawValue`. Stored
@@ -617,6 +631,7 @@ final class AppSettings: ObservableObject {
         interfaceRowPadding = store.double(Key.interfaceRowPadding)
         deviceSettings = DeviceSettingsSection(jsonObject: store.object(Key.devices))
         bypassPermissionAgents = Set(store.stringArray(Key.bypassPermissionAgents) ?? [])
+        agentArguments = store.stringDictionary(Key.agentArguments) ?? [:]
         disabledAgents = Set(store.stringArray(Key.disabledAgents) ?? [])
         addedAgents = Set(store.stringArray(Key.addedAgents) ?? [])
         agentOrder = store.stringArray(Key.agentOrder) ?? []
@@ -657,20 +672,42 @@ final class AppSettings: ObservableObject {
 
     /// Effective command for an agent **on a machine**: the path authored for that
     /// machine if it's non-empty, otherwise the preset's built-in default (`nil`
-    /// for a plain login shell), with the permission-bypass flag appended when
-    /// that switch is on. The flag is only added if it isn't already present, so a
-    /// user who typed it into the path by hand doesn't get it twice.
+    /// for a plain login shell), then the user's own arguments, then the
+    /// permission-bypass flag when that switch is on. The flag is only added if it
+    /// isn't already present anywhere in the line, so a user who typed it into the
+    /// path or the arguments by hand doesn't get it twice.
     ///
-    /// The path is per-machine and the bypass switch is not: where a CLI lives is
-    /// a fact about a box, while running an agent without its prompts is a
-    /// standing decision about that agent (RFC §The model).
+    /// The path is per-machine and the other two are not: where a CLI lives is a
+    /// fact about a box, while how you want the agent to run is a standing
+    /// decision about that agent (RFC §The model).
     func command(for agent: AgentPreset, on device: KnownDevice = .thisMac) -> String? {
         let authored = commandPath(for: agent, on: device)
         let base = (authored?.isEmpty == false ? authored : agent.command)
         guard let base else { return nil }
+        var command = base
+        if let extra = arguments(for: agent) {
+            command += " \(extra)"
+        }
         guard bypassesPermissions(agent), let flag = agent.permissionBypassFlag,
-              !base.contains(flag) else { return base }
-        return "\(base) \(flag)"
+              !command.contains(flag) else { return command }
+        return "\(command) \(flag)"
+    }
+
+    /// The arguments the user authored for this agent, or `nil` when they never
+    /// set any — the same empty-means-unset rule the command path follows, which
+    /// is what keeps a cleared field out of `settings.json`.
+    func arguments(for agent: AgentPreset) -> String? {
+        let authored = agentArguments[agent.rawValue]?.trimmingCharacters(in: .whitespaces)
+        return authored?.isEmpty == false ? authored : nil
+    }
+
+    func setArguments(_ arguments: String?, for agent: AgentPreset) {
+        let trimmed = arguments?.trimmingCharacters(in: .whitespaces)
+        if let trimmed, !trimmed.isEmpty {
+            agentArguments[agent.rawValue] = trimmed
+        } else {
+            agentArguments.removeValue(forKey: agent.rawValue)
+        }
     }
 
     /// The command path the user authored for this agent on this machine, before

--- a/Tests/Fixtures/agent-manifests/expected.json
+++ b/Tests/Fixtures/agent-manifests/expected.json
@@ -782,7 +782,7 @@
       "id": "opencode",
       "installURL": "https://opencode.ai",
       "order": 30,
-      "permissionBypassFlag": null,
+      "permissionBypassFlag": "--auto",
       "resume": {
         "create": null,
         "discover": {

--- a/Tests/termioTests/AgentLaunchCommandTests.swift
+++ b/Tests/termioTests/AgentLaunchCommandTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import termio
+
+/// How the pieces a user authors become one command line.
+///
+/// `AppSettings.command(for:on:)` splices three separately-edited things — the
+/// machine's path, the agent's arguments, the bypass switch — into a single
+/// string that is later handed to `zsh -ilc`. The order they land in and the
+/// rule that a flag is never added twice are the parts a caller cannot see.
+@MainActor
+final class AgentLaunchCommandTests: XCTestCase {
+
+    private func settings() -> AppSettings {
+        let suite = "agent-launch-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite) ?? .standard
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(suite).json")
+        return AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(defaults: defaults, fileURL: file, domainName: nil))
+    }
+
+    func testArgumentsFollowThePathAndPrecedeTheBypassFlag() {
+        let settings = settings()
+        settings.setArguments("--model opus", for: .claudeCode)
+        settings.setBypassPermissions(.claudeCode, enabled: true)
+
+        XCTAssertEqual(
+            settings.command(for: .claudeCode),
+            "claude --model opus --dangerously-skip-permissions")
+    }
+
+    func testAFlagTypedIntoTheArgumentsIsNotAddedTwice() {
+        // The same rule the command path already had: the switch tops the line up
+        // to the flag rather than appending it unconditionally, so a user who
+        // reached for the field before finding the switch doesn't get both.
+        let settings = settings()
+        settings.setArguments("--dangerously-skip-permissions", for: .claudeCode)
+        settings.setBypassPermissions(.claudeCode, enabled: true)
+
+        XCTAssertEqual(settings.command(for: .claudeCode),
+                       "claude --dangerously-skip-permissions")
+    }
+
+    func testArgumentsApplyToEveryMachineWhilePathsDoNot() {
+        // The scope split this setting exists for: how you want the agent to run
+        // travels with the agent, where it lives is a fact about a box.
+        let settings = settings()
+        let vps = KnownDevice(alias: "vps", deviceID: "h_1")
+        settings.setCommandPath("/opt/bin/codex", for: .codex, on: vps)
+        settings.setArguments("--sandbox danger-full-access", for: .codex)
+
+        XCTAssertEqual(settings.command(for: .codex, on: vps),
+                       "/opt/bin/codex --sandbox danger-full-access")
+        XCTAssertEqual(settings.command(for: .codex),
+                       "codex --sandbox danger-full-access")
+    }
+
+    func testAnEmptiedFieldLeavesNothingBehind() {
+        // An emptied field must hand the agent back to its default rather than
+        // storing "" — the rule that keeps a cleared preference out of the file.
+        let settings = settings()
+        settings.setArguments("--model opus", for: .claudeCode)
+        settings.setArguments("   ", for: .claudeCode)
+
+        XCTAssertNil(settings.arguments(for: .claudeCode))
+        XCTAssertTrue(settings.agentArguments.isEmpty)
+        XCTAssertEqual(settings.command(for: .claudeCode), "claude")
+    }
+
+    func testOpenCodeCanSkipItsPromptsFromTheSwitchAlone() {
+        // The reason issue #577 was filed: OpenCode's manifest carried no bypass
+        // flag, so the switch it needed was not on its pane at all.
+        XCTAssertEqual(AgentPreset.opencode.permissionBypassFlag, "--auto")
+
+        let settings = settings()
+        settings.setBypassPermissions(.opencode, enabled: true)
+        XCTAssertEqual(settings.command(for: .opencode), "opencode --auto")
+    }
+}


### PR DESCRIPTION
Starting an agent in a non-default mode meant typing the flag into the per-machine command path, which is the wrong scope: the path names where a CLI lives on one box, while wanting `--model opus` or a permission bypass is a standing decision about the agent, true on every machine.

Settings ▸ Agents ▸ *agent* ▸ Launch gains an **Arguments** field, held once for the app next to the bypass switch. `command(for:on:)` splices it between the path and the bypass flag, and the existing "don't add the flag twice" rule now covers the whole line, so reaching for the field before finding the switch is safe.

OpenCode also gains the `permissionBypassFlag` it was missing — `--auto`, the documented spelling of what its hidden `--yolo` alias does — so its **Skip permission prompts** switch appears at all. That alone is what issue #577 asked for; the Arguments field is the general form of it.

Closes #577

## Testing

- `swift build`, `swift test` (959 tests, 0 failures)
- New `AgentLaunchCommandTests`: argument order, the no-double-flag rule, arguments crossing machines while paths don't, an emptied field leaving nothing in `settings.json`, and OpenCode's switch composing `opencode --auto`
- `--auto` verified against opencode 1.17.20 on both `opencode` and `opencode run`
- Agent-manifest fixture regenerated from the Rust parser, so both parsers still agree

Release Notes:
- Each agent now has a Startup **Arguments** field in Settings ▸ Agents, passed on every session it starts.
- OpenCode can now skip its permission prompts from the **Skip permission prompts** switch.