### PR TITLE
Size a session to the device being used

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import CoreGraphics
 
 /// The termiod Session Protocol codec (v0.1, see termiod/src/protocol.rs) —
 /// framing, control payloads, and the encode/decode tables, with nothing that
@@ -1984,12 +1985,43 @@ extension Termiod {
 /// A terminal grid. A named pair rather than a tuple so "is the PTY already
 /// this size?" is one comparison the compiler checks, on a path where getting
 /// it wrong costs every viewer a repaint.
-public struct TerminalGrid: Equatable, Sendable {
+public struct TerminalGrid: Equatable, Sendable, Codable {
     public let rows: UInt16
     public let cols: UInt16
 
     public init(rows: UInt16, cols: UInt16) {
         self.rows = rows
         self.cols = cols
+    }
+
+    /// How many whole cells a rectangle of this size can show — a client's
+    /// *viewport*, the thing the host sizes sessions by.
+    ///
+    /// libghostty's own arithmetic, deliberately: floor of the space left after
+    /// padding on both sides (`renderer/size.zig`, `GridSize.update`). A client
+    /// measuring its viewport differently would declare a grid its own surface
+    /// then disagrees with by a column, and the pane would letterbox against
+    /// itself forever.
+    ///
+    /// Both clients must use this one function rather than each keeping its own
+    /// copy: the Mac pane and the phone's terminal host both have to answer "how
+    /// much could I show" the same way, because a session moves between them
+    /// (`docs/design/20260901-pty-size-is-not-the-write-token.md` §6.1).
+    ///
+    /// `nil` is no viewport at all — a window that has not laid out, a cell size
+    /// that is not there yet, or a rectangle too small for one cell. The host
+    /// counts that for nobody rather than treating it as a stand-in.
+    public static func fitting(
+        _ size: CGSize, cell: CGSize, paddingX: CGFloat, paddingY: CGFloat
+    ) -> TerminalGrid? {
+        guard cell.width > 0, cell.height > 0 else { return nil }
+        let cols = ((size.width - 2 * paddingX) / cell.width).rounded(.down)
+        let rows = ((size.height - 2 * paddingY) / cell.height).rounded(.down)
+        // A pane mid-teardown reports zero, and a NaN cell size would otherwise
+        // trap on the way to `UInt16`.
+        guard cols.isFinite, rows.isFinite, cols >= 1, rows >= 1 else { return nil }
+        return TerminalGrid(
+            rows: UInt16(clamping: Int(min(rows, 10_000))),
+            cols: UInt16(clamping: Int(min(cols, 10_000))))
     }
 }

--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -112,18 +112,26 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     ///
     /// This is a *viewport* declaration, not a claim on the session: the Mac
     /// forwards it as its bridge attachment's own viewport, and the daemon sizes
-    /// the session to the smallest viewport being rendered. The bridge is a byte
+    /// the session to the screen a person is in front of. The bridge is a byte
     /// forwarder with no surface of its own — its viewport is this client's, and
     /// this message is the only thing that gives it one.
     ///
     /// `rendering` is false when the client has the session open but is not
     /// showing it (a parked screen the phone navigated away from). Omitted by
     /// clients built before the field, which is read as showing.
-    case resize(cols: Int, rows: Int, rendering: Bool)
-    /// The PTY's actual grid and whether this client is the one sizing it.
-    /// Sent on attach and every time either changes, so a client that is only
-    /// watching can lay its surface out at the grid the bytes are wrapped for
-    /// instead of its own window.
+    ///
+    /// `surface` is the grid the client's surface is actually laid out at, which
+    /// is *not* the viewport whenever the client is showing a session bigger
+    /// than its screen: it lays out at the session's grid and scales, so the
+    /// bytes are parsed the way every other viewer parses them. Two facts, two
+    /// fields — a client that declared the grid it had been shrunk to could
+    /// never say it had room for more. Absent means the surface fills the
+    /// screen, which is what every client built before the field means.
+    case resize(cols: Int, rows: Int, rendering: Bool, surface: TerminalGrid?)
+    /// The PTY's actual grid and whether this client holds the write token.
+    /// Sent on attach and every time either changes, so a client that is not the
+    /// one the session is sized to can lay its surface out at the grid the bytes
+    /// are wrapped for instead of at its own window.
     case grid(cols: Int, rows: Int, writer: Bool)
     /// The remote process exited.
     case exit(code: Int32)
@@ -228,8 +236,15 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             return Self.json(fields)
         case .stop(let sessionID):
             return #"{"t":"stop","session":"\#(sessionID)"}"#
-        case .resize(let cols, let rows, let rendering):
-            return #"{"t":"resize","cols":\#(cols),"rows":\#(rows),"rendering":\#(rendering)}"#
+        case .resize(let cols, let rows, let rendering, let surface):
+            var fields: [String: Any] = [
+                "t": "resize", "cols": cols, "rows": rows, "rendering": rendering,
+            ]
+            if let surface {
+                fields["surfaceCols"] = Int(surface.cols)
+                fields["surfaceRows"] = Int(surface.rows)
+            }
+            return Self.json(fields)
         case .grid(let cols, let rows, let writer):
             return #"{"t":"grid","cols":\#(cols),"rows":\#(rows),"writer":\#(writer)}"#
         case .exit(let code):
@@ -353,9 +368,17 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             return .stop(sessionID: sessionID)
         case "resize":
             guard let cols = obj["cols"] as? Int, let rows = obj["rows"] as? Int else { return nil }
+            var surface: TerminalGrid?
+            if let surfaceCols = obj["surfaceCols"] as? Int,
+               let surfaceRows = obj["surfaceRows"] as? Int {
+                surface = TerminalGrid(
+                    rows: UInt16(clamping: surfaceRows), cols: UInt16(clamping: surfaceCols))
+            }
             // Missing = showing, which is what every phone built before the
             // field means by sending a grid at all.
-            return .resize(cols: cols, rows: rows, rendering: obj["rendering"] as? Bool ?? true)
+            return .resize(
+                cols: cols, rows: rows, rendering: obj["rendering"] as? Bool ?? true,
+                surface: surface)
         case "grid":
             guard let cols = obj["cols"] as? Int, let rows = obj["rows"] as? Int,
                   let writer = obj["writer"] as? Bool else { return nil }

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -503,12 +503,13 @@ final class CompanionServer {
             if !stopSession(sessionID) {
                 sendControl(.error(message: "unknown session — pull the list to refresh"), to: connection)
             }
-        case .resize(let cols, let rows, let rendering):
+        case .resize(let cols, let rows, let rendering, let surface):
             // The phone reports its grid on attach, foreground, and layout.
             // A report is a fact about the phone's screen, not a claim on the
-            // session: the daemon sizes the session to the smallest viewport
-            // being rendered, and the write token is a separate question.
-            bridges[id]?.applyClientViewport(cols: cols, rows: rows, rendering: rendering)
+            // session: the daemon sizes the session to the screen someone is in
+            // front of, and the write token is a separate question.
+            bridges[id]?.applyClientViewport(
+                cols: cols, rows: rows, rendering: rendering, surface: surface)
         case .listFiles(let projectID, let path):
             handleListFiles(projectID: projectID, path: path, on: connection)
         case .readFile(let projectID, let path, let dark):
@@ -1104,14 +1105,17 @@ final class SessionBridge: @unchecked Sendable {
     /// stand-in grid would size the session for a screen nobody is looking at.
     /// The phone downstream of it is the surface, and this is where the bridge
     /// borrows its viewport — including whether it is being shown at all.
-    func applyClientViewport(cols: Int, rows: Int, rendering: Bool) {
+    func applyClientViewport(cols: Int, rows: Int, rendering: Bool, surface: TerminalGrid?) {
         link.setViewport(rows: rows, cols: cols)
         link.setRendering(rendering)
-        // The phone's surface fills its screen — it never letterboxes — so the
-        // viewport it declares is also the grid it is laid out at. That is the
-        // fact the repaint arming needs, and on a bridge there is no local
-        // surface to hear it from.
-        link.noteSurfaceGrid(rows: rows, cols: cols)
+        // The grid the phone's surface is laid out at, which is the session's
+        // rather than the phone's whenever the phone is watching a screen bigger
+        // than itself. That is the fact the repaint arming needs, and a bridge
+        // has no local surface to hear it from. A client that sends no surface
+        // grid fills its screen with the session, so the two are the same.
+        let laidOut = surface ?? TerminalGrid(
+            rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+        link.noteSurfaceGrid(rows: Int(laidOut.rows), cols: Int(laidOut.cols))
     }
 
     private func publishGrid(grid: TerminalGrid? = nil, writer: Bool? = nil) {
@@ -1213,7 +1217,13 @@ extension TermioStore {
         // daemon. The spec below is therefore never used to create anything —
         // `attach` resolves the name first — so it carries nothing.
         guard termiodLinks[session.id] != nil else { return nil }
-        return makeTermiodLink(for: session, argv: [], cwd: "", env: [:])
+        // No viewport of its own: a bridge is a byte forwarder with no surface,
+        // and a stand-in grid here would size the session for a screen nobody is
+        // looking at — this Mac's own last grid, at the moment the phone opened
+        // it. The phone's first `resize` is where the bridge borrows one (§5.4).
+        return makeTermiodLink(
+            for: session, argv: [], cwd: "", env: [:],
+            viewport: TerminalGrid(rows: 0, cols: 0))
     }
 
     /// Create a session in a project for a phone `start` request — the same

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -454,8 +454,13 @@ private struct SharedGridLetterbox<Content: View>: View {
         // remount its NSView, which is the repaint this file exists to avoid. A
         // nil frame dimension is "no constraint", so the surface fills the pane.
         let size = letterboxSize
-        let fits = size.map { $0.width <= paneSize.width && $0.height <= paneSize.height } ?? true
-        ZStack(alignment: fits ? .center : .topLeading) {
+        // Always anchored, never centred. A centred island moves as the pane
+        // grows, so a window drag slid the text around inside it before
+        // snapping — the shake. Anchoring is also what every multiplexer does
+        // with the space it cannot fill: tmux pads to the right and bottom,
+        // screen leaves it blank. The text stays exactly where it is and only
+        // the empty area changes.
+        ZStack(alignment: .topLeading) {
             background
             content()
                 .frame(width: size?.width, height: size?.height)
@@ -493,8 +498,7 @@ private struct SharedGridLetterbox<Content: View>: View {
         // A pane already the session's size fills the pane exactly, with none of
         // the half-cell slack a letterbox needs, so the common case looks the
         // way it always did.
-        guard !runtime.viewportPending,
-              let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
+        guard let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
         else { return nil }
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)
         let width = CGFloat(grid.cols) * cell.width + 2 * paddingX + cell.width / 2

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -498,7 +498,8 @@ private struct SharedGridLetterbox<Content: View>: View {
         // A pane already the session's size fills the pane exactly, with none of
         // the half-cell slack a letterbox needs, so the common case looks the
         // way it always did.
-        guard let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
+        guard !runtime.viewportPending,
+              let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
         else { return nil }
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)
         let width = CGFloat(grid.cols) * cell.width + 2 * paddingX + cell.width / 2

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -498,7 +498,7 @@ private struct SharedGridLetterbox<Content: View>: View {
         // A pane already the session's size fills the pane exactly, with none of
         // the half-cell slack a letterbox needs, so the common case looks the
         // way it always did.
-        guard !runtime.viewportPending,
+        guard runtime.sizesByPolicy, !runtime.viewportPending,
               let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
         else { return nil }
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -493,7 +493,8 @@ private struct SharedGridLetterbox<Content: View>: View {
         // A pane already the session's size fills the pane exactly, with none of
         // the half-cell slack a letterbox needs, so the common case looks the
         // way it always did.
-        guard let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
+        guard !runtime.viewportPending,
+              let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
         else { return nil }
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)
         let width = CGFloat(grid.cols) * cell.width + 2 * paddingX + cell.width / 2

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -412,15 +412,15 @@ private enum TerminalFocusReason {
 /// Lays a surface out at the grid another device is sizing the session to.
 ///
 /// One PTY has one winsize, and every attachment parses the same bytes. The
-/// daemon sizes the session to the smallest viewport being rendered, so while a
-/// phone is watching, those bytes are wrapped for the phone's grid — and a
-/// surface stretched across this pane would re-wrap them at its own width, the
-/// §C.5 divergence: every line that wrapped on the phone lands somewhere else
-/// here, and a TUI that repaints incrementally never repairs it. So a pane
-/// larger than the session shows it at exactly the shared grid, centred, with
-/// the terminal background around it — the same picture the phone has, at the
-/// Mac's font. The phone leaves, the session springs back, and the surface
-/// returns to the pane.
+/// daemon sizes the session to the screen a person is in front of, so while
+/// somebody is working on the phone those bytes are wrapped for the phone's
+/// grid — and a surface stretched across this pane would re-wrap them at its own
+/// width, the §C.5 divergence: every line that wrapped on the phone lands
+/// somewhere else here, and a TUI that repaints incrementally never repairs it.
+/// So a pane larger than the session shows it at exactly the shared grid,
+/// centred, with the terminal background around it — the same picture the phone
+/// has, at the Mac's font. Typing here, or resizing this pane, brings the
+/// session back and the surface returns to the pane.
 ///
 /// This is also where the pane states its *viewport* — how much it could show,
 /// measured from its own geometry. The surface cannot answer that question once
@@ -469,20 +469,14 @@ private struct SharedGridLetterbox<Content: View>: View {
         }
     }
 
-    /// How much this pane could show: libghostty's own floor of the space left
-    /// after padding, so the number matches what the surface would report if it
-    /// were filling the pane rather than sitting at the shared grid.
+    /// How much this pane could show. `TerminalGrid.fitting` is libghostty's own
+    /// floor, shared with the phone so both clients answer the question the same
+    /// way — the session moves between them.
     private var paneGrid: TerminalGrid? {
         guard let cell = cellSize else { return nil }
-        let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)
-        let cols = ((paneSize.width - 2 * paddingX) / cell.width).rounded(.down)
-        let rows = ((paneSize.height - 2 * paddingY) / cell.height).rounded(.down)
-        // A pane mid-teardown reports zero, and a NaN cell size would otherwise
-        // trap on the way to `UInt16`.
-        guard cols.isFinite, rows.isFinite, cols >= 1, rows >= 1 else { return nil }
-        return TerminalGrid(
-            rows: UInt16(clamping: Int(min(rows, 10_000))),
-            cols: UInt16(clamping: Int(min(cols, 10_000))))
+        return TerminalGrid.fitting(
+            paneSize, cell: cell, paddingX: paddingX,
+            paddingY: CGFloat(TermioStore.terminalWindowPaddingY))
     }
 
     /// The size a surface at the shared grid takes, or nil to fill the pane.

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -157,9 +157,6 @@ extension TermioStore {
         link.onStartRefused = { [weak self, weak inMemory] message in
             self?.applyTermiodStartRefused(for: session.id, message: message, surface: inMemory)
         }
-        link.onViewportPending = { [weak self] pending in
-            self?.runtime(for: session.id).viewportPending = pending
-        }
         link.onConnectionLost = { [weak self, weak inMemory] in
             self?.applyTermiodConnectionLost(for: session.id, surface: inMemory)
         }

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -157,6 +157,9 @@ extension TermioStore {
         link.onStartRefused = { [weak self, weak inMemory] message in
             self?.applyTermiodStartRefused(for: session.id, message: message, surface: inMemory)
         }
+        link.onSizesByPolicy = { [weak self] byPolicy in
+            self?.runtime(for: session.id).sizesByPolicy = byPolicy
+        }
         link.onViewportPending = { [weak self] pending in
             self?.runtime(for: session.id).viewportPending = pending
         }

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -157,6 +157,9 @@ extension TermioStore {
         link.onStartRefused = { [weak self, weak inMemory] message in
             self?.applyTermiodStartRefused(for: session.id, message: message, surface: inMemory)
         }
+        link.onViewportPending = { [weak self] pending in
+            self?.runtime(for: session.id).viewportPending = pending
+        }
         link.onConnectionLost = { [weak self, weak inMemory] in
             self?.applyTermiodConnectionLost(for: session.id, surface: inMemory)
         }

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -13,8 +13,13 @@ extension TermioStore {
     /// `create_if_missing` resolves the name first, so a session that survived
     /// the last app quit is rejoined — same process, same pid — and only a
     /// session with no live counterpart spawns fresh.
+    /// `viewport` is this attachment's opening declaration — how much of the
+    /// session the screen behind it could show. A pane's own geometry replaces
+    /// it on the first layout pass; a relay with no screen of its own passes a
+    /// zero, which the daemon reads as "no viewport at all" and never sizes by.
     func makeTermiodLink(for session: Session, argv: [String], cwd: String,
-                         env: [String: String]) -> TermiodSessionLink {
+                         env: [String: String],
+                         viewport: TerminalGrid? = nil) -> TermiodSessionLink {
         // The session is the only source of truth for where it runs. There used
         // to be a `TERMIO_TERMIOD_REMOTE` fallback here from before the picker
         // existed, but it silently turned *every* session without an explicit
@@ -41,14 +46,16 @@ extension TermioStore {
                 env: Self.presentationEnvironment(from: env),
                 rows: UInt16(clamping: lastHostGridRows),
                 cols: UInt16(clamping: lastHostGridColumns))
+        let opening = viewport ?? TerminalGrid(
+            rows: UInt16(clamping: lastHostGridRows), cols: UInt16(clamping: lastHostGridColumns))
         return TermiodSessionLink(
             // Its uuid for a session Termio opened; the name it already had for
             // one adopted off the device's roster (see `Session.termiodSessionName`).
             sessionName: daemonSessionName(for: session),
             specification: specification,
             route: route,
-            rows: lastHostGridRows,
-            cols: lastHostGridColumns
+            rows: Int(opening.rows),
+            cols: Int(opening.cols)
         )
     }
 
@@ -164,17 +171,16 @@ extension TermioStore {
     }
 
     /// How much of a session this pane could show, measured from the pane
-    /// itself. The daemon sizes the session to the smallest viewport currently
-    /// rendering it, so this is the Mac's whole say in the matter — the write
-    /// token has none.
+    /// itself. The daemon sizes the session to the viewport of the screen being
+    /// used, and a pane that just changed shape is one somebody has their hands
+    /// on — so this is both the Mac's declaration and its claim to the size.
     func reportViewport(_ grid: TerminalGrid, for id: Session.ID) {
         termiodLinks[id]?.setViewport(rows: Int(grid.rows), cols: Int(grid.cols))
     }
 
     /// Whether this pane is on screen. A hidden pane keeps its viewport and
-    /// stops counting, so a window left open on another workspace does not hold
-    /// every session it has a pane for down to its own width — zellij's rule for
-    /// tabs nobody is looking at.
+    /// stops counting, so a window left open on another workspace never sizes a
+    /// session nobody is looking at there — zellij's rule for unviewed tabs.
     func reportRendering(_ showing: Bool, for id: Session.ID) {
         termiodLinks[id]?.setRendering(showing)
     }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1086,6 +1086,10 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The grid libghostty says this surface is actually laid out at. Read only
     /// by the repaint arming below — it is never what goes on the wire.
     private var surfaceGrid: TerminalGrid
+    /// Whether a viewport change of this pane's own is still unanswered, and the
+    /// stamp that lets only the newest one lower it. See `onViewportPending`.
+    private var viewportPending = false
+    private var viewportPendingGeneration: UInt64 = 0
     /// Whether the daemon said it sizes sessions by policy. Without it this is
     /// an older host that reads `R` as "set the PTY size", and the five-byte
     /// form it has never seen would drop the connection.
@@ -1205,6 +1209,12 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// grid the bytes are wrapped for, and the surface that shows them has to
     /// be laid out at it — see `SessionRuntime.sharedGrid`.
     var onSharedGrid: ((TerminalGrid) -> Void)?
+    /// Raised the moment this pane declares a new viewport and lowered when the
+    /// daemon's grid agrees — or when it plainly is not going to, because
+    /// somebody else is using the session. While it is up the pane's surface
+    /// follows the pane rather than the session, so the keyframe that follows
+    /// the resize lands on a surface that is already the right size.
+    var onViewportPending: ((Bool) -> Void)?
 
     init(sessionName: String,
          specification: Termiod.CreateSpecification,
@@ -1425,6 +1435,7 @@ final class TermiodSessionLink: @unchecked Sendable {
             guard !closed, viewportGrid != size else { return }
             viewportGrid = size
             guard attached else { return }
+            raiseViewportPendingLocked()
             scheduleViewportLocked()
         }
     }
@@ -1471,6 +1482,34 @@ final class TermiodSessionLink: @unchecked Sendable {
                 requestResyncLocked()
             }
         }
+    }
+
+    /// How long a declaration is treated as in flight before the pane accepts
+    /// that the session belongs to another screen. Long enough for the coalesced
+    /// send plus a local round trip, short enough that a pane watching a phone
+    /// lays its surface out at the phone's grid rather than sitting stretched
+    /// over bytes wrapped for it.
+    private static let viewportSettleDeadline = DispatchTimeInterval.milliseconds(600)
+
+    /// Must run on `workQueue`.
+    private func raiseViewportPendingLocked() {
+        viewportPendingGeneration &+= 1
+        let generation = viewportPendingGeneration
+        if !viewportPending {
+            viewportPending = true
+            DispatchQueue.main.async { [self] in onViewportPending?(true) }
+        }
+        workQueue.asyncAfter(deadline: .now() + Self.viewportSettleDeadline) { [self] in
+            guard !closed, generation == viewportPendingGeneration else { return }
+            lowerViewportPendingLocked()
+        }
+    }
+
+    /// Must run on `workQueue`.
+    private func lowerViewportPendingLocked() {
+        guard viewportPending else { return }
+        viewportPending = false
+        DispatchQueue.main.async { [self] in onViewportPending?(false) }
     }
 
     /// How long a moving pane must hold still before its size goes to the
@@ -1915,6 +1954,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
+            if grid == viewportGrid { lowerViewportPendingLocked() }
             Log.termiod.debug("""
             resize-trace session-is \(grid.rows, privacy: .public)x\
             \(grid.cols, privacy: .public)

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1083,9 +1083,6 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The last viewport actually written as an `R` frame, so an unchanged
     /// declaration isn't re-sent while the daemon is still applying the first.
     private var sentViewport: (grid: TerminalGrid, rendering: Bool)?
-    /// Bumped by every viewport change; only the newest scheduled send may write
-    /// its frame. See `scheduleViewportLocked`.
-    private var viewportGeneration: UInt64 = 0
     /// The grid libghostty says this surface is actually laid out at. Read only
     /// by the repaint arming below — it is never what goes on the wire.
     private var surfaceGrid: TerminalGrid
@@ -1104,8 +1101,8 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// keyframe, and that one paints right.
     ///
     /// Not gated on the write token any more. Under a size policy the writer's
-    /// own surface is letterboxed too whenever somebody smaller is looking, and
-    /// it needs the same repaint the observer always did.
+    /// own surface is letterboxed too whenever the session is sized to another
+    /// screen, and it needs the same repaint the observer always did.
     private var repaintPending = false
     /// Set on any deliberate teardown so the reader's EOF is not misread as a
     /// daemon crash.
@@ -1417,8 +1414,10 @@ final class TermiodSessionLink: @unchecked Sendable {
     ///
     /// Measured from the pane, not read back off the surface, and sent whether
     /// or not this client holds the write token. The daemon sizes the session to
-    /// the smallest viewport being rendered; who may type is a separate question
-    /// and asking it here is what used to turn a stray byte into a resize loop
+    /// the viewport of whichever screen someone is in front of, and a pane that
+    /// just changed shape is one somebody has their hands on. Who may *type* is
+    /// a separate question, and answering it here is what used to turn a stray
+    /// byte into a resize loop
     /// (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
     func setViewport(rows: Int, cols: Int) {
         let size = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
@@ -1467,27 +1466,41 @@ final class TermiodSessionLink: @unchecked Sendable {
         }
     }
 
-    /// How long the viewport must hold still before it goes to the daemon.
-    /// The same 50ms `PTYProcess.resizeFromHost` coalesces on, and for a
-    /// sharper reason here: on the in-process path an intermediate size costs a
-    /// SIGWINCH, while on this one a viewport that moves the session is a
-    /// host-side **barrier** — the session quiesces, resizes, and pushes a fresh
-    /// keyframe to every attachment. A live drag or a settling split emits a
-    /// burst of them, and each keyframe is a full repaint racing the child's own
+    /// How often a moving pane may move the session, at most.
+    ///
+    /// Twice ghostty's 25ms (`termio/Thread.zig`), because a viewport that moves
+    /// the session costs more here: on the in-process path an intermediate size
+    /// is a SIGWINCH, while on this one it is a host-side **barrier** — the
+    /// session quiesces, resizes, and pushes a fresh keyframe to every
+    /// attachment, and each keyframe is a full repaint racing the child's own
     /// redraw.
     private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(50)
 
-    /// Sends the viewport once the pane stops moving. Generation-stamped rather
-    /// than debounced with a cancellable work item because the size is re-read
-    /// at fire time: the last scheduled send is the only one that writes, and it
-    /// writes whatever the pane settled at.
+    /// Whether a flush is already on the queue. The window is not extended by
+    /// later changes — see `scheduleViewportLocked`.
+    private var viewportFlushScheduled = false
+
+    /// Flushes the viewport on a fixed cadence while the pane is moving, rather
+    /// than waiting for it to stop.
+    ///
+    /// This is ghostty's coalescer, not a debounce: the first change opens a
+    /// window, changes inside it only update the value, and the flush at the end
+    /// sends whatever the pane is at *then*. A drag therefore reflows the child
+    /// every 50ms while it is happening. The trailing debounce this replaced
+    /// re-armed its deadline on every change, so a continuous drag — the case it
+    /// most needed to serve — sent nothing at all until the pane held still, and
+    /// the terminal only caught up after the mouse came up.
+    ///
+    /// The tail is not lost: a change either finds no flush scheduled and opens
+    /// a window, or finds one that has not fired and will read the newer value.
     ///
     /// Must run on `workQueue`.
     private func scheduleViewportLocked() {
-        viewportGeneration &+= 1
-        let generation = viewportGeneration
+        guard !viewportFlushScheduled else { return }
+        viewportFlushScheduled = true
         workQueue.asyncAfter(deadline: .now() + Self.viewportCoalescingInterval) { [self] in
-            guard !closed, attached, generation == viewportGeneration else { return }
+            viewportFlushScheduled = false
+            guard !closed, attached else { return }
             do {
                 try sendViewportLocked()
             } catch {
@@ -1864,8 +1877,8 @@ final class TermiodSessionLink: @unchecked Sendable {
         }
     }
 
-    /// Records the PTY's real size — the smallest viewport currently rendering
-    /// this session, which is what every attachment's bytes are wrapped for.
+    /// Records the PTY's real size — the viewport of the screen being used,
+    /// which is what every attachment's bytes are wrapped for.
     ///
     /// Only noted, never answered. A writer used to answer a divergence by
     /// putting its own size back, which is how two devices watching one session

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1455,7 +1455,14 @@ final class TermiodSessionLink: @unchecked Sendable {
         let size = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
         workQueue.async { [self] in
             guard !closed else { return }
+            let changed = surfaceGrid != size
             surfaceGrid = size
+            if changed {
+                Log.termiod.debug("""
+                resize-trace surface-at \(size.rows, privacy: .public)x\
+                \(size.cols, privacy: .public)
+                """)
+            }
             guard attached else { return }
             if authoritativeGrid != size {
                 repaintPending = true
@@ -1536,6 +1543,10 @@ final class TermiodSessionLink: @unchecked Sendable {
         let showing = hostSizesByPolicy ? rendering : true
         if let sent = sentViewport, sent.grid == viewportGrid, sent.rendering == showing { return }
         sentViewport = (viewportGrid, showing)
+        Log.termiod.debug("""
+        resize-trace declare \(self.viewportGrid.rows, privacy: .public)x\
+        \(self.viewportGrid.cols, privacy: .public) rendering=\(showing, privacy: .public)
+        """)
         try Termiod.writeFrame(
             transport.writeDescriptor, kind: .resize,
             payload: Termiod.viewportPayload(
@@ -1577,7 +1588,14 @@ final class TermiodSessionLink: @unchecked Sendable {
     }
 
     /// Must run on `workQueue`.
+    /// Trace only: a repaint was asked for because the surface reached the
+    /// session's grid with bytes parsed at another one behind it.
+    private func traceResync() {
+        Log.termiod.debug("resize-trace resync-requested")
+    }
+
     private func requestResyncLocked() {
+        traceResync()
         guard !closed, attached, let transport else { return }
         do {
             try Termiod.writeFrame(transport.writeDescriptor, kind: .control,
@@ -1897,6 +1915,10 @@ final class TermiodSessionLink: @unchecked Sendable {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
+            Log.termiod.debug("""
+            resize-trace session-is \(grid.rows, privacy: .public)x\
+            \(grid.cols, privacy: .public)
+            """)
             DispatchQueue.main.async { [self] in onSharedGrid?(grid) }
             repaintPending = grid != surfaceGrid
             guard grid != viewportGrid else { return }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1435,7 +1435,6 @@ final class TermiodSessionLink: @unchecked Sendable {
             guard !closed, viewportGrid != size else { return }
             viewportGrid = size
             guard attached else { return }
-            raiseViewportPendingLocked()
             scheduleViewportLocked()
         }
     }
@@ -1582,6 +1581,16 @@ final class TermiodSessionLink: @unchecked Sendable {
         let showing = hostSizesByPolicy ? rendering : true
         if let sent = sentViewport, sent.grid == viewportGrid, sent.rendering == showing { return }
         sentViewport = (viewportGrid, showing)
+        // From here the surface may lead: the declaration is on the wire, the
+        // daemon's answer and its keyframe are coming, and the pane knows the
+        // grid they will be at. Before here — a drag still in the coalescing
+        // window — it must not: the pane's grid is changing every frame while
+        // nothing new has been drawn at any of those widths, so a surface that
+        // followed it would re-wrap the old screen once per frame. That is the
+        // mess during a drag; the session's grid is the last width anything was
+        // actually drawn for, and holding the surface there is what tmux and
+        // screen show while a window moves.
+        raiseViewportPendingLocked()
         Log.termiod.debug("""
         resize-trace declare \(self.viewportGrid.rows, privacy: .public)x\
         \(self.viewportGrid.cols, privacy: .public) rendering=\(showing, privacy: .public)

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1083,6 +1083,10 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The last viewport actually written as an `R` frame, so an unchanged
     /// declaration isn't re-sent while the daemon is still applying the first.
     private var sentViewport: (grid: TerminalGrid, rendering: Bool)?
+    /// Whether a viewport change of this pane's own is still unanswered, and the
+    /// stamp that lets only the newest one lower it. See `onViewportPending`.
+    private var viewportPending = false
+    private var viewportPendingGeneration: UInt64 = 0
     /// The grid libghostty says this surface is actually laid out at. Read only
     /// by the repaint arming below — it is never what goes on the wire.
     private var surfaceGrid: TerminalGrid
@@ -1205,6 +1209,11 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// grid the bytes are wrapped for, and the surface that shows them has to
     /// be laid out at it — see `SessionRuntime.sharedGrid`.
     var onSharedGrid: ((TerminalGrid) -> Void)?
+    /// Raised the moment this pane declares a new viewport and lowered when the
+    /// daemon's grid agrees with it — or when it plainly is not going to,
+    /// because somebody else is using the session. The letterbox is suppressed
+    /// while it is up: a pane must not letterbox against its own pending resize.
+    var onViewportPending: ((Bool) -> Void)?
 
     init(sessionName: String,
          specification: Termiod.CreateSpecification,
@@ -1425,8 +1434,36 @@ final class TermiodSessionLink: @unchecked Sendable {
             guard !closed, viewportGrid != size else { return }
             viewportGrid = size
             guard attached else { return }
+            raiseViewportPendingLocked()
             scheduleViewportLocked()
         }
+    }
+
+    /// How long a declaration is treated as in flight before the pane accepts
+    /// that the session belongs to another screen. Long enough for the coalesced
+    /// send plus a local round trip, short enough that a pane watching a phone
+    /// letterboxes rather than sitting stretched over bytes wrapped for it.
+    private static let viewportSettleDeadline = DispatchTimeInterval.milliseconds(600)
+
+    /// Must run on `workQueue`.
+    private func raiseViewportPendingLocked() {
+        viewportPendingGeneration &+= 1
+        let generation = viewportPendingGeneration
+        if !viewportPending {
+            viewportPending = true
+            DispatchQueue.main.async { [self] in onViewportPending?(true) }
+        }
+        workQueue.asyncAfter(deadline: .now() + Self.viewportSettleDeadline) { [self] in
+            guard !closed, generation == viewportPendingGeneration else { return }
+            lowerViewportPendingLocked()
+        }
+    }
+
+    /// Must run on `workQueue`.
+    private func lowerViewportPendingLocked() {
+        guard viewportPending else { return }
+        viewportPending = false
+        DispatchQueue.main.async { [self] in onViewportPending?(false) }
     }
 
     /// Whether this pane is on screen. A hidden pane is not rendering and stops
@@ -1481,37 +1518,24 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// 180ms — and none of them are wrong about it.
     private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(150)
 
-    /// When the last declaration actually went out, so a change arriving after a
-    /// quiet spell can skip the wait. See `scheduleViewportLocked`.
-    private var lastViewportSend: DispatchTime?
     /// Bumped by every viewport change inside a burst; only the newest scheduled
     /// send may write its frame. See `scheduleViewportLocked`.
     private var viewportGeneration: UInt64 = 0
 
-    /// Sends the first change at once and the rest of a burst only once it ends.
+    /// Sends a burst's final size, once it stops.
     ///
-    /// The two cases a pane produces are genuinely different and this is what
-    /// tells them apart. A **discrete** change — collapsing the sidebar,
-    /// splitting, a font size — arrives alone after a quiet spell: there is
-    /// nothing to coalesce it with, and delaying it is pure lag, so it goes now.
-    /// A **drag** is a continuous stream: every intermediate size costs every
-    /// viewer a repaint and none of them is the one the user is asking for, so
-    /// the stream collapses to one send when it stops.
+    /// One barrier per drag, at the end, and deliberately not one at the start
+    /// as well: the pane's own surface follows the drag live (the letterbox
+    /// stands aside while this declaration is in flight), so an early barrier
+    /// buys nothing and costs every viewer a full-screen repaint at the moment
+    /// the drag begins — which is what it looked like.
     ///
-    /// The result is two barriers for a drag rather than one per 50ms, and no
-    /// wait at all for a toggle. The trailing half is generation-stamped rather
-    /// than cancelled because the size is re-read at fire time: the last
-    /// scheduled send is the only one that writes, and it writes whatever the
-    /// pane settled at.
+    /// Generation-stamped rather than cancelled because the size is re-read at
+    /// fire time: the last scheduled send is the only one that writes, and it
+    /// writes whatever the pane settled at.
     ///
     /// Must run on `workQueue`.
     private func scheduleViewportLocked() {
-        let now = DispatchTime.now()
-        let quiet = lastViewportSend.map { now >= $0 + Self.viewportCoalescingInterval } ?? true
-        if quiet {
-            flushViewportLocked()
-            return
-        }
         viewportGeneration &+= 1
         let generation = viewportGeneration
         workQueue.asyncAfter(deadline: .now() + Self.viewportCoalescingInterval) { [self] in
@@ -1522,7 +1546,6 @@ final class TermiodSessionLink: @unchecked Sendable {
 
     /// Must run on `workQueue`.
     private func flushViewportLocked() {
-        lastViewportSend = DispatchTime.now()
         do {
             try sendViewportLocked()
         } catch {
@@ -1911,6 +1934,10 @@ final class TermiodSessionLink: @unchecked Sendable {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
+            // The answer to this pane's own declaration: the letterbox can stop
+            // standing aside, and in the common case it has nothing to do
+            // anyway because the two grids now match.
+            if grid == viewportGrid { lowerViewportPendingLocked() }
             DispatchQueue.main.async { [self] in onSharedGrid?(grid) }
             repaintPending = grid != surfaceGrid
             guard grid != viewportGrid else { return }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1215,6 +1215,11 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// follows the pane rather than the session, so the keyframe that follows
     /// the resize lands on a surface that is already the right size.
     var onViewportPending: ((Bool) -> Void)?
+    /// Whether this session's host sizes by policy, from the handshake. A pane
+    /// on an older host must not letterbox: there the writer's grid is the
+    /// size, so a difference is an unanswered declaration rather than another
+    /// viewer, and pinning to it never resolves.
+    var onSizesByPolicy: ((Bool) -> Void)?
 
     init(sessionName: String,
          specification: Termiod.CreateSpecification,
@@ -1240,6 +1245,8 @@ final class TermiodSessionLink: @unchecked Sendable {
                     channel, role: "attach", caps: Termiod.attachCapabilities)
                 clientID = handshake.clientID
                 hostSizesByPolicy = handshake.capabilities.contains(Termiod.viewportCapability)
+                let sizesByPolicy = hostSizesByPolicy
+                DispatchQueue.main.async { [self] in onSizesByPolicy?(sizesByPolicy) }
                 let device = handshake.device
                 DispatchQueue.main.async { [self] in onDevice?(device) }
                 let requested = viewportGrid
@@ -1469,7 +1476,8 @@ final class TermiodSessionLink: @unchecked Sendable {
             surfaceGrid = size
             if changed {
                 Log.termiod.debug("""
-                resize-trace surface-at \(size.rows, privacy: .public)x\
+                resize-trace \(self.sessionName.prefix(8), privacy: .public) surface-at \
+                \(size.rows, privacy: .public)x\
                 \(size.cols, privacy: .public)
                 """)
             }
@@ -1592,7 +1600,8 @@ final class TermiodSessionLink: @unchecked Sendable {
         // screen show while a window moves.
         raiseViewportPendingLocked()
         Log.termiod.debug("""
-        resize-trace declare \(self.viewportGrid.rows, privacy: .public)x\
+        resize-trace \(self.sessionName.prefix(8), privacy: .public) declare \
+        \(self.viewportGrid.rows, privacy: .public)x\
         \(self.viewportGrid.cols, privacy: .public) rendering=\(showing, privacy: .public)
         """)
         try Termiod.writeFrame(
@@ -1639,7 +1648,9 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// Trace only: a repaint was asked for because the surface reached the
     /// session's grid with bytes parsed at another one behind it.
     private func traceResync() {
-        Log.termiod.debug("resize-trace resync-requested")
+        Log.termiod.debug("""
+        resize-trace \(self.sessionName.prefix(8), privacy: .public) resync-requested
+        """)
     }
 
     private func requestResyncLocked() {
@@ -1965,7 +1976,8 @@ final class TermiodSessionLink: @unchecked Sendable {
             authoritativeGrid = grid
             if grid == viewportGrid { lowerViewportPendingLocked() }
             Log.termiod.debug("""
-            resize-trace session-is \(grid.rows, privacy: .public)x\
+            resize-trace \(self.sessionName.prefix(8), privacy: .public) session-is \
+            \(grid.rows, privacy: .public)x\
             \(grid.cols, privacy: .public)
             """)
             DispatchQueue.main.async { [self] in onSharedGrid?(grid) }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1083,10 +1083,6 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The last viewport actually written as an `R` frame, so an unchanged
     /// declaration isn't re-sent while the daemon is still applying the first.
     private var sentViewport: (grid: TerminalGrid, rendering: Bool)?
-    /// Whether a viewport change of this pane's own is still unanswered, and the
-    /// stamp that lets only the newest one lower it. See `onViewportPending`.
-    private var viewportPending = false
-    private var viewportPendingGeneration: UInt64 = 0
     /// The grid libghostty says this surface is actually laid out at. Read only
     /// by the repaint arming below — it is never what goes on the wire.
     private var surfaceGrid: TerminalGrid
@@ -1209,11 +1205,6 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// grid the bytes are wrapped for, and the surface that shows them has to
     /// be laid out at it — see `SessionRuntime.sharedGrid`.
     var onSharedGrid: ((TerminalGrid) -> Void)?
-    /// Raised the moment this pane declares a new viewport and lowered when the
-    /// daemon's grid agrees with it — or when it plainly is not going to,
-    /// because somebody else is using the session. The letterbox is suppressed
-    /// while it is up: a pane must not letterbox against its own pending resize.
-    var onViewportPending: ((Bool) -> Void)?
 
     init(sessionName: String,
          specification: Termiod.CreateSpecification,
@@ -1434,36 +1425,8 @@ final class TermiodSessionLink: @unchecked Sendable {
             guard !closed, viewportGrid != size else { return }
             viewportGrid = size
             guard attached else { return }
-            raiseViewportPendingLocked()
             scheduleViewportLocked()
         }
-    }
-
-    /// How long a declaration is treated as in flight before the pane accepts
-    /// that the session belongs to another screen. Long enough for the coalesced
-    /// send plus a local round trip, short enough that a pane watching a phone
-    /// letterboxes rather than sitting stretched over bytes wrapped for it.
-    private static let viewportSettleDeadline = DispatchTimeInterval.milliseconds(600)
-
-    /// Must run on `workQueue`.
-    private func raiseViewportPendingLocked() {
-        viewportPendingGeneration &+= 1
-        let generation = viewportPendingGeneration
-        if !viewportPending {
-            viewportPending = true
-            DispatchQueue.main.async { [self] in onViewportPending?(true) }
-        }
-        workQueue.asyncAfter(deadline: .now() + Self.viewportSettleDeadline) { [self] in
-            guard !closed, generation == viewportPendingGeneration else { return }
-            lowerViewportPendingLocked()
-        }
-    }
-
-    /// Must run on `workQueue`.
-    private func lowerViewportPendingLocked() {
-        guard viewportPending else { return }
-        viewportPending = false
-        DispatchQueue.main.async { [self] in onViewportPending?(false) }
     }
 
     /// Whether this pane is on screen. A hidden pane is not rendering and stops
@@ -1934,10 +1897,6 @@ final class TermiodSessionLink: @unchecked Sendable {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
-            // The answer to this pane's own declaration: the letterbox can stop
-            // standing aside, and in the common case it has nothing to do
-            // anyway because the two grids now match.
-            if grid == viewportGrid { lowerViewportPendingLocked() }
             DispatchQueue.main.async { [self] in onSharedGrid?(grid) }
             repaintPending = grid != surfaceGrid
             guard grid != viewportGrid else { return }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1466,49 +1466,70 @@ final class TermiodSessionLink: @unchecked Sendable {
         }
     }
 
-    /// How often a moving pane may move the session, at most.
+    /// How long a moving pane must hold still before its size goes to the
+    /// daemon, and the shortest gap between two declarations.
     ///
-    /// Twice ghostty's 25ms (`termio/Thread.zig`), because a viewport that moves
-    /// the session costs more here: on the in-process path an intermediate size
-    /// is a SIGWINCH, while on this one it is a host-side **barrier** — the
-    /// session quiesces, resizes, and pushes a fresh keyframe to every
-    /// attachment, and each keyframe is a full repaint racing the child's own
-    /// redraw.
-    private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(50)
+    /// Not ghostty's 25ms, and deliberately: ghostty's resize is an ioctl on a
+    /// PTY it owns alone, while this one is a **barrier** — the session
+    /// quiesces, resizes, and pushes a fresh keyframe to every attachment. A
+    /// drag flushed on a cadence is therefore twenty full repaints a second
+    /// racing the child's own redraw, which is visible as the terminal shaking
+    /// and, when an agent TUI's incremental repaint loses that race, as rows
+    /// left behind at the width they were drawn at. Every multiplexer coalesces
+    /// harder than ghostty for this reason — tmux rate-limits a pane to one
+    /// resize per 250ms, zellij collapses a burst to its last, cmux debounces
+    /// 180ms — and none of them are wrong about it.
+    private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(150)
 
-    /// Whether a flush is already on the queue. The window is not extended by
-    /// later changes — see `scheduleViewportLocked`.
-    private var viewportFlushScheduled = false
+    /// When the last declaration actually went out, so a change arriving after a
+    /// quiet spell can skip the wait. See `scheduleViewportLocked`.
+    private var lastViewportSend: DispatchTime?
+    /// Bumped by every viewport change inside a burst; only the newest scheduled
+    /// send may write its frame. See `scheduleViewportLocked`.
+    private var viewportGeneration: UInt64 = 0
 
-    /// Flushes the viewport on a fixed cadence while the pane is moving, rather
-    /// than waiting for it to stop.
+    /// Sends the first change at once and the rest of a burst only once it ends.
     ///
-    /// This is ghostty's coalescer, not a debounce: the first change opens a
-    /// window, changes inside it only update the value, and the flush at the end
-    /// sends whatever the pane is at *then*. A drag therefore reflows the child
-    /// every 50ms while it is happening. The trailing debounce this replaced
-    /// re-armed its deadline on every change, so a continuous drag — the case it
-    /// most needed to serve — sent nothing at all until the pane held still, and
-    /// the terminal only caught up after the mouse came up.
+    /// The two cases a pane produces are genuinely different and this is what
+    /// tells them apart. A **discrete** change — collapsing the sidebar,
+    /// splitting, a font size — arrives alone after a quiet spell: there is
+    /// nothing to coalesce it with, and delaying it is pure lag, so it goes now.
+    /// A **drag** is a continuous stream: every intermediate size costs every
+    /// viewer a repaint and none of them is the one the user is asking for, so
+    /// the stream collapses to one send when it stops.
     ///
-    /// The tail is not lost: a change either finds no flush scheduled and opens
-    /// a window, or finds one that has not fired and will read the newer value.
+    /// The result is two barriers for a drag rather than one per 50ms, and no
+    /// wait at all for a toggle. The trailing half is generation-stamped rather
+    /// than cancelled because the size is re-read at fire time: the last
+    /// scheduled send is the only one that writes, and it writes whatever the
+    /// pane settled at.
     ///
     /// Must run on `workQueue`.
     private func scheduleViewportLocked() {
-        guard !viewportFlushScheduled else { return }
-        viewportFlushScheduled = true
+        let now = DispatchTime.now()
+        let quiet = lastViewportSend.map { now >= $0 + Self.viewportCoalescingInterval } ?? true
+        if quiet {
+            flushViewportLocked()
+            return
+        }
+        viewportGeneration &+= 1
+        let generation = viewportGeneration
         workQueue.asyncAfter(deadline: .now() + Self.viewportCoalescingInterval) { [self] in
-            viewportFlushScheduled = false
-            guard !closed, attached else { return }
-            do {
-                try sendViewportLocked()
-            } catch {
-                Log.termiod.error("""
-                viewport of \(self.sessionName, privacy: .public) failed: \
-                \(error.localizedDescription, privacy: .public)
-                """)
-            }
+            guard !closed, attached, generation == viewportGeneration else { return }
+            flushViewportLocked()
+        }
+    }
+
+    /// Must run on `workQueue`.
+    private func flushViewportLocked() {
+        lastViewportSend = DispatchTime.now()
+        do {
+            try sendViewportLocked()
+        } catch {
+            Log.termiod.error("""
+            viewport of \(self.sessionName, privacy: .public) failed: \
+            \(error.localizedDescription, privacy: .public)
+            """)
         }
     }
 

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -57,4 +57,13 @@ final class SessionRuntime {
     /// mangled and has to ask for another one. A surface that already moved
     /// paints it right the first time.
     var viewportPending = false
+    /// Whether the host this session lives on sizes by policy at all.
+    ///
+    /// The letterbox only means anything under that policy: it exists because
+    /// the session's grid can belong to another screen. An older daemon — a VPS
+    /// that has not been redeployed — reads a resize as "set the PTY size" from
+    /// the writer, so the pane's own grid *is* the session's, and a difference
+    /// between them is not another viewer, it is a declaration that host will
+    /// never answer. Pinning the surface to it freezes the terminal for good.
+    var sizesByPolicy = false
 }

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -37,12 +37,12 @@ final class SessionRuntime {
     /// foreground-demotion streak (RFC 20260830 §D2), cleared the moment the
     /// foreground stops being the shell or the agent reports working again.
     var agentExitNotice: String?
-    /// The PTY's real grid, from the daemon: the smallest viewport currently
-    /// rendering this session. The bytes on the wire are wrapped for it, and the
+    /// The PTY's real grid, from the daemon: the viewport of whichever screen a
+    /// person is in front of. The bytes on the wire are wrapped for it, and the
     /// only faithful way to show them is a surface laid out at it — letterboxed
     /// in the pane, not stretched to the window (§C.5 of the session protocol).
     /// Not read together with `isWriter` any more: under a size policy the pane
-    /// holding the write token is letterboxed too whenever somebody smaller is
-    /// looking at the same session.
+    /// holding the write token is letterboxed too whenever the session is sized
+    /// to somebody else's screen.
     var sharedGrid: TerminalGrid?
 }

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -45,4 +45,16 @@ final class SessionRuntime {
     /// holding the write token is letterboxed too whenever the session is sized
     /// to somebody else's screen.
     var sharedGrid: TerminalGrid?
+    /// Whether this pane's own viewport change is still in flight.
+    ///
+    /// The letterbox reads it, and it separates the two reasons the session's
+    /// grid can differ from the pane's. Somebody else is using the session on a
+    /// smaller screen: lay the surface out at their grid, or this pane re-wraps
+    /// bytes that were wrapped for theirs (§C.5). *This* pane was just resized:
+    /// let the surface follow the pane. It is about to be granted, and the
+    /// ordering is what matters — the keyframe that follows a resize arrives
+    /// before the next layout pass, so a surface still at the old grid paints it
+    /// mangled and has to ask for another one. A surface that already moved
+    /// paints it right the first time.
+    var viewportPending = false
 }

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -45,4 +45,18 @@ final class SessionRuntime {
     /// holding the write token is letterboxed too whenever the session is sized
     /// to somebody else's screen.
     var sharedGrid: TerminalGrid?
+    /// Whether this pane's own viewport change is still in flight.
+    ///
+    /// The letterbox reads it, and it is the difference between the two reasons
+    /// the session's grid can differ from the pane's. Somebody else is using the
+    /// session on a smaller screen: letterbox, or this pane re-wraps bytes that
+    /// were wrapped for theirs (§C.5). *This* pane was just resized and the
+    /// daemon has not answered yet: letterboxing there pins the screen to the
+    /// width the drag started at and slides it around inside the growing pane,
+    /// which is what a window drag looked like. Under a size policy that follows
+    /// the device being used, an in-flight change of this pane's own is a
+    /// resize that is about to be granted — so the surface follows the pane, the
+    /// way it would in a terminal with no host at all, and the keyframe at the
+    /// end is what everyone converges on.
+    var viewportPending = false
 }

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -45,18 +45,4 @@ final class SessionRuntime {
     /// holding the write token is letterboxed too whenever the session is sized
     /// to somebody else's screen.
     var sharedGrid: TerminalGrid?
-    /// Whether this pane's own viewport change is still in flight.
-    ///
-    /// The letterbox reads it, and it is the difference between the two reasons
-    /// the session's grid can differ from the pane's. Somebody else is using the
-    /// session on a smaller screen: letterbox, or this pane re-wraps bytes that
-    /// were wrapped for theirs (§C.5). *This* pane was just resized and the
-    /// daemon has not answered yet: letterboxing there pins the screen to the
-    /// width the drag started at and slides it around inside the growing pane,
-    /// which is what a window drag looked like. Under a size policy that follows
-    /// the device being used, an in-flight change of this pane's own is a
-    /// resize that is about to be granted — so the surface follows the pane, the
-    /// way it would in a terminal with no host at all, and the keyframe at the
-    /// end is what everyone converges on.
-    var viewportPending = false
 }

--- a/Tests/termioTests/TerminalViewportGridTests.swift
+++ b/Tests/termioTests/TerminalViewportGridTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import TermioShared
+
+/// The one piece of arithmetic both clients declare their viewport with.
+///
+/// It is worth pinning because nothing else can catch it going wrong: a client
+/// that floors differently, or forgets that padding is on both sides, declares a
+/// grid its own surface then disagrees with by a column — and the visible result
+/// is not an error but a pane that letterboxes against itself, or a session that
+/// creeps a column narrower every time it is measured.
+final class TerminalViewportGridTests: XCTestCase {
+    private let cell = CGSize(width: 8, height: 20)
+
+    private func grid(_ width: CGFloat, _ height: CGFloat,
+                      paddingX: CGFloat = 4, paddingY: CGFloat = 2) -> TerminalGrid? {
+        TerminalGrid.fitting(
+            CGSize(width: width, height: height), cell: cell,
+            paddingX: paddingX, paddingY: paddingY)
+    }
+
+    /// Padding is subtracted on *both* sides, and the remainder is floored.
+    func testWholeCellsAfterPaddingOnBothSides() {
+        // 808 − 2×4 = 800 = 100 cells exactly; 404 − 2×2 = 400 = 20 rows.
+        XCTAssertEqual(grid(808, 404), TerminalGrid(rows: 20, cols: 100))
+    }
+
+    /// A pane one point short of the next cell keeps the smaller grid. Rounding
+    /// here would declare room the surface does not have, and the surface would
+    /// answer with a grid one column narrower than the session it was given.
+    func testShortOfACellDoesNotRoundUp() {
+        XCTAssertEqual(grid(815, 404)?.cols, 100)
+        XCTAssertEqual(grid(816, 404)?.cols, 101)
+        XCTAssertEqual(grid(808, 423)?.rows, 20)
+        XCTAssertEqual(grid(808, 424)?.rows, 21)
+    }
+
+    /// Anything that cannot hold a whole cell is "no viewport at all", which the
+    /// host counts for nobody — deliberately not a stand-in grid, which would
+    /// size the session for a window that has not laid out yet.
+    func testTooSmallOrUnmeasuredIsNoViewport() {
+        XCTAssertNil(grid(0, 0))
+        XCTAssertNil(grid(-100, -100))
+        XCTAssertNil(grid(8, 404), "narrower than one cell plus its padding")
+        XCTAssertNil(grid(808, 20), "shorter than one row plus its padding")
+        XCTAssertNil(TerminalGrid.fitting(
+            CGSize(width: 800, height: 400), cell: .zero, paddingX: 4, paddingY: 2),
+            "no cell size yet")
+    }
+
+    /// A NaN anywhere in the layout must not reach `UInt16`, which traps.
+    func testNonFiniteIsRefusedRatherThanTrapping() {
+        XCTAssertNil(grid(CGFloat.nan, 400))
+        XCTAssertNil(grid(800, CGFloat.nan))
+        XCTAssertNil(grid(CGFloat.infinity, CGFloat.infinity))
+        XCTAssertNil(TerminalGrid.fitting(
+            CGSize(width: 800, height: 400), cell: CGSize(width: CGFloat.nan, height: 20),
+            paddingX: 4, paddingY: 2))
+    }
+
+    /// A window dragged onto a wall of displays still describes a grid a `u16`
+    /// can carry, and one the daemon will not try to allocate a screen for.
+    func testAbsurdSizesClamp() {
+        let huge = grid(10_000_000, 10_000_000)
+        XCTAssertEqual(huge?.cols, 10_000)
+        XCTAssertEqual(huge?.rows, 10_000)
+    }
+
+    /// Zero padding is a legitimate setting, not a special case.
+    func testZeroPaddingUsesTheWholeRectangle() {
+        XCTAssertEqual(
+            grid(800, 400, paddingX: 0, paddingY: 0), TerminalGrid(rows: 20, cols: 100))
+    }
+}

--- a/Tests/termioTests/TermiodSizePolicyIntegrationTests.swift
+++ b/Tests/termioTests/TermiodSizePolicyIntegrationTests.swift
@@ -3,13 +3,15 @@ import TermioShared
 @testable import termio
 
 /// Two attachments on one session, against a real daemon: the PTY is the
-/// smallest viewport being rendered, and the write token does not move it.
+/// viewport of the screen a person is in front of, and nothing else moves it.
 ///
-/// Every assertion here was false before
-/// `docs/design/20260901-pty-size-is-not-the-write-token.md`. The size followed
-/// the token — gaining it re-asserted the winner's grid — so two devices trading
-/// the token traded the PTY with it, and one byte misread as typing was a
-/// full-speed resize loop. This is the test that says it does not.
+/// Both halves have been wrong, in opposite directions
+/// (`docs/design/20260901-pty-size-is-not-the-write-token.md`). The size first
+/// followed the write token, which gaining it re-asserted, so one byte misread
+/// as typing was a full-speed resize loop. Then it followed the smallest viewer,
+/// and a phone that had opened a session once held a 200-column pane at 47 for
+/// as long as it stayed open — collapsing the pane's sidebar moved nothing at
+/// all, which is the report this file ends with.
 ///
 /// Opt-in on the same terms as the other daemon suites: set
 /// `TERMIO_TERMIOD_TEST_BIN` to run it.
@@ -102,10 +104,11 @@ final class TermiodSizePolicyIntegrationTests: XCTestCase {
         }
     }
 
-    func testTheSessionIsTheSmallestViewportAndTheTokenDoesNotMoveIt() throws {
+    func testTheSessionIsTheScreenBeingUsed() throws {
         let name = "size-policy-\(UUID().uuidString.prefix(8))"
         let wide = TerminalGrid(rows: 50, cols: 200)
         let narrow = TerminalGrid(rows: 42, cols: 47)
+        let widened = TerminalGrid(rows: 50, cols: 240)
 
         let mac = link(name, rows: Int(wide.rows), cols: Int(wide.cols))
         let macGrid = GridWatcher()
@@ -114,31 +117,47 @@ final class TermiodSizePolicyIntegrationTests: XCTestCase {
         defer { mac.detach() }
         waitForGrid(macGrid, wide, "one viewer, its own grid")
 
-        // A phone opens the same session on a much smaller screen.
+        // A phone opens the same session on a much smaller screen. Opening it
+        // there is using it, so the session goes to the phone and the Mac
+        // letterboxes.
         let phone = link(name, rows: Int(narrow.rows), cols: Int(narrow.cols))
         let phoneGrid = GridWatcher()
         phone.onSharedGrid = { phoneGrid.grid = $0 }
         phone.start()
         defer { phone.detach() }
-        waitForGrid(phoneGrid, narrow, "the phone is smaller, so the session is")
+        waitForGrid(phoneGrid, narrow, "the phone was just opened, so the session is its size")
         waitForGrid(macGrid, narrow, "and the Mac is told, so it can letterbox")
 
-        // Typing takes the write token. It used to take the grid with it.
+        // Typing is the plainest statement of which screen someone is at.
         mac.send(Data("echo\n".utf8))
-        assertGridHolds(macGrid, narrow, "typing on the Mac must not resize the session")
-        phone.send(Data("echo\n".utf8))
-        assertGridHolds(phoneGrid, narrow, "nor typing on the phone")
+        waitForGrid(macGrid, wide, "typing on the Mac brings the session back to it")
+        assertGridHolds(
+            phoneGrid, wide, "a phone that is merely attached must not pull it back")
 
-        // Putting the session away on the phone is what gives the width back.
+        phone.send(Data("echo\n".utf8))
+        waitForGrid(phoneGrid, narrow, "and typing on the phone hands it over again")
+
+        // The report that produced this policy: with a second viewer attached,
+        // collapsing the pane's sidebar has to resize the session. Under
+        // smallest-wins the Mac's new width lost to the phone's every time.
+        mac.setViewport(rows: Int(widened.rows), cols: Int(widened.cols))
+        waitForGrid(macGrid, widened, "resizing a pane is using it")
+
+        // Putting the session away on the phone leaves the Mac the only screen
+        // anyone is in front of.
+        phone.send(Data("echo\n".utf8))
+        waitForGrid(macGrid, narrow, "the phone takes it back")
         phone.setRendering(false)
-        waitForGrid(macGrid, wide, "a viewer that stopped rendering stops counting")
+        waitForGrid(macGrid, widened, "a viewer that stopped rendering stops counting")
 
         phone.setRendering(true)
-        waitForGrid(macGrid, narrow, "and counts again when it comes back")
+        waitForGrid(macGrid, narrow, "and opening it again is using the phone")
     }
 
     /// The other half: a viewer that leaves altogether releases the session too,
     /// and the size it left behind survives until somebody is rendering again.
+    /// A departure is the one size change nobody asked for, so it is the one
+    /// that has to fall back rather than hold.
     func testDetachingHandsTheWidthBack() throws {
         let name = "size-detach-\(UUID().uuidString.prefix(8))"
         let wide = TerminalGrid(rows: 50, cols: 200)
@@ -153,7 +172,7 @@ final class TermiodSizePolicyIntegrationTests: XCTestCase {
 
         let phone = link(name, rows: Int(narrow.rows), cols: Int(narrow.cols))
         phone.start()
-        waitForGrid(macGrid, narrow, "the phone squeezes it")
+        waitForGrid(macGrid, narrow, "opening it on the phone takes the session there")
 
         phone.detach()
         waitForGrid(macGrid, wide, "and hands it back on the way out")

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ from the real front matter).
 | done | rfc | [Loose terminals as first-class entities](design/20260713-loose-terminal-entity.md) |
 | done | rfc | [Remote git — the pane's verbs run on the device](design/20260818-remote-git-plane.md) |
 | done | rfc | [Session identity survives the agent](design/20260830-session-identity-survives-the-agent.md) |
+| draft | bug | ["HANDOFF: window drag still corrupts the terminal mid-drag"](bug/window-drag-resize-artifacts-HANDOFF.md) |
 | draft | design | [分享 Agent 会话（带密码的实时分享链接）](design/20260628-session-share.md) |
 | draft | design | [调研：下一批 AgentAdapter 的落盘格式（OpenCode / Pi / Amp / Cursor / Kimi）](design/20260711-agent-transcript-survey.md) |
 | draft | design | ["Markdown preview — Apple-grade reading typography"](design/20260718-markdown-preview-reading-typography.md) |
@@ -129,7 +130,6 @@ from the real front matter).
 | draft | rfc | [Installing termio's agent integration on a device](design/20260824-agent-integration-on-a-device.md) |
 | draft | rfc | [iOS as a device client](design/20260824-ios-as-device-client.md) |
 | draft | rfc | [Onboarding —— 首次启动体验设计](design/20260630-onboarding.md) |
-| draft | rfc | [PTY size is not the write token](design/20260901-pty-size-is-not-the-write-token.md) |
 | draft | rfc | [Retire the companion's second protocol — the phone attaches to a device](design/20260831-companion-second-protocol-retires.md) |
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |

--- a/docs/bug/window-drag-resize-artifacts-HANDOFF.md
+++ b/docs/bug/window-drag-resize-artifacts-HANDOFF.md
@@ -1,0 +1,203 @@
+---
+title: "HANDOFF: window drag still corrupts the terminal mid-drag"
+status: draft
+type: bug
+created: 2026-09-01
+updated: 2026-09-01
+related:
+  - ../design/20260901-pty-size-is-not-the-write-token.md
+  - ../design/20260730-termiod-session-protocol.md
+  - terminal-resize-no-reflow-HANDOFF.md
+  - agent-tui-focus-report-resize-storm.md
+---
+
+# HANDOFF — window drag still corrupts the terminal mid-drag
+
+> **OPEN.** Sizing is fixed and proven. What is still wrong is what the screen
+> *looks like* while a window is being dragged. Everything below is measured, not
+> reasoned; the open questions at the end are the ones nobody has data for.
+
+## 0. Read this first
+
+The reporter's words, in order, across one afternoon on branch
+`feat/size-follows-the-device-in-use` (PR #591):
+
+1. "right sidebar 展开折叠 无法 resize tui" — **fixed**, see §2.
+2. "resize 过程抖动 and 依然错位" — partly fixed, see §3.
+3. "还是会抖动" — partly fixed, see §4.
+4. "drag 过程中还是会乱？结束的时候不乱" — **the live one**, see §5.
+5. "完全不会 resize 了" — a regression introduced chasing #4; fixed, see §6.
+
+Nine commits. The sizing half is tested and I stand behind it. The visual half
+(§5) has been changed five times by an agent that **cannot see the screen** —
+`screencapture` is refused (no Screen Recording) and `osascript` returns -25211
+(no Accessibility) for this session, so every visual claim in this file comes
+from the reporter's screenshots or from the trace in §1, never from observation.
+That is the single biggest reason this took so long, and the first thing a
+follow-up should fix.
+
+## 1. How to get evidence (do this before changing anything)
+
+The client logs a four-line trace at debug level. Nothing else in this
+investigation produced a usable signal.
+
+```sh
+log stream --predicate 'subsystem == "sh.termio.app.dev"' --debug --style compact \
+  | grep resize-trace
+```
+
+```
+resize-trace <session> declare 45x97 rendering=true   # what this pane told the daemon
+resize-trace <session> session-is 45x97               # what the daemon answered
+resize-trace <session> surface-at 45x97               # what libghostty laid the surface out at
+resize-trace <session> resync-requested               # the pane asking for a paintable keyframe
+```
+
+Four links log into one stream — one per open session, plus the companion
+bridge. Before the session name was added, their interleaved bursts read as a
+loop and cost an hour. Two other measurements that settle arguments quickly:
+
+```sh
+# what the daemon believes
+env -u TERMIOD_SOCK TERMIO_CHANNEL=dev termiod list --json
+
+# what the kernel actually holds — the child reflows from this, not from us
+python3 -c 'import os,fcntl,termios,struct
+fd=os.open("/dev/ttys004", os.O_RDONLY|os.O_NOCTTY|os.O_NONBLOCK)
+print(struct.unpack("HHHH", fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\0"*8))[:2])'
+```
+
+**`TERMIOD_SOCK` leaks.** Any shell inside Termio carries it, it overrides
+`TERMIO_CHANNEL`, and `open` passes it to the app — so a dev build launched from
+a Termio terminal attaches to the **release** daemon and shares the user's real
+sessions. Two apps on one session is also a faithful reproduction of the original
+bug, so this trap both causes and hides it. Launch with
+`env -u TERMIOD_SOCK … open ./termio-dev.app`.
+
+## 2. Fixed and proven: the session sized to the smallest viewer
+
+`#580`/`#586` shipped `size = min(viewport of attachments rendering)`. Any second
+viewer — another window on the same daemon, a phone with the session open — held
+every other one at its width, so collapsing a pane's sidebar moved nothing.
+
+Measured before the fix: one window, ⌘⌥0 moves the PTY 41×63 ↔ 41×97 every time;
+a second window at 700×600 on the same session pins it at 41×61 and four toggles
+move nothing, the app logging `PTY is now 41x61; this pane has room for 41x70`.
+
+Now: `size = viewport of the most recently *used* attachment`, where a use is
+typing, declaring a changed viewport, or attaching — never output, never a device
+report, never a token claim. tmux's `latest` with zellij's rendering filter. See
+§11 of the size-policy RFC. Covered by `session.rs` unit tests and
+`TermiodSizePolicyIntegrationTests` against a real daemon.
+
+## 3. Fixed: the screen was truncated instead of rewrapped
+
+termiod's VT resizes without reflow on purpose — a shell's SIGWINCH redisplay
+moves the cursor up by a row count computed from the *old* width, so rewrapping
+under it duplicates the prompt (the ⌘D report). Every attachment then repaints
+from that screen, so a line the program had wrapped stayed broken where it was
+broken: widen the window and rows start mid-word. `mage in clipboard` in the
+reporter's screenshot is `image in clipboard` with the `i` still on the row above.
+
+Now gated on what is on screen: a shell gets the truncating resize, anything else
+gets the rewrap. **The first version of this gate was wrong and shipped**: it
+asked `foreground.job`, but an agent session is `zsh -ilc exec claude`, where
+`exec` replaces the shell image — the child *is* the agent, its pgid is the
+session's own, and the answer was always "no job". Every agent session kept the
+truncating resize. It now matches argv0 against a closed set of shell names.
+
+Both directions are pinned in `vt/tests/resize_reflow.rs`
+(`widening_does_not_re_join_a_wrapped_line`,
+`widening_with_reflow_re_joins_a_wrapped_line`) and the classifier in
+`only_a_shell_gets_the_truncating_resize`.
+
+## 4. Fixed: a barrier per intermediate size
+
+A viewport flushed on a fixed cadence made a drag ~20 barriers a second — each
+one quiesces the session, resizes, and pushes a fresh keyframe to every
+attachment, racing the child's own redraw. Ghostty affords 25ms because its
+resize is an ioctl on a PTY one surface owns; ours is a barrier. tmux
+rate-limits a pane to one resize per 250ms, zellij collapses a burst to its last,
+cmux debounces 180ms.
+
+Now one send per drag, at the end, 150ms after the pane stops moving. Measured on
+a real 2.8s drag: six declarations, each answered by the daemon in 2–11ms.
+
+## 5. **Still open: the screen is wrong *during* the drag**
+
+Reporter, after the fixes above: *"drag 过程中还是会乱？结束的时候不乱"* — the end
+state is correct, the journey is not.
+
+There are only two coherent behaviours and termio has been oscillating between
+them because each was tried without being able to see the result:
+
+| | during the drag | why it is wrong |
+| --- | --- | --- |
+| **surface follows the pane** | libghostty re-wraps the *old* screen once per frame, at widths nothing was ever drawn for | the mess the reporter sees |
+| **surface pinned to the session's grid** | nothing moves, padding grows | correct-looking, but the keyframe after the resize lands on a surface still at the old grid, paints mangled, and needs a second repaint (`resync-requested` fires after every resize in the trace) |
+
+The current commit tries to take both: pinned while the pane is moving, leading
+from the moment the declaration is written to the wire, so the keyframe lands on
+a correctly-sized surface. **Unverified by anyone who can see it.**
+
+Ghostty has neither problem because it has neither half of the architecture: one
+VT, no host, no keyframe, and the PTY resizes continuously so the child's output
+is always fresh for the current width.
+
+## 6. Regression, fixed: pinning against a host with no size policy
+
+Chasing §5, the letterbox was regated from `!isWriter` to "the session's grid
+differs from this pane's". Correct under a size policy; catastrophic without one.
+An older daemon — the reporter's VPS, `route=ssh:ukvps`, `caps=events,snapshot`
+— reads a resize as *set the PTY size, from the writer*, so the pane's own grid
+**is** the session's. A difference there is a declaration that host will never
+answer, and the surface stayed pinned to it forever: *"完全不会 resize 了"*.
+
+The pane now asks the handshake (`viewport` capability) before it letterboxes at
+all. Any future gate on this path must ask the same question.
+
+## 7. The architectural answer, not yet attempted
+
+cmux does not have this bug family because it never runs two terminal
+authorities in one session:
+
+- a local pane is `ioMode: .exec` — ghostty owns the child, the PTY and the
+  terminal protocol (`TerminalSurfaceIOMode.swift:7`);
+- a remote pane is `.manualMirror` — *"the embedder owns the PTY and terminal
+  protocol while Ghostty mirrors output for rendering and encodes only user
+  input"* (`:12`), with remote tmux as the single authority for the screen;
+- a phone watching a Mac pane does not change the grid at all — it **shrinks the
+  font** (`MobileViewportFitGeometry.swift:103`).
+
+termio's `.inMemory` is cmux's `manual`, not `manualMirror`: libghostty is a full
+terminal on the client, reflowing on its own authority, while termiod runs a
+second authoritative VT. Every artifact in this file lives in the gap between
+them. `GHOSTTY_SURFACE_IO_MANUAL_MIRROR` is **not upstream** — upstream
+`include/ghostty.h` has no io mode at all; cmux added it to their fork, and we
+maintain `termio-sh/libghostty-swift` as ours.
+
+A mirror mode there would delete this class by construction. It is the same shape
+of change as `.exec` → `.inMemory` was, so it wants an RFC before code — and it
+must be argued against §A's anti-100× invariant, since a mirror still must not
+put a per-frame grid encoder between the PTY and the pipe.
+
+## 8. What to investigate next
+
+1. **Get eyes on it.** Screen Recording + Accessibility for whoever drives this,
+   or a screen recording from the reporter. Five blind changes is four too many.
+2. **Decide §5 deliberately**, with the trace open: does the pinned or the
+   leading surface look better mid-drag? They are one boolean apart today
+   (`viewportPending`), so the experiment is cheap.
+3. **Why does `resync-requested` fire after every resize?** If the ordering fix
+   in §5 is right it should now be rare. If it still fires every time, the
+   keyframe is still landing on a mis-sized surface and the extra repaint is a
+   second visible paint per resize.
+4. **The 45↔46 row oscillation at launch** in the trace: the pane declares 46,
+   then 45, and the surface alternates. Suspect the half-cell slack in
+   `letterboxSize` against libghostty's own padding rounding — one of the two is
+   off by a row.
+5. **Redeploy the VPS daemon** (`termiod deploy --host ukvps`); remote sessions
+   are on an old build and will keep behaving like the pre-policy world.
+6. **Consider the mirror RFC** (§7) before adding any further reconciliation
+   logic to the client. Each patch so far has been correct in isolation and the
+   pile is now the problem.

--- a/docs/bug/window-drag-resize-artifacts-HANDOFF.md
+++ b/docs/bug/window-drag-resize-artifacts-HANDOFF.md
@@ -201,3 +201,55 @@ put a per-frame grid encoder between the PTY and the pipe.
 6. **Consider the mirror RFC** (§7) before adding any further reconciliation
    logic to the client. Each patch so far has been correct in isolation and the
    pile is now the problem.
+
+## 9. Independent probe (codex), and what its drag left in the trace
+
+A second agent re-ran the investigation from this document. Its result: a focused
+3s edge drag ended with the daemon and `TIOCGWINSZ` **both at 45×21** — the two
+agree, so the sizing chain is consistent end to end and §2 holds. It could not
+get Screen Recording either, and had no retained trace, so it adds nothing to §5.
+
+Two agents are now blind on the same half of the same bug. **The blocker is a
+permission, not a question about the code**, and it should be cleared before
+anyone writes another line: Screen Recording + Accessibility for the session
+driving the app, or a five-second screen recording of a drag from the reporter.
+
+The trace *was* still capturing during that probe, and it settles one open
+question and opens another.
+
+**§8.3 answered: `resync-requested` still fires after every resize.** Even with
+the surface leading its own declaration:
+
+```
+20:05:32.561 6E769100 declare 45x21 rendering=true
+20:05:32.561 6E769100 session-is 45x21
+20:05:32.562 6E769100 surface-at 45x21
+20:05:32.562 6E769100 resync-requested
+```
+
+The surface reaches the grid one millisecond *after* the daemon's answer, so the
+keyframe that rides behind `E resized` still lands on a surface that has not been
+re-laid-out. The ordering fix moved the race, it did not remove it. A client
+cannot win this by predicting: the fix is to hold the post-barrier keyframe until
+`surfaceGrid == authoritativeGrid` (with a timeout) rather than paint it and ask
+again — or to stop having two VTs at all (§7).
+
+**New: two sessions declare identical viewports at the same instant.**
+
+```
+20:05:32.561 D65810C6 declare 45x21 rendering=true
+20:05:32.561 6E769100 declare 45x21 rendering=true
+20:05:32.561 5AAA195E declare 45x44 rendering=false
+```
+
+`D65810C6` and `6E769100` are different sessions reporting the *same* grid in the
+same millisecond, both `rendering=true`, and both resize. A split would give them
+different geometry — a side-by-side split halves the columns, a stacked one
+halves the rows — so identical numbers mean two panes each measuring the whole
+pane rect. `SharedGridLetterbox` computes `paneGrid` from
+`paneFrames[id] ?? bounds`, and a session with no split geometry falls back to
+`bounds`: the entire pane. Hidden panes are meant to be excluded by
+`rendering=false` (`5AAA195E` correctly is), so the question is why two are
+marked visible at once. Worth checking `store.visiblePaneIDs` before assuming the
+letterbox is at fault.
+

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -320,15 +320,17 @@ maintains an internal grid at *authoritative PTY dimensions* with its own
 *local* viewport layered on top (letterbox / scale / scroll) — never by parsing
 at its own window size. *(`Attached` carries `rows`/`cols` as of Phase 1c. Both app clients conform: the
 Mac pane letterboxes at the shared grid (`SharedGridLetterbox`) whenever the
-session is smaller than the pane, and the phone fills its screen — under the
-2026-09-01 size policy it is never the larger of the two, so it has nothing to
-scale. Neither is keyed on the write token any more. The keyframe that announces
-a new grid reaches a client before its surface has moved, so it is parsed at the
-old grid; the first surface report that lands on the shared grid sends
-`request_snapshot`, and that keyframe paints right. A pane that letterboxes must
-declare its viewport from its own geometry rather than from the surface: a
-surface laid out at the shared grid reports that grid, and a pane declaring what
-its surface reports could never say it had room for more. The reference CLI
+session is a different size than the pane, and the phone lays its surface out at
+that grid and scales the whole thing down to fit. Neither is keyed on the write
+token any more. The keyframe that announces a new grid reaches a client before
+its surface has moved, so it is parsed at the old grid; the first surface report
+that lands on the shared grid sends `request_snapshot`, and that keyframe paints
+right. A client that lays its surface out at the shared grid must declare its
+viewport from its own geometry rather than from the surface: a surface laid out
+at the shared grid reports *that* grid, and a client declaring what its surface
+reports could never say it had room for its own width back. The phone carries
+both facts over the companion wire for the same reason — the Mac's bridge has no
+surface of its own to read the second one from. The reference CLI
 client still parses at its own size — acceptable for a single same-size CLI.)*
 
 **Writer policy — single writer, follows the device being used, observable.**
@@ -356,13 +358,16 @@ explicitly rejected (§H); the write token is also the natural place a future
 share ACL plugs in without new message shapes.
 
 **Resize policy — the PTY has one size and the *host* computes it, from the
-attachments that are actually rendering.** Amended 2026-09-01 by
+screen a person is in front of.** Amended 2026-09-01 by
 [PTY size is not the write token](20260901-pty-size-is-not-the-write-token.md);
 what follows replaces "the writer owns it".
 
 ```
-size = componentwise min(viewport of each attachment that is interactive,
-                         rendering, and has declared one)
+size = viewport of the most recently used attachment
+       among those interactive, rendering, and having declared one
+
+used by: typing · declaring a viewport · attaching
+not by:  output · device reports · gaining the write token
 ```
 
 `R` declares *this attachment's viewport* — "my window could show N×M" — and is
@@ -375,6 +380,18 @@ observer has no tty and therefore no screen a viewport could be about, so
 `termio read` tailing a session cannot squeeze the window someone is working in.
 With nobody rendering, the size stays exactly where it was.
 
+"Used" is deliberately narrow, and it is what separates this from the policy it
+replaces. Gaining the write token is *not* a use — a client claims the token to
+be allowed to type, and a claim can arrive from a queued keystroke or a
+handover — and neither is a byte the terminal produced. Typing, resizing a
+window, and opening the session on a device are: each is a person acting on a
+particular screen. This is tmux's `latest`, which tmux ships as an option rather
+than a default because binding size to recency thrashes. It does not here, for
+one structural reason: the host is the only thing that resizes. The old
+implementation had *both ends* re-assert their own grid on every token grant, so
+two clients could saw the PTY between their two sizes; a stray use now costs one
+resize, not an oscillation.
+
 The barrier is unchanged: quiesce, resize, emit fresh `S`, resume deltas (the
 ghostty-web lesson), and `E {ev:"resized"}` still carries the authoritative
 dimensions. What changed is who decides. Binding the size to the token made
@@ -382,10 +399,10 @@ every token move a resize barrier and every byte misread as typing a resize
 loop — measured at 6135 token moves in 30 seconds, the grid alternating 39×38 ↔
 47×42. Per-client server-side reflow remains rejected — it means one vt per
 viewer per session, which is a nested-window-manager tax in disguise — so the
-mismatch is *shown*: a viewer larger than the session lays its surface out at
-the session's grid and leaves the rest blank, the way tmux pads and screen
-leaves space. Under a smallest-wins policy no renderer is ever narrower than the
-PTY, so nothing is ever scaled down.
+mismatch is *shown*: a viewer whose screen is not the one the session is sized to
+lays its surface out at the session's grid — blank space around it where there is
+room, scaled down where there is not, the way tmux pads and screen leaves space.
+The Mac pane pads; the phone, against a 200-column pane, scales.
 
 ### C.6 Terminal plane staging
 

--- a/docs/design/20260901-pty-size-is-not-the-write-token.md
+++ b/docs/design/20260901-pty-size-is-not-the-write-token.md
@@ -21,6 +21,13 @@ related:
 >
 > §1–§4 are the argument, written before the code. §5 settles what §4 left open,
 > §6 records where §4 was wrong, and §10 says what the tests hold.
+>
+> **§11 supersedes §4's policy.** Smallest-wins shipped and the complaint §7
+> predicted arrived the same afternoon: with a second viewer attached, collapsing
+> a pane's sidebar resized nothing at all. The size now follows the screen a
+> person is in front of. Everything §1–§3 argues — that size must not ride on the
+> write token, and that the host must own the policy — is unchanged and is what
+> makes §11 safe.
 
 ---
 
@@ -274,6 +281,9 @@ sit at 38 columns. Whether that is acceptable, or whether termio needs tmux's
 `window-size` as a user-facing option, is the open question. Recommendation: ship
 the correct default first; add the option only if the complaint is real.
 
+*Answered the same afternoon, and not by the phone: two Termio windows on one
+session were enough. See §11.*
+
 **Where the policy runs.** Settled: the daemon, in
 `Session::apply_size_policy`, called from every change to the attachment set —
 an arrival, a departure, a viewport, a pane going to a background tab. It is the
@@ -323,16 +333,100 @@ stays as it is. Recorded so the next reader does not mistake it for the bug.
 
 ## 10. What the tests hold
 
-- `termiod/src/session.rs` — the policy itself: smallest wins; rows and columns
-  minimised independently; a hidden attachment stops counting and starts again;
-  nobody rendering leaves the size alone; a viewport of zero counts for nobody;
-  an observer never sizes anything. Plus the one that had to change shape: a
-  failed `TIOCSWINSZ` now tells nobody, because there is no requester to answer.
+*Updated by §11; the shapes below are current.*
+
+- `termiod/src/session.rs` — the policy itself: the session is the viewport of
+  the attachment most recently used; the answer is one screen's grid and never a
+  blend of two; changing a viewport is a use and a token claim is not; a hidden
+  attachment stops counting and starts again; nobody rendering leaves the size
+  alone; a viewport of zero counts for nobody; an observer never sizes anything.
+  Plus the one that had to change shape: a failed `TIOCSWINSZ` now tells nobody,
+  because there is no requester to answer.
 - `Tests/termioTests/TermiodSizePolicyIntegrationTests.swift` — two real Swift
-  attachments against a real daemon: the session is the smaller of the two, and
-  **typing on either end does not move it**. That last assertion is the whole
-  RFC, and it was false before this branch.
+  attachments against a real daemon: typing on a screen brings the session to it,
+  a viewer that is merely attached does not pull it back, and **resizing a pane
+  with a second viewer attached resizes the session**. That last assertion is the
+  report §11 exists for, and it was false on the branch that shipped §4.
 - `Tests/termioTests/TermiodWriteTokenIntegrationTests.swift` — unchanged, and
   that is the point: §H #6 is an input invariant and this did not touch it.
 - `Tests/termioTests/TermiodViewportFrameTests.swift` — the `R` payload's
   layout, which is the whole compatibility story.
+
+## 11. The complaint was real, and it was not the phone
+
+Shipped, and reported within hours: *"right sidebar 展开折叠 无法 resize tui, in
+last release version you could do it."*
+
+Reproduced against a real daemon on a dev build of `main`. One Termio window:
+⌘⌥0 moves the PTY 41×63 ↔ 41×97, every time. A second Termio window attached to
+the same session at 700×600: the PTY pins to 41×61 and four toggles in the first
+window move nothing, the app logging `PTY is now 41x61; this pane has room for
+41x70` each time. Quit the second window and the toggles work again.
+
+So §7's mitigation is not enough, and the case that breaks it is not the exotic
+one. It does not need a phone: a second window — two dev builds on one channel,
+a session open in a worktree app — is enough, and *every* viewer of a session is
+a hostage to the smallest one. The user asked for the size to follow the device
+being used.
+
+### 11.1 The policy
+
+```
+size = viewport of the most recently used attachment
+       among those interactive, rendering, and having declared one
+```
+
+`use_clock` is a counter on the session, stamped onto an attachment by exactly
+three things:
+
+| stamps a use | does not |
+| --- | --- |
+| typing (`SessionMsg::Input`, writer-only) | output, or any byte the terminal produced |
+| declaring a changed viewport, while rendering | a device report (`TerminalDeviceReport` — its own frame kind) |
+| attaching | gaining the write token |
+| | going to `rendering: false` |
+
+Everything else in §4 survives: the daemon still owns the policy, `R` is still a
+viewport declaration accepted from any attachment, an observer still counts for
+nothing, and nobody rendering still leaves the size where it was.
+
+### 11.2 Why this is not the `latest` §2 warns about
+
+§3 is right that termio's old `latest` was the worst version of it, and none of
+what made it bad is here:
+
+- **The trigger is a person, not a byte.** Bytes the terminal produced never
+  reach `Input` — clients send them on their own frame kind — so the storm's fuel
+  is still excluded.
+- **There is one authority.** §4 deleted both ends' grid re-assertion, and this
+  does not bring it back. The oscillation needed *two* clients each answering the
+  other's size; the daemon now decides alone, and a stray use costs one resize.
+- **The token is not the signal.** A claim is what a client sends to be allowed
+  to type; typing is what says somebody is there. Keeping those apart is why a
+  queued keystroke or a handover moves nothing.
+
+### 11.3 What it costs, honestly
+
+The phone can be *narrower* than the PTY again, which is exactly the case
+smallest-wins existed to make impossible — so §6.3's deletion is reverted: iOS
+lays its surface out at the shared grid and scales it down to fit, as it did
+before. With that comes §6.1's trap, now on the phone: a screen that letterboxes
+must declare its viewport from its own geometry, or it can only ever say it has
+room for the grid it was scaled to and the session can never come back to it. The
+phone therefore measures its viewport from the terminal host, and its surface's
+own report travels beside it as a second fact (`surfaceCols`/`surfaceRows` on the
+companion `resize`, optional, absent = the surface fills the screen) purely so
+the Mac's bridge can arm the repaint it has no local surface to hear about.
+
+Two viewers at different sizes now means one of them is scaled or padded at all
+times, which is the tmux/screen/zellij answer and was always going to be. The
+difference is which one: the screen nobody is touching.
+
+### 11.4 One thing §5.4 said and the code did not
+
+`companionAttachment` builds its link through `makeTermiodLink`, which put the
+Mac's `lastHostGrid` in the attach payload — so the bridge declared a stand-in
+viewport for a screen it does not have, against §5.4's own rule. Harmless under
+smallest-wins (it was never the smallest). Not harmless here: an attach is a use,
+so a stale stand-in would have taken the session for a frame. The bridge now
+attaches with a zero grid, which the daemon reads as no viewport at all.

--- a/ios/Sources/CompanionBackend.swift
+++ b/ios/Sources/CompanionBackend.swift
@@ -143,6 +143,9 @@ final class CompanionDeviceSession: DeviceSession {
     /// phone's own attachment, so on this wire it travels like any other byte.
     func sendDeviceReport(_ data: Data) { transport.send(data) }
     func setViewport(columns: Int, rows: Int) { transport.setViewport(cols: columns, rows: rows) }
+    func noteSurfaceGrid(columns: Int, rows: Int) {
+        transport.noteSurfaceGrid(cols: columns, rows: rows)
+    }
     func setRendering(_ showing: Bool) { transport.setRendering(showing) }
     func reassertGrid() { transport.reassertGrid() }
 }

--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -35,11 +35,18 @@ final class CompanionTransport {
     /// foreground: the first layout often fires before the socket exists and
     /// would be silently lost, and a reconnect never re-fires it (the view's
     /// size didn't change). The Mac forwards it as its bridge attachment's own
-    /// viewport; the session's size is the smallest one being rendered, and the
-    /// write token has nothing to do with it.
+    /// viewport; the session's size is the viewport of the screen someone is in
+    /// front of, and the write token has nothing to do with it.
+    ///
+    /// `surface` rides along because the bridge has no surface of its own to
+    /// read it from: while this screen shows a session bigger than itself the
+    /// two are different grids, and the Mac needs the second one to know when a
+    /// keyframe can finally be painted here.
     private var gridCols = 0
     private var gridRows = 0
     private var gridRendering = true
+    private var surfaceCols = 0
+    private var surfaceRows = 0
     private let gridLock = NSLock()
     /// Guards send order: `auth` must be the first frame on the socket. The
     /// terminal view calls `resize` (→ `sendGrid`) as it lays out, which can land
@@ -110,12 +117,25 @@ final class CompanionTransport {
 
     /// This screen's viewport. The Mac's bridge has no surface of its own, so it
     /// forwards this as its own attachment's viewport and the daemon sizes the
-    /// session to the smallest one being rendered.
+    /// session to the screen a person is in front of.
     func setViewport(cols: Int, rows: Int) {
         gridLock.lock()
         gridCols = cols
         gridRows = rows
         gridLock.unlock()
+        sendGrid()
+    }
+
+    /// The grid the surface is actually laid out at — this screen's own while it
+    /// fills the host, the session's while it is showing something bigger and
+    /// scaling it down. Never a declaration of what this screen has room for.
+    func noteSurfaceGrid(cols: Int, rows: Int) {
+        gridLock.lock()
+        let changed = surfaceCols != cols || surfaceRows != rows
+        surfaceCols = cols
+        surfaceRows = rows
+        gridLock.unlock()
+        guard changed else { return }
         sendGrid()
     }
 
@@ -139,11 +159,19 @@ final class CompanionTransport {
         let cols = gridCols
         let rows = gridRows
         let rendering = gridRendering
+        let laidOutCols = surfaceCols
+        let laidOutRows = surfaceRows
         let ready = authSent
         gridLock.unlock()
         guard ready, cols > 0, rows > 0 else { return }
+        // Omitted while the surface fills the host, which is the common case and
+        // what a Mac built before the field assumes.
+        let surface = (laidOutCols > 0 && laidOutRows > 0 && (laidOutCols, laidOutRows) != (cols, rows))
+            ? TerminalGrid(rows: UInt16(clamping: laidOutRows), cols: UInt16(clamping: laidOutCols))
+            : nil
         link.send(
-            CompanionControl.resize(cols: cols, rows: rows, rendering: rendering).encoded())
+            CompanionControl.resize(
+                cols: cols, rows: rows, rendering: rendering, surface: surface).encoded())
     }
 
     func stop() {

--- a/ios/Sources/DeviceClient.swift
+++ b/ios/Sources/DeviceClient.swift
@@ -97,7 +97,7 @@ protocol DeviceSession: AnyObject {
 
     /// The PTY's actual grid and whether this device holds the write token, on
     /// the main queue: once on attach and on every change of either. The grid is
-    /// the smallest viewport rendering the session — what the bytes arriving are
+    /// the viewport of the screen being used — what the bytes arriving are
     /// wrapped for — and is unrelated to the token that travels beside it.
     var onSharedGrid: ((TerminalGrid, Bool) -> Void)? { get set }
 
@@ -108,12 +108,21 @@ protocol DeviceSession: AnyObject {
     /// A reply the surface generated to a host query (`TerminalDeviceReport`).
     /// Passes only while this device is the writer, and never claims.
     func sendDeviceReport(_ data: Data)
-    /// Declares this screen's viewport. The device sizes the session to the
-    /// smallest viewport being rendered, so this is a fact about this screen and
-    /// not a claim on the session — it goes through whether or not this device
-    /// holds the write token
+    /// Declares this screen's viewport: how much of a session it could show,
+    /// measured from the screen itself. The device sizes a session to the
+    /// viewport of whichever screen a person is in front of, so this is a fact
+    /// about this screen and not a claim on the session — it goes through
+    /// whether or not this device holds the write token
     /// (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
     func setViewport(columns: Int, rows: Int)
+    /// The grid the surface is *actually* laid out at, which is the session's
+    /// rather than this screen's whenever this screen is showing a session
+    /// bigger than itself. Never a declaration: a screen that told the device
+    /// the grid it had been shrunk to could never say it had room for more, and
+    /// the session could never come back to it. Its one job is the repaint — a
+    /// keyframe parsed before the surface reached the shared grid is mangled,
+    /// and arriving there is what asks for a fresh one.
+    func noteSurfaceGrid(columns: Int, rows: Int)
     /// Whether this screen is showing the session. A screen the container parked
     /// keeps its viewport and stops counting, so a session left open on the
     /// phone does not hold a Mac pane at phone width forever.

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -51,14 +51,20 @@ final class TerminalViewController: UIViewController {
     private var fitDebounce: DispatchWorkItem?
     /// The area the surface may occupy, pinned by constraints between the
     /// header and the keyboard. The surface is framed by hand inside it
-    /// (`layoutTerminalSurface`): while another device sizes the session, the
-    /// surface has to be laid out at that device's grid, not this rectangle.
+    /// (`layoutTerminalSurface`): while the session is sized to another screen,
+    /// the surface has to be laid out at that screen's grid, not this rectangle.
     private let terminalHost: UIView = {
         let host = UIView()
         host.clipsToBounds = true
         host.translatesAutoresizingMaskIntoConstraints = false
         return host
     }()
+    /// The PTY's grid, from the session: the viewport of whichever screen a
+    /// person is in front of. `nil` until the session says.
+    private var sharedGrid: TerminalGrid?
+    /// The live surface's cell size, from the resize delegate. Both the
+    /// letterbox and this screen's own viewport are measured with it.
+    private var surfaceMetrics: TerminalGridMetrics?
     private lazy var shellSession = ShellSession(shell: defaultSandboxShell)
     private var companion: DeviceSession?
     private var companionSession: InMemoryTerminalSession?
@@ -294,21 +300,83 @@ final class TerminalViewController: UIViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
     }
 
-    /// Frames the surface inside `terminalHost`: it fills it.
+    /// Frames the surface inside `terminalHost`, and states what this screen
+    /// could show while it is there.
     ///
-    /// It used to letterbox — lay the surface out at the shared grid and scale
-    /// the whole thing down to fit — because while another device held the write
-    /// token the PTY was that device's size, and it could be *smaller* than this
-    /// phone's. The device now sizes a session to the smallest viewport
-    /// rendering it, so a phone showing one is never wider than the PTY except
-    /// against a Mac pane narrower than a phone; there is nothing left to scale
-    /// down, and blank space is the honest picture for what remains (§4 of
-    /// `docs/design/20260901-pty-size-is-not-the-write-token.md`).
+    /// Normally the surface fills the host. While the session is sized to
+    /// another screen — somebody is working at the Mac — every byte arriving
+    /// here is wrapped for that grid, and a surface at this phone's own width
+    /// re-wraps those lines into a screen a TUI's incremental repaints never
+    /// repair (§C.5 of the session protocol). So the surface is laid out at
+    /// exactly the shared grid, the same picture the Mac has, and the whole
+    /// thing is scaled down to fit, top-aligned and centred. Using the phone —
+    /// typing, or resizing this host — brings the session back to it and the
+    /// surface fills the host again.
+    ///
+    /// Half a cell of slack on each axis: libghostty floors
+    /// `(size − padding) / cell` for its grid, and an exact multiple can round
+    /// to one column short.
+    ///
+    /// This is also where the screen states its *viewport*, measured from the
+    /// host's own geometry. The surface cannot answer that question once it is
+    /// laid out at somebody else's grid: it reports the grid it was scaled to,
+    /// so a screen that declared what its surface reports could never say it had
+    /// room for its own width back, and the session could never return to it
+    /// (`docs/design/20260901-pty-size-is-not-the-write-token.md` §6.1).
     private func layoutTerminalSurface() {
         let host = terminalHost.bounds
         guard host.width > 0, host.height > 0 else { return }
+        let screen = hostGrid
+        if case .device = backend, let screen {
+            companion?.setViewport(columns: Int(screen.cols), rows: Int(screen.rows))
+        }
+        // A frame set under a transform is undefined; always start from identity.
         terminalView.transform = .identity
-        terminalView.frame = host
+        guard case .device = backend,
+              let grid = sharedGrid, grid != screen,
+              let cell = cellSize, grid.cols > 0, grid.rows > 0
+        else {
+            terminalView.frame = host
+            return
+        }
+        let width = CGFloat(grid.cols) * cell.width + 2 * Self.terminalPaddingX + cell.width / 2
+        let height = CGFloat(grid.rows) * cell.height + 2 * Self.terminalPaddingY + cell.height / 2
+        let fit = min(1, host.width / width, host.height / height)
+        terminalView.bounds = CGRect(x: 0, y: 0, width: width, height: height)
+        terminalView.transform = CGAffineTransform(scaleX: fit, y: fit)
+        terminalView.center = CGPoint(x: host.midX, y: height * fit / 2)
+    }
+
+    /// How much of a session this screen could show. The same
+    /// `TerminalGrid.fitting` the Mac pane measures itself with, so the two
+    /// clients declare comparable viewports — the session moves between them and
+    /// a per-platform copy of this arithmetic would drift a column apart. `nil`
+    /// before the surface has reported a cell size, which the device reads as no
+    /// viewport at all rather than as a stand-in.
+    private var hostGrid: TerminalGrid? {
+        guard let cell = cellSize else { return nil }
+        return TerminalGrid.fitting(
+            terminalHost.bounds.size, cell: cell,
+            paddingX: Self.terminalPaddingX, paddingY: Self.terminalPaddingY)
+    }
+
+    private var cellSize: CGSize? {
+        guard let metrics = surfaceMetrics,
+              metrics.cellWidthPixels > 0, metrics.cellHeightPixels > 0
+        else { return nil }
+        let scale = max(1, traitCollection.displayScale)
+        return CGSize(
+            width: CGFloat(metrics.cellWidthPixels) / scale,
+            height: CGFloat(metrics.cellHeightPixels) / scale)
+    }
+
+    /// The session's word on the PTY's grid. Not keyed on the write token: the
+    /// screen holding it is letterboxed too whenever the session is sized to
+    /// somebody else's.
+    private func applySharedGrid(_ grid: TerminalGrid) {
+        guard sharedGrid != grid else { return }
+        sharedGrid = grid
+        view.setNeedsLayout()
     }
 
     // MARK: - Header
@@ -781,9 +849,11 @@ final class TerminalViewController: UIViewController {
                     }
                 },
                 resize: { [weak transport] viewport in
-                    // The surface fills the host, so what it reports *is* this
-                    // screen's viewport — how much of a session it could show.
-                    transport?.setViewport(
+                    // What the *surface* was laid out at, which is the shared
+                    // grid rather than this screen's whenever the session is
+                    // sized to another one. The viewport the device sizes by is
+                    // measured from the host instead (`layoutTerminalSurface`).
+                    transport?.noteSurfaceGrid(
                         columns: Int(viewport.columns), rows: Int(viewport.rows))
                 }
             )
@@ -796,6 +866,9 @@ final class TerminalViewController: UIViewController {
             }
             transport.onState = { [weak self] state in
                 self?.companionStateChanged(state)
+            }
+            transport.onSharedGrid = { [weak self] grid, _ in
+                self?.applySharedGrid(grid)
             }
             companion = transport
             companionSession = terminalSession
@@ -1214,6 +1287,19 @@ extension TerminalViewController: UIImagePickerControllerDelegate, UINavigationC
 
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         picker.dismiss(animated: true)
+    }
+}
+
+extension TerminalViewController: TerminalSurfaceGridResizeDelegate {
+    /// Cell metrics for `layoutTerminalSurface`; they change with the font, so
+    /// a pinch re-frames a letterboxed surface at the same grid and re-states
+    /// this screen's viewport at the new cell size.
+    func terminalDidResize(_ size: TerminalGridMetrics) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, surfaceMetrics != size else { return }
+            surfaceMetrics = size
+            view.setNeedsLayout()
+        }
     }
 }
 

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -12,10 +12,10 @@ import TermioShared
 ///   than a torrent of historical escapes that mangles an idle TUI. The phone
 ///   reattaches every time it unlocks.
 /// - **The grid is arbitrated.** The PTY's size is a host-side policy over every
-///   attachment that is rendering — the smallest viewport wins — so `E resized`
-///   is authoritative and this client honours it rather than assuming its own
-///   viewport won. It declares that viewport whether or not it holds the write
-///   token; the two are unrelated
+///   attachment that is rendering — the screen a person is in front of wins — so
+///   `E resized` is authoritative and this client honours it rather than
+///   assuming its own viewport won. It declares that viewport whether or not it
+///   holds the write token; the two are unrelated
 ///   (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
 /// - **Input is gated on a token.** Many clients may watch one session and
 ///   exactly one may type into it.
@@ -24,10 +24,10 @@ final class TermiodSession: DeviceSession {
     var onState: ((DeviceSessionState) -> Void)?
     var onSharedGrid: ((TerminalGrid, Bool) -> Void)?
 
-    /// How long the grid must hold still before a size goes to the device. Every
-    /// distinct size is a host-side barrier — quiesce, resize, fresh keyframe to
-    /// every attachment — so a settling keyboard animation must not become a
-    /// burst of full repaints.
+    /// How often a moving screen may move the session, at most. Every distinct
+    /// size is a host-side barrier — quiesce, resize, fresh keyframe to every
+    /// attachment — so a keyboard animation must not become a burst of full
+    /// repaints. A cadence, not a settle: see `scheduleViewport`.
     private static let resizeCoalescingInterval = DispatchTimeInterval.milliseconds(50)
 
     private let sessionName: String
@@ -41,15 +41,18 @@ final class TermiodSession: DeviceSession {
     /// Keystrokes that arrived before the attach landed. The device would refuse
     /// them and the person would have to retype, so they wait.
     private var pendingInput = Data()
-    /// This screen's viewport: the grid its surface is laid out at, which is the
-    /// whole terminal host — the phone shows a session at its own size and never
-    /// scales it down, because under a smallest-wins policy it is never the
-    /// larger of the two.
+    /// This screen's viewport: how much of a session the terminal host could
+    /// show, measured from the host's own geometry. Not the same as the grid the
+    /// surface ends up at — a screen watching a session bigger than itself lays
+    /// the surface out at the session's grid and scales it down.
     private var viewportGrid = TerminalGrid(rows: 0, cols: 0)
+    /// The grid the surface is actually laid out at. Read only by the repaint
+    /// arming in `noteSurfaceGrid`; it never goes on the wire.
+    private var surfaceGrid = TerminalGrid(rows: 0, cols: 0)
     /// Whether this screen is showing the session. A parked screen the container
     /// kept alive stops counting toward the session's size.
     private var rendering = true
-    /// What the PTY actually is: the smallest viewport rendering it.
+    /// What the PTY actually is: the viewport of the screen being used.
     private var authoritativeGrid: TerminalGrid?
     /// A surface not yet laid out at the shared grid. The keyframe that
     /// announced the grid was parsed at the old one, and the surface is
@@ -61,7 +64,9 @@ final class TermiodSession: DeviceSession {
     /// an older host that reads `R` as "set the PTY size" and refuses it from
     /// anyone but the writer.
     private var hostSizesByPolicy = false
-    private var viewportGeneration: UInt64 = 0
+    /// Whether a flush is already on the queue; the window is not extended by
+    /// later changes (`scheduleViewport`).
+    private var viewportFlushScheduled = false
     /// The last declaration actually written, so an unchanged one is not
     /// re-sent: a viewport that moves the session is a host-side barrier.
     private var sentViewport: (grid: TerminalGrid, rendering: Bool)?
@@ -144,20 +149,36 @@ final class TermiodSession: DeviceSession {
         }
     }
 
-    /// Declares how much of a session this screen could show, whether or not
-    /// this phone holds the write token. The device sizes the session to the
-    /// smallest viewport being rendered; who may type is a separate question.
+    /// Declares how much of a session this screen could show, measured from the
+    /// screen and not read back off the surface: once the surface is laid out at
+    /// a bigger shared grid it reports *that*, and a screen that declared it
+    /// could never say it had room for less. Sent whether or not this phone
+    /// holds the write token — the device sizes a session to the screen someone
+    /// is in front of, and who may type is a separate question.
     func setViewport(columns: Int, rows: Int) {
         queue.async { [self] in
             let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: columns))
             guard viewportGrid != grid else { return }
             viewportGrid = grid
             guard attached, grid.rows > 0, grid.cols > 0 else { return }
-            // Arriving at the shared grid is the one moment a screen showing a
-            // session smaller than itself needs something from the device: a
-            // keyframe it can finally paint. Leaving it — a pinch reports the
-            // old frame at new cell metrics before the layout settles — arms the
-            // next arrival, so the bytes parsed in between are repainted too.
+            scheduleViewport()
+        }
+    }
+
+    /// The grid the surface was actually laid out at.
+    ///
+    /// Arriving at the shared grid is the one moment a screen showing a session
+    /// bigger than itself needs something from the device: a keyframe it can
+    /// finally paint, because the one that announced the resize was parsed at
+    /// the old grid. Leaving it — a pinch reports the old frame at new cell
+    /// metrics before the layout settles — arms the next arrival, so the bytes
+    /// parsed in between are repainted too.
+    func noteSurfaceGrid(columns: Int, rows: Int) {
+        queue.async { [self] in
+            let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: columns))
+            guard surfaceGrid != grid else { return }
+            surfaceGrid = grid
+            guard attached, grid.rows > 0, grid.cols > 0 else { return }
             if authoritativeGrid != grid {
                 repaintPending = true
             } else if repaintPending {
@@ -166,7 +187,6 @@ final class TermiodSession: DeviceSession {
                     channel.send(kind: .control, payload: payload)
                 }
             }
-            scheduleViewport()
         }
     }
 
@@ -206,10 +226,10 @@ final class TermiodSession: DeviceSession {
                 // already exists, and spawning one here would turn "that session
                 // is gone" into a second, empty shell.
                 specification: nil,
-                // Zero when the surface has not laid out yet, which the device
+                // Zero when the screen has not laid out yet, which the device
                 // counts as no viewport at all. A 24×80 stand-in used to go here
-                // instead, and under a smallest-wins policy that would squeeze
-                // every other viewer for as long as the first layout pass took.
+                // instead, and an attach is a use — it would have sized the
+                // session for a screen that had not measured itself.
                 rows: grid.rows,
                 cols: grid.cols
             ))
@@ -374,11 +394,16 @@ final class TermiodSession: DeviceSession {
     /// rather than debounced with a cancellable item because the size is re-read
     /// at fire time: the last scheduled send is the only one that writes, and it
     /// writes whatever the layout settled at.
+    /// Ghostty's coalescer rather than a debounce: the first change opens a
+    /// window, changes inside it only update the value, and the flush sends
+    /// whatever the screen is at then. A rotation or a keyboard animation
+    /// therefore reflows while it is happening instead of after it settles.
     private func scheduleViewport() {
-        viewportGeneration &+= 1
-        let generation = viewportGeneration
+        guard !viewportFlushScheduled else { return }
+        viewportFlushScheduled = true
         queue.asyncAfter(deadline: .now() + Self.resizeCoalescingInterval) { [self] in
-            guard attached, generation == viewportGeneration else { return }
+            viewportFlushScheduled = false
+            guard attached else { return }
             sendViewport()
         }
     }

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -24,11 +24,12 @@ final class TermiodSession: DeviceSession {
     var onState: ((DeviceSessionState) -> Void)?
     var onSharedGrid: ((TerminalGrid, Bool) -> Void)?
 
-    /// How often a moving screen may move the session, at most. Every distinct
+    /// How long a moving screen must hold still before its size goes to the
+    /// device, and the shortest gap between two declarations. Every distinct
     /// size is a host-side barrier — quiesce, resize, fresh keyframe to every
-    /// attachment — so a keyboard animation must not become a burst of full
-    /// repaints. A cadence, not a settle: see `scheduleViewport`.
-    private static let resizeCoalescingInterval = DispatchTimeInterval.milliseconds(50)
+    /// attachment — so a rotation or a keyboard animation must not become a
+    /// burst of full repaints.
+    private static let resizeCoalescingInterval = DispatchTimeInterval.milliseconds(150)
 
     private let sessionName: String
     private let channel: TermiodChannel
@@ -64,9 +65,10 @@ final class TermiodSession: DeviceSession {
     /// an older host that reads `R` as "set the PTY size" and refuses it from
     /// anyone but the writer.
     private var hostSizesByPolicy = false
-    /// Whether a flush is already on the queue; the window is not extended by
-    /// later changes (`scheduleViewport`).
-    private var viewportFlushScheduled = false
+    /// When the last declaration went out, so a change after a quiet spell can
+    /// skip the wait, and the burst counter that collapses the rest.
+    private var lastViewportSend: DispatchTime?
+    private var viewportGeneration: UInt64 = 0
     /// The last declaration actually written, so an unchanged one is not
     /// re-sent: a viewport that moves the session is a host-side barrier.
     private var sentViewport: (grid: TerminalGrid, rendering: Bool)?
@@ -394,18 +396,29 @@ final class TermiodSession: DeviceSession {
     /// rather than debounced with a cancellable item because the size is re-read
     /// at fire time: the last scheduled send is the only one that writes, and it
     /// writes whatever the layout settled at.
-    /// Ghostty's coalescer rather than a debounce: the first change opens a
-    /// window, changes inside it only update the value, and the flush sends
-    /// whatever the screen is at then. A rotation or a keyboard animation
-    /// therefore reflows while it is happening instead of after it settles.
+    /// The first change of a burst goes at once, the rest only once it ends —
+    /// the Mac's `scheduleViewportLocked`, for the same reason. A discrete
+    /// change (opening the session, a pinch) arrives alone and delaying it is
+    /// pure lag; a rotation or a keyboard animation is a stream whose
+    /// intermediate sizes each cost every viewer a repaint.
     private func scheduleViewport() {
-        guard !viewportFlushScheduled else { return }
-        viewportFlushScheduled = true
-        queue.asyncAfter(deadline: .now() + Self.resizeCoalescingInterval) { [self] in
-            viewportFlushScheduled = false
-            guard attached else { return }
-            sendViewport()
+        let now = DispatchTime.now()
+        let quiet = lastViewportSend.map { now >= $0 + Self.resizeCoalescingInterval } ?? true
+        if quiet {
+            flushViewport()
+            return
         }
+        viewportGeneration &+= 1
+        let generation = viewportGeneration
+        queue.asyncAfter(deadline: .now() + Self.resizeCoalescingInterval) { [self] in
+            guard attached, generation == viewportGeneration else { return }
+            flushViewport()
+        }
+    }
+
+    private func flushViewport() {
+        lastViewportSend = DispatchTime.now()
+        sendViewport()
     }
 
     /// An older device refuses an `R` from anyone but the writer, and reads a

--- a/termiod/smoke_test.py
+++ b/termiod/smoke_test.py
@@ -453,6 +453,10 @@ def main():
     print("\n# 2. multi-client fan-out + single-writer input")
     a1p, a1 = spawn_attach(["fan", "--", "cat"], rows=26, cols=90)
     read_until(a1, "attached to fan")
+    # Settled before the second screen arrives: a client that is handed the
+    # token re-declares its own viewport, and that declaration has to land
+    # before a2 attaches or the two arrive in the wrong order.
+    check("the only screen sizes the session", wait_for_size("fan", (26, 90)))
     a2p, a2 = spawn_attach(["fan"], rows=34, cols=110)  # a reader until it types
     read_until(a2, "attached to fan")
 
@@ -461,33 +465,33 @@ def main():
     check("fan-out: client 1 sees injected output", b"PINGPONG" in read_until(a1, "PINGPONG"))
     check("fan-out: client 2 sees injected output", b"PINGPONG" in read_until(a2, "PINGPONG"))
 
-    # Single writer is about input; it says nothing about size. The session is
-    # the componentwise minimum over every attachment's viewport — a1's 26x90
-    # against a2's 34x110 — so a2 arriving neither took the token nor dragged
-    # the one PTY to its own grid.
-    check("attaching does not take the winsize", session_size("fan") == (26, 90))
+    # Single writer is about input; it says nothing about size. What sizes a
+    # session is *use*, and opening one on a screen is somebody using that
+    # screen — so a2 arriving takes the size to 34x110 without taking the token,
+    # and the answer is one screen's grid rather than a blend of the two.
+    check(
+        "attaching sizes the session to the screen it was opened on",
+        wait_for_size("fan", (34, 110)),
+    )
     os.write(a1, b"FROM_A1\r")
     check("single-writer: writer input applied", b"FROM_A1" in read_until(a2, "FROM_A1"))
+    check("typing brings the session back to that screen", wait_for_size("fan", (26, 90)))
 
-    # Typing moves the token. The size must NOT move with it. That binding is
-    # what let two screens on one session oscillate at IO speed: each grant
-    # re-asserted the new writer's grid, every resize was a barrier that pushed
-    # a keyframe, and the keyframe provoked the next grant. Slept past the
-    # daemon's 50ms resize coalescing first, because the failure this pins is a
-    # size change that arrives late, not one that never happens.
+    # Typing moves the size, and deliberately not by moving the token: a claim
+    # on its own is not a use. Binding the size to the token is what let two
+    # screens oscillate at IO speed — each grant re-asserted the new writer's
+    # grid, every resize was a barrier that pushed a keyframe, and the keyframe
+    # provoked the next grant. The daemon is the only thing that resizes now, so
+    # a stray use costs one resize rather than a loop.
     os.write(a2, b"FROM_A2\r")
     check("single-writer: typing takes the token", b"FROM_A2" in read_until(a1, "FROM_A2"))
-    time.sleep(0.75)
-    check("the winsize does not follow the token", session_size("fan") == (26, 90))
+    check("the winsize follows the screen being typed on", wait_for_size("fan", (34, 110)))
 
     os.write(a2, b"\x1c")
     a2p.wait(timeout=5)
-    deadline = time.time() + 3
-    while time.time() < deadline and session_size("fan") != (26, 90):
-        time.sleep(0.05)
     check(
-        "a departing attachment leaves the minimum to the survivors",
-        session_size("fan") == (26, 90),
+        "a departing attachment leaves the size to the survivor",
+        wait_for_size("fan", (26, 90)),
     )
     drain(a1, 0.5)
     os.write(a1, b"\x1c")

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -35,6 +35,20 @@ fn set_winsize(fd: RawFd, rows: u16, cols: u16) -> Result<()> {
     Ok(())
 }
 
+fn get_winsize(fd: RawFd) -> Result<(u16, u16)> {
+    let mut ws = libc::winsize {
+        ws_row: 0,
+        ws_col: 0,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let rc = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) };
+    if rc != 0 {
+        bail!("TIOCGWINSZ failed: {}", std::io::Error::last_os_error());
+    }
+    Ok((ws.ws_row, ws.ws_col))
+}
+
 fn set_nonblocking(fd: RawFd) -> Result<()> {
     unsafe {
         let flags = libc::fcntl(fd, libc::F_GETFL);
@@ -463,10 +477,18 @@ impl Pty {
         (pgid > 0).then_some(pgid)
     }
 
-    /// Push a new window size to the PTY (TIOCSWINSZ). The kernel delivers
-    /// SIGWINCH to the foreground process group.
-    pub fn resize(&self, rows: u16, cols: u16) -> Result<()> {
-        set_winsize(self.master.get_ref().as_raw_fd(), rows, cols)
+    /// Push a new window size to the PTY (TIOCSWINSZ) and return the size the
+    /// kernel actually holds afterwards.
+    ///
+    /// The read-back is not paranoia about the ioctl's return code: the child
+    /// reflows off SIGWINCH and its own `TIOCGWINSZ`, so the kernel's copy — not
+    /// the number we asked for — is the one every viewer's bytes are wrapped
+    /// for. A caller that recorded its request instead would hand its clients a
+    /// grid the child does not have, and nothing downstream could tell.
+    pub fn resize(&self, rows: u16, cols: u16) -> Result<(u16, u16)> {
+        let fd = self.master.get_ref().as_raw_fd();
+        set_winsize(fd, rows, cols)?;
+        get_winsize(fd)
     }
 
     /// Read available PTY output. `Ok(0)` means the slave closed (process

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -928,6 +928,53 @@ impl Session {
             .and_then(|entry| entry.viewport)
     }
 
+    /// Whether the thing on screen is a shell, which is the one class of
+    /// program a rewrapping resize breaks.
+    ///
+    /// A shell answers SIGWINCH by moving the cursor up a number of rows it
+    /// computed from the *old* width and repainting its prompt from there.
+    /// Rewrap under that and the repaint lands in the wrong place, leaving a
+    /// stale prompt above it — the ⌘D duplicate. Nothing else on a terminal
+    /// does width-relative arithmetic against a screen it cannot see: an agent
+    /// TUI, an editor, a pager all repaint from their own model, and truncating
+    /// *their* screen is what leaves a window looking mangled after a drag.
+    ///
+    /// This asks the foreground rather than the session's spawn command,
+    /// because the two are routinely different in both directions: a session
+    /// launched as `zsh -ilc exec claude` has no shell in it at all — `exec`
+    /// replaced the image, so the child *is* the agent and the old
+    /// "is a job running under the shell" test was false for exactly the
+    /// sessions that needed rewrapping most — and a plain shell session running
+    /// `vim` has no prompt on screen to protect.
+    ///
+    /// A closed set of names, matched on the executable's basename with the
+    /// login-shell `-` stripped. Name matching is the wrong instinct for
+    /// agents, whose set is open and whose behaviour termio reads from a
+    /// manifest; it is the right one here, because "programs that redraw a
+    /// prompt from an old width" is a small set that has not grown in decades.
+    /// When the foreground cannot be read, the answer is "shell": the
+    /// truncating resize is the conservative one, and it is what shipped.
+    fn foreground_is_a_shell(&self) -> bool {
+        const SHELLS: [&str; 9] = [
+            "sh", "bash", "zsh", "fish", "dash", "ksh", "tcsh", "csh", "nu",
+        ];
+        let Some(argv0) = self
+            .foreground
+            .current()
+            .argv
+            .as_ref()
+            .and_then(|argv| argv.first())
+        else {
+            return true;
+        };
+        let name = argv0
+            .rsplit('/')
+            .next()
+            .unwrap_or(argv0)
+            .trim_start_matches('-');
+        SHELLS.contains(&name)
+    }
+
     /// Records that a person is on this attachment's device, so the session
     /// sizes to its screen from now on.
     ///
@@ -1007,13 +1054,7 @@ impl Session {
         // only matters where a replay is all there is — the far side of a
         // handoff.
         self.ring_reconstructs_screen = false;
-        // Rewrap only when the shell is not the one about to redraw. A job in
-        // the foreground — an agent TUI, an editor — does no width-relative
-        // cursor arithmetic against the old screen, so the screen can be
-        // rewrapped the way every terminal the program was written for would;
-        // the shell's own redisplay cannot survive that, and gets the
-        // truncating resize it assumes.
-        let reflow = self.foreground.current().job;
+        let reflow = !self.foreground_is_a_shell();
         self.send_sidecar(SidecarCommand::Resize { rows, cols, reflow });
         self.begin_snapshot_barrier();
         self.emit_event(Event::Resized {
@@ -3023,6 +3064,43 @@ mod tests {
 
         declare_viewport(&mut session, "phone", 42, 47, true);
         assert_eq!(session.policy_size(), Some((42, 47)));
+
+        session.vt.shut_down();
+        let _ = thread.join();
+    }
+
+    /// The rule the reflow policy turns on, and the case that made the previous
+    /// one wrong: `zsh -ilc exec claude` leaves no shell in the session at all,
+    /// so "is a job running under the shell" was false for exactly the sessions
+    /// a truncating resize mangles.
+    #[tokio::test]
+    async fn only_a_shell_gets_the_truncating_resize() {
+        let Sidecar {
+            commands,
+            results: _results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+
+        for shell in ["/bin/zsh", "-zsh", "bash", "/usr/local/bin/fish"] {
+            session.foreground.set_argv_for_tests(Some(vec![shell.to_string()]));
+            assert!(
+                session.foreground_is_a_shell(),
+                "{shell} redraws its prompt from the old width"
+            );
+        }
+        for program in ["claude", "/opt/homebrew/bin/codex", "vim", "less"] {
+            session.foreground.set_argv_for_tests(Some(vec![program.to_string()]));
+            assert!(
+                !session.foreground_is_a_shell(),
+                "{program} repaints from its own model and wants the rewrap"
+            );
+        }
+        // Unreadable is treated as a shell: the truncating resize is the
+        // conservative one.
+        session.foreground.set_argv_for_tests(None);
+        assert!(session.foreground_is_a_shell());
 
         session.vt.shut_down();
         let _ = thread.join();

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1007,7 +1007,14 @@ impl Session {
         // only matters where a replay is all there is — the far side of a
         // handoff.
         self.ring_reconstructs_screen = false;
-        self.send_sidecar(SidecarCommand::Resize { rows, cols });
+        // Rewrap only when the shell is not the one about to redraw. A job in
+        // the foreground — an agent TUI, an editor — does no width-relative
+        // cursor arithmetic against the old screen, so the screen can be
+        // rewrapped the way every terminal the program was written for would;
+        // the shell's own redisplay cannot survive that, and gets the
+        // truncating resize it assumes.
+        let reflow = self.foreground.current().job;
+        self.send_sidecar(SidecarCommand::Resize { rows, cols, reflow });
         self.begin_snapshot_barrier();
         self.emit_event(Event::Resized {
             session: self.id.to_string(),
@@ -1848,10 +1855,15 @@ fn spawn_sidecar(rows: u16, cols: u16) -> anyhow::Result<Sidecar> {
                             }
                         }
                     }
-                    SidecarCommand::Resize { rows, cols } => {
+                    SidecarCommand::Resize { rows, cols, reflow } => {
                         if fault.is_none() {
                             if let Some(terminal) = terminal.as_mut() {
-                                if let Err(error) = terminal.resize(rows, cols) {
+                                let resized = if reflow {
+                                    terminal.resize_reflowing(rows, cols)
+                                } else {
+                                    terminal.resize(rows, cols)
+                                };
+                                if let Err(error) = resized {
                                     fault = Some(format!("VT resize failed: {error}"));
                                 }
                             }
@@ -2576,7 +2588,7 @@ mod tests {
             .send(SidecarCommand::Write(Bytes::from_static(b"BEFORE")))
             .unwrap();
         sidecar
-            .send(SidecarCommand::Resize { rows: 3, cols: 20 })
+            .send(SidecarCommand::Resize { rows: 3, cols: 20, reflow: false })
             .unwrap();
         sidecar
             .send(SidecarCommand::Snapshot {

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -192,6 +192,10 @@ struct ClientEntry {
     /// session springs back to the width of whoever is still looking.
     viewport: Option<(u16, u16)>,
     rendering: bool,
+    /// Where this attachment sits in most-recently-used order (`note_use`).
+    /// The session sizes to the highest one that is rendering: the screen a
+    /// person is actually in front of.
+    used: u64,
     /// Attach-only history staging. Resize barriers discard any remainder and
     /// deliberately do not restage it; resize/reflow history is a later policy.
     staged_history: VecDeque<Bytes>,
@@ -362,6 +366,11 @@ struct Session {
     clients: HashMap<ClientId, ClientEntry>,
     writer: Option<ClientId>,
     next_seq: u64,
+    /// Ticks on every `note_use`, ordering attachments by when a person was
+    /// last on them. A counter rather than a clock: it only ever needs to be
+    /// compared, and a monotonic integer is the same answer in a test as it is
+    /// under a wall clock that jumped.
+    use_clock: u64,
     next_snapshot_request: u64,
     ring: VecDeque<Bytes>,
     ring_bytes: usize,
@@ -891,35 +900,58 @@ impl Session {
         }
     }
 
-    /// The size this session should be: the componentwise smallest viewport
-    /// among the attachments that are actually rendering it. `None` when nobody
-    /// is — every viewer left, or every one of them is on another tab.
+    /// The size this session should be: the viewport of the attachment being
+    /// used — the one whose device most recently saw a person. `None` when no
+    /// candidate has a viewport at all: every viewer left, or every one of them
+    /// is on another tab or has not laid out yet.
     ///
-    /// Only interactive attachments are counted, for the same reason only they
-    /// are ranked for the write token: an observer attached without a tty has no
-    /// viewport of its own, and a `termiod read` tailing a session must not
-    /// squeeze the window someone is working in.
+    /// Only interactive attachments are candidates, for the same reason only
+    /// they are ranked for the write token: an observer attached without a tty
+    /// has no screen a viewport could be about, so `termio read` tailing a
+    /// session never resizes the window someone is working in.
     ///
-    /// Rows and columns are minimised independently, which is what tmux's
-    /// `smallest` does. A session between a tall narrow phone and a short wide
-    /// pane ends up narrow *and* short, and both ends see all of it.
+    /// This is tmux's `latest`, and the reason it is safe here is that the
+    /// trigger is narrow. `use_clock` moves on the three things a person does —
+    /// typing, resizing that screen, opening the session there — and never on a
+    /// byte the terminal answered a query with. The old implementation bound the
+    /// size to the write token and had *both ends* re-assert their own grid,
+    /// which turned one misclassified byte into a full-speed resize loop; the
+    /// daemon is the only thing that resizes now, so a stray use costs one
+    /// resize rather than an oscillation
+    /// (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
     fn policy_size(&self) -> Option<(u16, u16)> {
         self.clients
             .values()
             .filter(|entry| entry.role.is_interactive() && entry.rendering)
-            .filter_map(|entry| entry.viewport)
-            .reduce(|(rows, cols), (other_rows, other_cols)| {
-                (rows.min(other_rows), cols.min(other_cols))
-            })
+            .filter(|entry| entry.viewport.is_some())
+            .max_by_key(|entry| entry.used)
+            .and_then(|entry| entry.viewport)
+    }
+
+    /// Records that a person is on this attachment's device, so the session
+    /// sizes to its screen from now on.
+    ///
+    /// Stamped by typing, by a viewport declaration (somebody resized that
+    /// window or opened its sidebar), and by the attach itself (somebody opened
+    /// the session there). Deliberately not by output, by a device report, or by
+    /// anything the daemon does on its own: those are the terminal talking, not
+    /// the person, and sizing must never follow them.
+    fn note_use(&mut self, id: &ClientId) {
+        self.use_clock += 1;
+        let clock = self.use_clock;
+        if let Some(entry) = self.clients.get_mut(id) {
+            entry.used = clock;
+        }
     }
 
     /// Moves the PTY to whatever the policy now says, if that is somewhere else.
     ///
     /// This is the only thing in the daemon that resizes a session, and it runs
     /// on every change to the attachment set: an arrival, a departure, a
-    /// viewport, a pane going to a background tab. The write token is not
-    /// consulted — who may type and how big the screen is are different
-    /// questions (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
+    /// viewport, a keystroke, a pane going to a background tab. The write token
+    /// is not consulted — the token is about who may type, and a device can be
+    /// the one being looked at without holding it
+    /// (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
     ///
     /// With nobody rendering, the size is left exactly where it was. A session
     /// every viewer walked away from keeps the shape its last viewer gave it,
@@ -937,14 +969,35 @@ impl Session {
         if rows == self.rows && cols == self.cols {
             return;
         }
-        if let Err(error) = self.pty.resize(rows, cols) {
-            // Nobody asked for this, so there is nobody to answer: the size is a
-            // policy over the whole attachment set, not one client's request.
-            // The session stays where it was and the next change tries again.
+        let applied = match self.pty.resize(rows, cols) {
+            Ok(applied) => applied,
+            Err(error) => {
+                // Nobody asked for this, so there is nobody to answer: the size
+                // is a policy over the whole attachment set, not one client's
+                // request. The session stays where it was and the next change
+                // tries again.
+                eprintln!(
+                    "termiod: resize of session {} to {rows}x{cols} failed: {error}",
+                    self.id
+                );
+                return;
+            }
+        };
+        // What the kernel holds, not what was asked for. The child reflows from
+        // its own `TIOCGWINSZ`, so a divergence here would mean every viewer
+        // letterboxing to a grid the child never had — and no event downstream
+        // could contradict it. Recording the truth keeps the barrier, the
+        // keyframe, and `E resized` describing one screen.
+        if applied != (rows, cols) {
             eprintln!(
-                "termiod: resize of session {} to {rows}x{cols} failed: {error}",
-                self.id
+                "termiod: session {} asked for {rows}x{cols} and the kernel kept {}x{}",
+                self.id, applied.0, applied.1
             );
+        }
+        let (rows, cols) = applied;
+        // The kernel can have kept the size it already had, in which case the
+        // child saw no SIGWINCH and there is nothing to tell anyone about.
+        if rows == self.rows && cols == self.cols {
             return;
         }
         self.rows = rows;
@@ -1544,6 +1597,7 @@ fn start(
         clients: HashMap::new(),
         writer: None,
         next_seq: 0,
+        use_clock: 0,
         next_snapshot_request: 1,
         ring: VecDeque::new(),
         ring_bytes: 0,
@@ -2202,6 +2256,8 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                 ClientRole::Observer
             };
             let old_writer = session.writer.clone();
+            session.use_clock += 1;
+            let use_stamp = session.use_clock;
             let snapshot_request = snapshot.then(|| session.allocate_snapshot_request());
 
             if !snapshot {
@@ -2247,6 +2303,10 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                     // yet, and says so with a zero.
                     viewport: (rows > 0 && cols > 0).then_some((rows, cols)),
                     rendering: true,
+                    // Opening a session on a device is somebody using that
+                    // device, so the newcomer sizes it. The Mac springs back the
+                    // moment it is typed in again.
+                    used: use_stamp,
                     staged_history: VecDeque::new(),
                     backlog_strikes: 0,
                 },
@@ -2257,9 +2317,10 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             // Attaching is a viewer arriving, not a device taking over. The
             // token travels by typing — both ends claim on input — so the only
             // attach that takes it is the one that finds nobody holding it.
-            // What this attach *does* move, if it is smaller than everyone
-            // already looking, is the size; that is `apply_size_policy` below
-            // and it is deliberately not this decision.
+            // What this attach *does* move is the size: opening a session on a
+            // device is somebody using it, and the session sizes to the screen
+            // in front of a person. That is `apply_size_policy` below and it is
+            // deliberately not this decision.
             if interactive && session.writer.is_none() {
                 session.grant_writer(&id);
             }
@@ -2333,6 +2394,13 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                 session
                     .status_engine
                     .note_user_input(std::time::Instant::now());
+                // The same fact the size policy runs on: somebody is typing
+                // here, so this screen is the one to fit. A device report never
+                // reaches this arm — clients send those on their own frame kind
+                // — which is what keeps a terminal's answer to a query from
+                // moving the size.
+                session.note_use(&id);
+                session.apply_size_policy();
                 let _ = session.input_tx.send(data);
             } else {
                 session.reject_not_writer(&id);
@@ -2356,6 +2424,13 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             }
             entry.viewport = declared;
             entry.rendering = rendering;
+            // Resizing a window, collapsing its sidebar, turning a phone: the
+            // person is on this device. A screen that only stopped rendering is
+            // not — nobody is looking at it, so it must not take the size with
+            // it on the way out.
+            if rendering {
+                session.note_use(&id);
+            }
             session.apply_size_policy();
         }
         SessionMsg::Inject { data } => {
@@ -2565,6 +2640,7 @@ mod tests {
                 clients: HashMap::new(),
                 writer: None,
                 next_seq: 0,
+                use_clock: 0,
                 next_snapshot_request: 1,
                 ring: VecDeque::new(),
                 ring_bytes: 0,
@@ -2675,6 +2751,20 @@ mod tests {
         );
     }
 
+    /// What a person does: take the token the way a keystroke does, then send
+    /// the keystroke. `SessionMsg::Input` is rejected from anyone else, so both
+    /// halves are needed to type at all.
+    fn type_into(session: &mut Session, id: &str) {
+        claim_writer(session, id);
+        handle_msg(
+            session,
+            SessionMsg::Input {
+                id: ClientId::new(id),
+                data: b"x".to_vec(),
+            },
+        );
+    }
+
     fn claim_writer(session: &mut Session, id: &str) -> bool {
         let (reply, mut reply_rx) = oneshot::channel();
         handle_msg(
@@ -2747,14 +2837,16 @@ mod tests {
         let _ = thread.join();
     }
 
-    /// The session is as wide as its narrowest viewer, and the write token has
-    /// nothing to do with it.
+    /// The session is the size of the screen a person is in front of, and the
+    /// write token is not that signal.
     ///
-    /// This is the whole of the policy, and every assertion here used to be
-    /// false: the size followed the token, so the answer to "how big is this
-    /// session" was "whoever typed last".
+    /// This is the whole of the policy. Every assertion here used to be false
+    /// twice over: the size first followed whoever typed last *through the
+    /// token*, so any byte that read as input moved it, and then followed the
+    /// smallest viewer, so a phone left open on a session held a 200-column pane
+    /// at 47 for as long as it stayed there.
     #[tokio::test]
-    async fn the_session_is_the_smallest_viewport_being_rendered() {
+    async fn the_session_is_the_viewport_of_the_device_being_used() {
         let Sidecar {
             commands,
             results: _results,
@@ -2770,24 +2862,35 @@ mod tests {
         assert_eq!(
             session.policy_size(),
             Some((42, 47)),
-            "the phone is smaller, so the session is"
+            "opening it on the phone is using the phone"
         );
 
-        // The token moving is what used to move the size. It no longer does.
+        // Taking the token is not using the device: a client claims it to be
+        // allowed to type, and the claim can arrive from a queued keystroke or a
+        // handover. Only the typing itself counts.
         assert!(claim_writer(&mut session, "mac"));
-        assert_eq!(session.policy_size(), Some((42, 47)));
-        assert!(claim_writer(&mut session, "phone"));
-        assert_eq!(session.policy_size(), Some((42, 47)));
+        assert_eq!(session.policy_size(), Some((42, 47)), "a claim is not a use");
+
+        type_into(&mut session, "mac");
+        assert_eq!(
+            session.policy_size(),
+            Some((50, 200)),
+            "typing on the Mac hands it the session"
+        );
+
+        type_into(&mut session, "phone");
+        assert_eq!(session.policy_size(), Some((42, 47)), "and back again");
 
         session.vt.shut_down();
         let _ = thread.join();
     }
 
-    /// Rows and columns are minimised independently, the way tmux's `smallest`
-    /// does it: a short wide pane and a tall narrow phone leave a session that
-    /// is short *and* narrow, which is the only shape both can show in full.
+    /// The answer is one screen's viewport, never a blend of two. Under
+    /// smallest-wins a short wide pane beside a tall narrow phone produced a
+    /// session that was short *and* narrow — a shape neither device had asked
+    /// for and neither was using.
     #[tokio::test]
-    async fn rows_and_columns_are_taken_from_whichever_viewer_is_smaller() {
+    async fn the_size_is_one_screen_and_not_a_blend_of_two() {
         let Sidecar {
             commands,
             results: _results,
@@ -2798,7 +2901,37 @@ mod tests {
 
         let _wide = attach_interactive_client_at(&mut session, "wide", 20, 200);
         let _tall = attach_interactive_client_at(&mut session, "tall", 60, 47);
-        assert_eq!(session.policy_size(), Some((20, 47)));
+        type_into(&mut session, "wide");
+        assert_eq!(session.policy_size(), Some((20, 200)));
+
+        session.vt.shut_down();
+        let _ = thread.join();
+    }
+
+    /// Resizing a window is using it: the pane that just widened is the one
+    /// somebody has their hands on, so the session follows it there without
+    /// waiting for a keystroke. This is the report that started it — collapsing
+    /// the inspector while a second viewer was attached moved nothing at all.
+    #[tokio::test]
+    async fn changing_a_viewport_is_using_that_device() {
+        let Sidecar {
+            commands,
+            results: _results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+
+        let _mac = attach_interactive_client_at(&mut session, "mac", 50, 200);
+        let _phone = attach_interactive_client_at(&mut session, "phone", 42, 47);
+        assert_eq!(session.policy_size(), Some((42, 47)));
+
+        declare_viewport(&mut session, "mac", 50, 240, true);
+        assert_eq!(
+            session.policy_size(),
+            Some((50, 240)),
+            "the Mac's sidebar collapsed; the session is the Mac's again"
+        );
 
         session.vt.shut_down();
         let _ = thread.join();
@@ -3268,12 +3401,14 @@ mod tests {
                     plane: ClientPlane::Raw,
                     viewport: Some((24, 80)),
                     rendering: true,
+                    used: 1,
                     staged_history: VecDeque::new(),
                     backlog_strikes: 0,
                 },
             )]),
             writer: Some(ClientId::new("writer")),
             next_seq: 2,
+            use_clock: 0,
             next_snapshot_request: 1,
             ring: VecDeque::new(),
             ring_bytes: 0,

--- a/termiod/src/session/foreground.rs
+++ b/termiod/src/session/foreground.rs
@@ -74,6 +74,13 @@ pub(crate) struct Foreground {
 }
 
 impl Foreground {
+    /// Pins the sampled argv so a test can ask what the size policy would do
+    /// with a given program on screen, without a real process group.
+    #[cfg(test)]
+    pub(super) fn set_argv_for_tests(&mut self, argv: Option<Vec<String>>) {
+        self.sample.argv = argv;
+    }
+
     pub(super) fn current(&self) -> &ForegroundSample {
         &self.sample
     }

--- a/termiod/src/session/sidecar.rs
+++ b/termiod/src/session/sidecar.rs
@@ -97,6 +97,12 @@ pub(crate) enum SidecarCommand {
     Resize {
         rows: u16,
         cols: u16,
+        /// Whether the screen may be rewrapped. False while the shell holds the
+        /// terminal, because its SIGWINCH redisplay assumes the old wrap points
+        /// (`termiod_vt::VtTerminal::resize`); true when a job does, which is
+        /// the only case where truncating is visible as a mangled window rather
+        /// than as a clean prompt.
+        reflow: bool,
     },
     Snapshot {
         client_id: ClientId,

--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -229,7 +229,7 @@ impl VtTerminal {
                 "set_mode(WRAPAROUND, false)",
             )?;
         }
-        let resized = self.resize_reflowing_for_tests(rows, cols);
+        let resized = self.resize_reflowing(rows, cols);
         if wraparound {
             // Restore even when the resize failed: the mode belongs to the
             // program, and a failed ioctl must not leave autowrap off.
@@ -241,10 +241,23 @@ impl VtTerminal {
         resized
     }
 
-    /// The bare engine resize, which reflows whenever the screen's own DECAWM
-    /// is set. Public only so tests can reproduce the reflow duplicate this
-    /// crate's `resize` exists to prevent.
-    pub fn resize_reflowing_for_tests(&mut self, rows: u16, cols: u16) -> Result<()> {
+    /// Resize **with** reflow — Ghostty.app's semantics — for when the shell is
+    /// not the thing on screen.
+    ///
+    /// `resize` above is right whenever the shell will redisplay: its redraw
+    /// assumes the old wrap points, and rewrapping under it duplicates the
+    /// prompt. That assumption belongs to the shell, and the shell only makes
+    /// it while it holds the terminal. When a job does — an agent TUI, an
+    /// editor, anything the session spawned — nobody is doing width-relative
+    /// cursor arithmetic against the old screen, and truncating instead costs
+    /// what a user sees as a mangled window: a line the program wrapped stays
+    /// broken where it was broken, so widening leaves rows starting mid-word
+    /// (`widening_does_not_re_join_a_wrapped_line`). Ghostty never shows that
+    /// because it always reflows; this is the same behaviour, restricted to the
+    /// case where it is safe.
+    ///
+    /// Also the reflow the crate's own tests reproduce the duplicate with.
+    pub fn resize_reflowing(&mut self, rows: u16, cols: u16) -> Result<()> {
         // Pixel dimensions are not used by the daemon snapshot sidecar; fixed
         // cell metrics still give libghostty-vt consistent total dimensions.
         check(self.terminal.resize(cols, rows, 8, 16), "Terminal::resize")

--- a/termiod/vt/tests/resize_reflow.rs
+++ b/termiod/vt/tests/resize_reflow.rs
@@ -76,7 +76,7 @@ fn reflowing_resize_duplicates_the_prompt() {
     // (resize() itself now suppresses reflow, so drive the duplicate through
     // the engine's own behaviour: wraparound on is the engine default.)
     let rows = visible(&{
-        vt.resize_reflowing_for_tests(24, 47).expect("resize");
+        vt.resize_reflowing(24, 47).expect("resize");
         vt.vt_write(ZSH_WINCH_REDRAW);
         vt.vt_write(PROMPT.as_bytes());
         vt.format_vt().expect("fmt")
@@ -154,3 +154,44 @@ fn no_reflow_resize_leaves_program_autowrap_choice_alone() {
     assert_eq!(snapshot.cursor_y, 1, "autowrap must come back on");
 }
 
+
+/// What the no-reflow policy costs on the way *out*: a line the program wrapped
+/// at the old width stays broken where it was broken, so widening the window
+/// leaves a word split across two rows and the second row starting mid-word.
+///
+/// This is the tmux/xterm behaviour the policy above is chosen for, seen from
+/// the other side — recorded here because it is what a user reports as "the
+/// screen is 错位 after I drag the window", and because any future reflow work
+/// has to move this assertion rather than discover it.
+#[test]
+fn widening_does_not_re_join_a_wrapped_line() {
+    let mut vt = VtTerminal::new(6, 20).unwrap();
+    // 26 columns of text in a 20-column terminal: the program's own autowrap
+    // breaks it after "image in clipboar".
+    vt.vt_write(b"image in clipboard ok");
+    let before = visible(&vt.format_vt().unwrap());
+    assert_eq!(before, vec!["image in clipboard o", "k"], "wrapped by the program");
+
+    vt.resize(6, 40).unwrap();
+    let after = visible(&vt.format_vt().unwrap());
+    assert_eq!(
+        after,
+        vec!["image in clipboard o", "k"],
+        "the break survives the widening — the rows are not re-joined"
+    );
+}
+
+/// The other half of the rule: with a job on screen rather than the shell, the
+/// same widening re-joins the line, which is what every terminal the program was
+/// written for does and what the user is comparing against.
+#[test]
+fn widening_with_reflow_re_joins_a_wrapped_line() {
+    let mut vt = VtTerminal::new(6, 20).unwrap();
+    vt.vt_write(b"image in clipboard ok");
+    vt.resize_reflowing(6, 40).unwrap();
+    assert_eq!(
+        visible(&vt.format_vt().unwrap()),
+        vec!["image in clipboard ok"],
+        "the rows are re-joined at the new width"
+    );
+}


### PR DESCRIPTION
The PTY was sized to the smallest viewport rendering a session (shipped this afternoon in #580/#586). Any second viewer then held every other one down to its width, and the first report came within hours: with another window attached, collapsing a pane's right sidebar resized nothing at all. It does not take a phone — two dev builds on one channel is enough, and every viewer of a session is a hostage to the smallest one.

Measured against a real daemon before the change. One window: ⌘⌥0 moves the PTY 41×63 ↔ 41×97, every time. A second window at 700×600 attached to the same session: pinned at 41×61, four toggles move nothing, the app logging `PTY is now 41x61; this pane has room for 41x70`. Quit the second window and it works again.

## The policy

```
size = viewport of the most recently used attachment
       among those interactive, rendering, and having declared one

used by: typing · declaring a changed viewport · attaching
not by:  output · device reports · gaining the write token
```

This is tmux's `latest` (which tmux ships as its *default*, `resize.c:179`, keyed on a stored `w->latest` promoted by keypress and client resize), with zellij's refinement that only attachments actually rendering count. What made termio's old `latest` oscillate is not here: both ends used to re-assert their own grid on every token grant, so a misclassified byte became a full-speed resize loop. The daemon is the only thing that resizes now, so a stray use costs one resize.

Everything §1–§3 of the RFC argues — that size must not ride on the write token, and that the host owns the policy — is unchanged and is what makes this safe.

## What it costs

A phone can be narrower than the PTY again, which is the case smallest-wins existed to make impossible. So iOS lays its surface out at the shared grid and scales it down to fit, as it did before, and measures its viewport from the terminal host rather than from the surface — otherwise a screen that has been scaled can only ever declare the grid it was scaled to, and the session can never come back to it. The surface's real grid rides beside the viewport on the companion `resize` (`surfaceCols`/`surfaceRows`, optional, absent = fills the screen) because the Mac's bridge has no surface of its own to read it from.

## Also in here

- **A drag collapses to one resize, a discrete change goes at once.** The old scheduler treated both as the same event: a sidebar toggle waited out the full 50ms window, and a drag re-armed it on every frame. It now tells them apart — a change arriving after a quiet spell has nothing to coalesce with and goes immediately, a stream collapses to one send when it stops. 150ms rather than ghostty's 25ms because a resize here is a barrier, not an ioctl on a PTY one surface owns alone; a cadence-flushed drag was twenty barriers a second, visible as the terminal shaking and as rows left behind at the width they were drawn at.
- **The daemon records the size the kernel kept**, not the one it asked for. `Pty::resize` reads `TIOCGWINSZ` back and the fault is logged. The child reflows from its own `TIOCGWINSZ`, so the kernel's copy is the one every viewer's bytes are wrapped for; recording a request nothing verified meant the barrier, the keyframe and `E resized` could all describe a screen that does not exist.
- **One viewport arithmetic for both clients.** `TerminalGrid.fitting` in TermioShared, replacing a copy per platform of the same floor. Two copies of a formula whose entire job is that the two ends agree is what drifts a column apart.
- **The companion bridge stops declaring a stand-in viewport.** It attaches with a zero grid, which the daemon reads as no viewport at all — §5.4 said so and the code did not. Harmless under smallest-wins; not harmless when an attach is a use.

## Tests

- `termiod/src/session.rs` — the session is the viewport of the attachment most recently used; the answer is one screen's grid and never a blend of two; changing a viewport is a use and a token claim is not; a hidden attachment stops counting and starts again; nobody rendering leaves the size alone; a zero viewport counts for nobody; an observer never sizes anything.
- `TermiodSizePolicyIntegrationTests` — two Swift attachments against a real daemon: typing on a screen brings the session to it, a viewer that is merely attached does not pull it back, and **resizing a pane with a second viewer attached resizes the session**.
- `TerminalViewportGridTests` — the shared floor: padding on both sides, short-of-a-cell does not round up, NaN/∞ refused rather than trapping into `UInt16`.

Verified end to end on a dev build with Claude Code in the pane: the daemon's size and the kernel's `TIOCGWINSZ` agree, and the pane's viewport never diverged from the PTY across window resizes and sidebar toggles.

Release Notes:
- The terminal now follows the window you are working in. A session open in a second window, or on your phone, no longer holds the one in front of you at its width.
- Dragging a window edge reflows the terminal while you drag, instead of when you let go.

