### PR TITLE
Turn the README comparison into a table and resync the translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,21 +12,40 @@
 
 <p><a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a> | 日本語 | <a href="README.ko.md">한국어</a></p>
 
-<br />
-
-Claude Code、Codex をはじめ、あらゆる CLI エージェントを本物の Mac ターミナルで並列に実行 —<br />
-Swift と libghostty、Electron なし。メニューバーのドットが、いま対応の必要なエージェントを知らせ、<br />
-席を離れているあいだは iPhone が見守ります。
-
-<br />
-
 [**macOS 版をダウンロード**](https://downloads.termio.sh/termio.dmg) &nbsp;&bull;&nbsp; [ウェブサイト](https://termio.sh) &nbsp;&bull;&nbsp; [ドキュメント](https://termio.sh/docs) &nbsp;&bull;&nbsp; [変更履歴](https://termio.sh/changelog) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/H9DKVwsE5f)
-
-<br />
 
 <img alt="ダークモードの Termio: プロジェクトサイドバーの横で動作するライブ Claude Code セッション" src="web/landing/public/screenshots/hero1.png" width="100%" />
 
 </div>
+
+## ターミナルファーストの ADE
+
+コードの大半をエージェントが書くようになると、環境の仕事はエージェントを動かすこと、そして「いまどれがあなたを必要としているか」を伝えることになります。Termio はその環境であり、本物のターミナルです。エージェントはすでにターミナルに住んでいるからです。
+
+初回起動時に、各エージェント自身のフックを自動で設定します。セッションは作業中・アイドル・*要対応* を報告し、サイドバーのドット、詰まったときに鳴るメニューバーのアイコン、そして同じシグナルがあなたの iPhone にも届きます。Claude Code、Codex、OpenCode、Pi、Amp、Cursor、Copilot、Kimi、Antigravity、Crush、Grok、そのほかどんな CLI エージェントでも。
+
+詳しい議論は [*From IDE to ADE*](docs/essays/from-ide-to-ade.md) をご覧ください。
+
+### tmux の代わりに
+
+みんなが tmux を覚えろと言う理由が、Termio では覚えなくて済みます。各セッションのシェルはデーモン `termiod` の中で動くので、アプリを終了してもデタッチされるだけです。ノートを閉じて、また Termio を開けば、エージェントは離れたときのまま — 同じプロセス、同じスクロールバック。終了させるのは「セッションを閉じる」（⌘W）だけです。
+
+分割は ⌘D、ズームは ⇧⌘↩。Ctrl-b のようなプレフィックスキーはありません。⌘ ショートカットはペイン内のプログラムに届かないので、vim や TUI とキーが衝突しません。スクロール・選択・コピーはトラックパッドと ⌘C で。copy-mode はありません。
+
+### リモート VPS
+
+`ssh` で入れる Linux VPS ならどれでも。Termio は `~/.ssh/config` を読むだけで、書き換えることはありません。**設定 ▸ デバイス ▸ セットアップ**が SSH 経由でバイナリを 1 つ `~/.local/bin` にコピーし、デーモンを起動し、そのマシンにエージェントのフックを入れます。ローカルのセッションもリモートのセッションも、同じホストを通ります。
+
+セッションは接続ではなくマシンの上で生きています。回線が切れてもエージェントは働き続け、再接続すれば画面がそのまま戻ります。Zed Remote や VS Code Remote は、リモート作業を生きた接続の中に閉じ込めます。
+
+## 他のツールとの比較
+
+| | どんなツールか | Termio との違い |
+| --- | --- | --- |
+| **[Ghostty](https://ghostty.org)** | ターミナルそのもの。Termio はそのコアである [libghostty](https://ghostty.org) で描画しています（フォークではありません）。 | Ghostty はエージェントを追跡せず、セッションを永続化せず、VPS 上で動かすこともしません。速いターミナルが欲しいなら Ghostty です。Termio はエージェントが動く環境のほうです。 |
+| **[cmux](https://cmux.com)** | いちばん近い親戚：ネイティブ Swift、libghostty、エージェントが呼んだときに鳴る通知、iPhone コンパニオン。リモートは SSH ワークスペース（マシン上のリレー、必要なら tmux）で、iPhone は Mac とペアリングします。 | すべてのセッションが `termiod` 上で動きます。この Mac でも Linux VPS でも同じで、iPhone はそのホストへ直接アタッチします。ステータスはメニューバー、プロジェクトと worktree はサイドバーに。cmux にはアプリ内のスクリプト可能なブラウザがあり、Ghostty の設定も読みますが、Termio にはありません。 |
+| **[herdr](https://herdr.dev)** | いま使っているターミナルの中で動くマルチプレクサ。永続化の考え方は同じ（サーバーが PTY を持つ）で、各エージェントを作業中・ブロック中・アイドルとしてマークします。形は tmux 的：プレフィックスキー、TUI、SSH でアタッチ、macOS / Linux / Windows 対応。 | Termio はネイティブの Mac アプリで、Mac のショートカット、iPhone コンパニオン、そしてサイドバーのワークスペースとしての VPS があります。アタッチしに行く TUI ではありません。 |
+| **[Otty](https://otty.sh)** | エージェント向けに調整されたネイティブ Mac ターミナル：タブのバッジ、コンポーザ、Claude / Codex / OpenCode を再開できるセッション復元。ターミナルと ADE の中間に位置します。 | Termio はその ADE 側です。セッションは `termiod` の中で生き、アプリを終了しても残り、Linux VPS 上でも iPhone 上でも同じオブジェクトです。 |
 
 ## インストール
 
@@ -38,108 +57,148 @@ brew install --cask termio-sh/tap/termio
 
 **iPhone では**: [TestFlight](https://testflight.apple.com/join/1Arf1UKR) でコンパニオンのベータ版を入手し、Mac アプリの設定 ▸ Mobile に表示される QR コードをスキャンしてペアリングしてください。
 
-## エージェント時代の開発のために
+## 使えるもの
 
-IDE は、人間がコードを打ち込むことを前提に設計されてきました。コードの大半をエージェントが書くようになると、環境の役割は変わります。そこはエージェントが働く場所であり、あなたが指示し、レビューし、行き詰まったエージェントを助ける場所です。Termio はまさにその環境です。エージェントがすでに住んでいる場所だからこそターミナルファーストであり、複数のエージェントが同時に動き、そのほとんどは手がかからず、ひとつだけが詰まっている — そんな新しい仕事のかたちのために作られています。（詳しい議論は [*From IDE to ADE*](docs/essays/from-ide-to-ade.md) をご覧ください。）
-
-- **Web ビューではない、本物のターミナル。** Swift + AppKit を
-  [libghostty](https://ghostty.org)（Ghostty のターミナルコア）の上に構築し、
-  Metal でレンダリングします。Electron も xterm.js も使っていません。
-- **プロジェクト → セッション。** サイドバーは実際の作業の構造をそのまま映します。
-  各プロジェクトが自分のターミナルとエージェントを持ち、その下に並行タスク用の
-  git ワークツリーがネストされます。
-- **設定ゼロのステータス表示。** Termio は各エージェント固有のフックを自動で配線し、
-  エージェントがもともと発しているシグナルを読み取ります。作業中・アイドル・
-  *要対応* — セッションごとのドットに加え、メニューバーのトレイは普段は静かに、
-  エージェントの作業中は脈打ち、あなたの対応待ちになると鳴って知らせます。
-- **離れずにレビュー。** 読み取り専用の git ペイン（変更、履歴、unified diff）、
-  クリックでそのまま編集できるエディタ付きのファイルツリー、プロジェクト全体のコンテンツ検索 —
-  コミットする場所は、あくまでターミナルのままです。
-- **git ワークツリー。** サイドバーから作成すると、プロジェクト配下にネストされた
-  フォルダとして表示されます。並行タスクごとに 1 ブランチ。
-- **チャット。** どのプロジェクトにも属さない使い捨てのエージェント会話。
-- **使用量メーター。** Claude と Codex のプラン上限を、設定 → Usage に
-  ローカルで表示します。
-- **テーマ。** ライト、ダーク、システムに追従するガラス調。
-- **自動アップデート。** 公証済み DMG を Sparkle が更新します。
-- **無料。** アカウントもライセンスキーも有料プランもありません。MIT ライセンスです。
-
-## tmux を学ばなくていい
-
-みんなが tmux を学べと言う理由は、エージェントの作業にはターミナルより長生きする
-セッションが要るからです — アプリを終了しても、ノートを閉じても、エージェントは
-動き続けてほしい。Termio はそれを最初からやります。各セッションのシェルはデーモン
-`termiod` の中に住んでいるので、終了しても切断されるだけ。アプリを開き直せば、
-エージェントは離れたときのまま — 同じプロセス、同じスクロールバックです。
-終わらせるのは「セッションを閉じる」（⌘W）だけ。
-
-tmux が教えてくれるはずだった残りは、Mac のショートカットか、もう知っていることです。
-
-- 分割は ⌘D、ズームは ⇧⌘↩ — 先に Ctrl-b は要りません。⌘ ショートカットは
-  ペインの中のプログラムに届かないので、vim や TUI とキーを取り合いません。
-- スクロール・選択・コピーはトラックパッド、マウス、⌘C。出入りする copy-mode は
-  ありません。
-- Linux マシンのセッションも同じデーモンが動き、どのシェルからでも
-  `termiod attach <session>` で入れます。
-- スクリプトは `termio sessions`（後述）が `send-keys` の役目を果たし、
-  エージェントのステータスは画面ではなくプロトコル上のオブジェクトです。
-
-## お使いのエージェントで動く
-
-Claude Code、Codex、Gemini CLI、Grok、Cursor Agent、Copilot、Amp、OpenCode、
-Pi、Kimi — そのほかどんな CLI エージェントでも動きます。セッションは本物のターミナルそのものだからです。組み込み対応のエージェントは、Termio がそれぞれのフックやプラグインを自動でインストールするため、初回起動からステータス検出が機能します。
+<table>
+<tr>
+<td width="50%" valign="top">
+<h3>プロジェクトがセッションを持つ</h3>
+<p>チェックアウトごとに 1 プロジェクト、その下にターミナルとエージェント。チャットはその上 — どのプロジェクトにも属さない使い捨てのエージェントセッションです。</p>
+<img alt="ターミナル、チャット、プロジェクト、worktree とそのネストしたセッションを表示する Termio のサイドバー" src="web/landing/public/screenshots/docs/04-project-session-hierarchy.png" />
+</td>
+<td width="50%" valign="top">
+<h3>Git worktree</h3>
+<p>並行タスク 1 つにつき 1 ブランチ、サイドバーから作成できます。worktree は元のプロジェクトの下にネストします。</p>
+<img alt="Termio のサイドバー内の worktree、ネストしたセッションと worktree を追加するコンテキストメニュー" src="web/landing/public/screenshots/docs/12-worktree-hierarchy.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>ペイン分割</h3>
+<p>⌘D で右に、⇧⌘D で下に分割。エージェント、開発サーバー、シェルを 1 つのウインドウに。</p>
+<img alt="Codex セッションと 2 つのシェルペインをグループ化した Termio" src="web/landing/public/screenshots/docs/03-grouped-panes.png" />
+</td>
+<td width="50%" valign="top">
+<h3>ひと目でわかるステータス</h3>
+<p>作業中、アイドル、完了、<em>要対応</em> — すべての行にマークが付きます。同じ一覧が <code>termio sessions list</code> です。</p>
+<img alt="作業中・完了・要対応を報告する Termio のサイドバーと、ターミナルの termio sessions list" src="web/landing/public/screenshots/docs/05-session-statuses.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>ファイルエディタ</h3>
+<p>ツリーでファイルをクリック。シンタックスハイライトと自動保存。コミットはこれまでどおりターミナルで。</p>
+<img alt="ターミナルの横で Swift ファイルをシンタックスハイライト付きで開いた Termio のファイルインスペクタ" src="web/landing/public/screenshots/docs/06-files-editor.png" />
+</td>
+<td width="50%" valign="top">
+<h3>変更</h3>
+<p>現在の統合 diff を表示する読み取り専用の git ペイン。コミット、プッシュ、PR はターミナルのままです。</p>
+<img alt="ファイルを選択し、赤と緑の統合 diff をターミナルの横に表示した Termio の変更タブ" src="web/landing/public/screenshots/docs/07-changes-diff.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>検索</h3>
+<p>プロジェクト全体の内容検索。エディタの該当行にそのままジャンプします。</p>
+<img alt="4 つのファイルにまたがる DiffGapText の一致を並べた Termio の検索タブ" src="web/landing/public/screenshots/docs/09-project-search.png" />
+</td>
+<td width="50%" valign="top">
+<h3>コマンドパレット</h3>
+<p>⌘⇧P。分割、フォーカス、メニューを探し回るような操作はすべてここから。</p>
+<img alt="split と入力し「右に分割」を選択している Termio のコマンドパレット" src="web/landing/public/screenshots/docs/10-command-palette.png" />
+</td>
+</tr>
+</table>
 
 ## ターミナルから操作する
 
-Termio には `termio` CLI が同梱されており、セッションをスクリプトから操作できます — エージェント自身からも。Termio の中で動くエージェントは、兄弟セッションを起動してタスクを渡し、返答を読み取れます。
+`termio` CLI は動作中のアプリを操作します。Termio の中のエージェントは、兄弟セッションを起こし、タスクを渡し、その返答を読み取れます:
 
 ```sh
 termio .                                    # カレントディレクトリをプロジェクトとして開く
-termio sessions list                        # 誰が作業中か、アイドルか、あなたを待っているか
+termio sessions list                        # 作業中・アイドル・あなた待ちの一覧
 termio sessions spawn "fix the flaky test"  # プロンプトを渡して新しいエージェントセッションを開始
 termio sessions run "pnpm test --watch"     # コマンドを渡して通常のターミナルセッションを開始
-termio sessions send ab12cd34 "1"           # 兄弟セッションの許可プロンプトに応答
-termio sessions read ab12cd34 --lines 40    # そのセッションの画面を出力
-termio sessions watch                       # ステータスの変化をリアルタイムにストリーム
+termio sessions send ab12cd34 "1"           # 兄弟セッションの権限確認に答える
+termio sessions read ab12cd34 --lines 40    # セッションの画面の内容を出力
+termio sessions watch                       # ステータスの変化をストリームで受け取る
 termio sessions focus ab12cd34              # アプリでそのセッションを前面に出す
 termio sessions close ab12cd34              # 閉じる
 termio notify "the migration finished"      # macOS の通知を送る
 ```
 
-残りはフラグが担います。`--wait` はターンが落ち着くまでブロックし、最終ステータスと読むべきトランスクリプトの行範囲を返します。`--json` は任意の `sessions` コマンドを機械可読にし、`--agent` は `spawn` が起動するエージェントを選び、`--direction` / `--ratio` は新しいペインの位置と大きさを決めます。
+`--wait` はそのターンが落ち着くまで待ち、最終ステータスと読むべきトランスクリプトの範囲を返します。`--json` はどの `sessions` コマンドも機械可読にします。`--agent` は `spawn` が起動するエージェントを選びます。`--direction` / `--ratio` は新しいペインの位置と大きさを決めます。
 
 ```sh
 termio sessions spawn "run the migration" --agent codex --wait
 ```
 
+セッション制御は各エージェントのスキルフォルダ（`~/.claude/skills`、`~/.codex/skills`）に `termio` [エージェントスキル](https://termio.sh/skill.md)をインストールし、起動のたびに最新に保ちます。ほかのエージェントも、このリポジトリから同じスキルを入れられます:
+
+```sh
+npx skills add termio-sh/termio --skill termio
+```
+
 ## iPhone で
 
-コンパニオンアプリが、Mac のすべてのセッションをスマートフォンにライブでミラーリングします — チャットの要約ではなく、TUI そのものです。キーバーが esc、tab、ctrl、矢印キーをキーボードの上に並べ、長押しで話せば音声がそのままプロンプトに文字起こしされます。無料のパブリックベータを公開中です: [TestFlight で参加](https://testflight.apple.com/join/1Arf1UKR)。
+コンパニオンはすべてのセッションをライブでミラーします — チャットの要約ではなく、完全な TUI です。キーバーがキーボードの上に esc、tab、ctrl、矢印キーを並べ、長押しで話すと音声がプロンプトに書き起こされます。[TestFlight](https://testflight.apple.com/join/1Arf1UKR) で public beta 公開中。
+
+<table>
+  <tr>
+    <td><img alt="iPhone の Termio: ホーム画面、プロジェクトの上に要対応のセッション" src="web/landing/public/screenshots/iphone-home.webp" width="230" /></td>
+    <td><img alt="iPhone の Termio: プロジェクト内のセッションが、それぞれのステータスを報告している" src="web/landing/public/screenshots/iphone-sessions.webp" width="230" /></td>
+    <td><img alt="iPhone の Termio: キーボードの上にキーバーが並んだライブのエージェントセッション" src="web/landing/public/screenshots/iphone-session-keys.webp" width="230" /></td>
+  </tr>
+</table>
+
+## アーキテクチャ
+
+すべてのセッションは `termiod` の中で生きています。クライアントはアタッチするだけです。クライアントを閉じてもエージェントは死にません。プロトコルは 1 つ、変わるのはパイプだけです。
+
+```
+  ┌─────────────────┐ unix  ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ unix  │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ unix  │   (Mac)    │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
+
+  ┌─────────────────┐ ssh   ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ ssh   │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ ssh   │  (Linux)   │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
+```
+
+iPhone は Mac を経由せず、マシン上の `termiod` に直接アタッチします。VPS 上のセッションは、ノート PC 上のセッションとまったく同じオブジェクトです。
+
+その考え方は [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) にあります。
 
 ## ロードマップ
 
-- **Linux リモートサーバー** — VPS や開発マシンなど、自分の Linux マシンで
-  セッションを動かし、Mac アプリから管理できます。
-- **Mux サーバー** — 永続的なセッションホスト。セッションは接続ではなくマシン側に
-  生きるので、ノートを閉じてもエージェントは動き続け、再接続すれば画面がそのまま
-  戻ります。
-- **Issue トリアージ** — GitHub・GitLab・Linear の issue をアプリ内で確認し、
-  そのままエージェントに任せられます。
-- **モバイルの TUI → GUI** — ライブミラーの上に、エージェントセッションを GUI として
-  表示するオプション。
-- **Windows 対応** — ネイティブの Windows アプリ。同じ思想、同じターミナルコアで、
-  Electron 移植ではありません。
-- **Web 対応** — どのブラウザからでもセッションに接続。ターミナルはリンクで
-  共有できます。
+- **Issue トリアージ** — GitHub、GitLab、Linear の issue をアプリの中に。そのままエージェントに渡せます。
+- **TUI クライアント** — tmux にアタッチするように、どのターミナルからでもアタッチ。
+- **モバイルでの TUI → GUI** — ライブミラーの上に、エージェントセッションの GUI 表示をオプションで。
+- **Android** — iPhone と同じコンパニオン。
+- **Windows 対応** — ネイティブの Windows アプリとしての Termio。同じ考え方、同じターミナルコア、Electron なし。
+- **Web 対応** — どのブラウザからでもセッションにアタッチ。リンクで共有できるターミナルも。
 
-進捗のフォローやご意見は [GitHub Issues](https://github.com/termio-sh/termio/issues) へ。
+進捗を追ったり意見を寄せたりするには [GitHub Issues](https://github.com/termio-sh/termio/issues) へ。
 
 ## コミュニティ
 
-**Termio は長期的なメンテナーを募集しています。** Termio を気に入って使っていて、
-上のロードマップのどこか — Linux リモートサーバー、Web クライアント、Windows、
-iOS コンパニオンアプリ — を担当してみたい方は、Discord で声をかけるか、issue を
-拾ってみてください。
+**Termio は長期のメンテナを探しています。** 使っていて気に入っていて、上のロードマップのどれか — Web クライアント、Windows、iOS コンパニオン — を担当してみたい方は、Discord で声をかけてください。issue を 1 つ拾うところからでも大歓迎です。
 
 - **[Discord](https://discord.gg/H9DKVwsE5f)** — 開発者やほかのユーザーと交流できます
 - **[GitHub Issues](https://github.com/termio-sh/termio/issues)** — バグ報告と機能リクエスト
@@ -152,4 +211,4 @@ iOS コンパニオンアプリ — を担当してみたい方は、Discord で
 
 ## ライセンス
 
-[MIT](LICENSE) ライセンスです。
+[MIT](LICENSE)。

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,21 +12,56 @@
 
 <p><a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a> | <a href="README.ja.md">日本語</a> | 한국어</p>
 
-<br />
-
-Claude Code, Codex를 비롯한 어떤 CLI 에이전트든 진짜 Mac 터미널에서 나란히 실행해보세요 —<br />
-Swift와 libghostty, Electron은 없습니다. 누가 여러분을 기다리는지 메뉴바 점이 알려주고,<br />
-자리를 비운 사이에는 iPhone이 지켜봅니다.
-
-<br />
-
 [**macOS용 다운로드**](https://downloads.termio.sh/termio.dmg) &nbsp;&bull;&nbsp; [웹사이트](https://termio.sh) &nbsp;&bull;&nbsp; [문서](https://termio.sh/docs) &nbsp;&bull;&nbsp; [변경 내역](https://termio.sh/changelog) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/H9DKVwsE5f)
-
-<br />
 
 <img alt="다크 모드의 Termio: 프로젝트 사이드바 옆에서 실행 중인 Claude Code 세션" src="web/landing/public/screenshots/hero1.png" width="100%" />
 
 </div>
+
+## 터미널 퍼스트 ADE
+
+코드의 대부분을 에이전트가 쓰게 되면, 개발 환경이 할 일은 그 에이전트들을 돌리고
+지금 누가 나를 필요로 하는지 알려주는 거예요. Termio가 바로 그 환경이고, 진짜
+터미널이에요. 에이전트가 이미 살고 있는 곳이 터미널이니까요.
+
+처음 실행할 때 각 에이전트가 가진 훅을 알아서 연결해요. 세션은 작업 중인지,
+쉬고 있는지, *당신이 필요한지*를 알려줘요 — 사이드바의 점, 에이전트가 막혔을 때
+울리는 메뉴 막대 아이콘, 그리고 휴대폰에도 같은 신호가 가요. Claude Code, Codex,
+OpenCode, Pi, Amp, Cursor, Copilot, Kimi, Antigravity, Crush, Grok, 그 밖의 어떤
+CLI 에이전트든요.
+
+더 긴 이야기는 [*From IDE to ADE*](docs/essays/from-ide-to-ade.md)에 있어요.
+
+### tmux 대신
+
+사람들이 tmux를 배우라고 하는 이유, Termio에서는 배우지 않아도 돼요. 모든 세션의
+셸이 데몬 `termiod` 안에서 살기 때문에 앱을 종료해도 연결만 끊길 뿐이에요.
+노트북을 덮었다가 Termio를 다시 열면 에이전트는 떠날 때 그대로예요 — 같은
+프로세스, 같은 스크롤백. 세션을 끝내는 건 세션 닫기(⌘W)뿐이에요.
+
+분할은 ⌘D, 확대는 ⇧⌘↩. Ctrl-b 같은 프리픽스 키는 없어요. ⌘ 단축키는 페인 안의
+프로그램까지 전달되지 않으니 vim이나 TUI와 키가 부딪히지 않아요. 스크롤, 선택,
+복사는 트랙패드와 ⌘C로 하면 되고, copy-mode도 없어요.
+
+### 원격 VPS
+
+`ssh`로 들어갈 수 있는 Linux VPS라면 어디든 돼요. Termio는 `~/.ssh/config`를 읽기만
+하고 절대 고쳐 쓰지 않아요. **설정 ▸ 기기 ▸ 설정하기**가 SSH로 바이너리 하나를
+`~/.local/bin`에 복사하고, 데몬을 띄우고, 그 머신에 에이전트 훅까지 설치해요.
+로컬 세션과 원격 세션이 같은 호스트를 지나가요.
+
+세션은 연결이 아니라 머신 위에 살아요. 연결이 끊겨도 에이전트는 계속 일하고, 다시
+붙으면 화면이 그대로 돌아와요. Zed Remote와 VS Code Remote는 원격 작업을 살아 있는
+연결 안에 묶어 두죠.
+
+## 다른 도구와 비교하면
+
+| | 어떤 도구인지 | Termio는 무엇이 다른지 |
+| --- | --- | --- |
+| **[Ghostty](https://ghostty.org)** | 터미널 그 자체예요. Termio는 그 코어인 [libghostty](https://ghostty.org)로 그려요. 포크가 아니에요. | Ghostty는 에이전트를 추적하지도, 세션을 유지하지도, VPS에서 돌리지도 않아요. 빠른 터미널이 필요하다면 Ghostty예요. Termio는 에이전트가 그 안에서 도는 환경이고요. |
+| **[cmux](https://cmux.com)** | 가장 가까운 사촌이에요: 네이티브 Swift, libghostty, 에이전트가 부르면 울리는 알림, iPhone 컴패니언. 원격은 SSH 워크스페이스라서 머신에 릴레이를 두고 원하면 tmux를 쓰고, 휴대폰은 Mac과 페어링해요. | Termio는 모든 세션이 `termiod` 위에서 돌아요. 이 Mac이든 Linux VPS든 같고, 휴대폰은 그 호스트에 바로 붙어요. 상태는 메뉴 막대에, 프로젝트와 worktree는 사이드바에 있고요. cmux에는 앱 안에 스크립트로 다룰 수 있는 브라우저가 있고 Ghostty 설정도 읽지만, Termio에는 없어요. |
+| **[herdr](https://herdr.dev)** | 지금 쓰는 터미널 안에서 도는 멀티플렉서예요. 지속성에 대한 생각은 같고(서버가 PTY를 들고 있어요), 에이전트마다 작업 중·막힘·유휴를 표시해요. 모양은 tmux 쪽이에요: 프리픽스 키, TUI, SSH로 붙기, macOS / Linux / Windows. | Termio는 네이티브 Mac 앱이에요. Mac 단축키, iPhone 컴패니언, 그리고 사이드바 안의 워크스페이스로서의 VPS가 있어요. 붙으러 가는 TUI가 아니고요. |
+| **[Otty](https://otty.sh)** | 에이전트에 맞춰 다듬은 네이티브 Mac 터미널이에요: 탭 배지, 입력창, Claude / Codex / OpenCode를 이어서 여는 세션 복원. 터미널과 ADE 사이에 있어요. | Termio는 그중 ADE 쪽이에요. 세션이 `termiod` 안에 살아서 앱을 종료해도 남고, Linux VPS에서도 iPhone에서도 똑같은 객체예요. |
 
 ## 설치하기
 
@@ -42,72 +77,63 @@ brew install --cask termio-sh/tap/termio
 컴패니언 베타를 받은 뒤, Mac 앱의 Settings ▸ Mobile에 뜨는 QR 코드를
 스캔해서 페어링하면 돼요.
 
-## 에이전트로 개발하는 시대를 위해 만들었어요
+## 무엇을 쓸 수 있나요
 
-IDE는 사람이 직접 코드를 타이핑하던 시절에 맞춰 만들어졌어요. 에이전트가
-대부분의 코드를 쓰는 시대에는 개발 환경의 역할도 달라져요. 에이전트가
-일하는 곳이자, 여러분이 지시하고, 검토하고, 막힌 곳을 풀어주는 곳이어야
-하죠. Termio가 바로 그 환경이에요. 에이전트가 이미 살고 있는 터미널을
-중심에 두고, 새로운 작업 방식에 맞춰 만들었어요 — 여러 에이전트가 동시에
-달리고, 대부분은 알아서 잘 굴러가는데, 하나쯤은 막혀 있는 그런 상황이요.
-(더 긴 이야기는 [*From IDE to ADE*](docs/essays/from-ide-to-ade.md)에서
-읽어보세요.)
-
-- **웹 뷰가 아니라 진짜 터미널이에요.** [libghostty](https://ghostty.org)
-  (Ghostty의 터미널 코어) 위에 Swift + AppKit으로 만들었고, Metal로
-  렌더링해요. Electron도, xterm.js도 없어요.
-- **프로젝트 → 세션.** 사이드바가 실제 일하는 방식을 그대로 반영해요.
-  프로젝트마다 자기 터미널과 에이전트를 품고, 병렬 작업용 git 워크트리가
-  그 아래에 중첩돼요.
-- **설정 없이 되는 상태 표시.** Termio가 에이전트마다 고유의 훅을 알아서
-  연결하고, 에이전트가 원래 내보내는 신호를 읽어요. 작업 중인지, 대기
-  중인지, *needs you*인지 세션마다 점으로 보여주고, 메뉴바 트레이는 평소엔
-  잠잠하다가 에이전트가 일할 때 은은하게 깜빡이고, 여러분의 답을 기다리며
-  막혀 있을 때 울려요.
-- **자리를 뜨지 않고 검토해요.** 읽기 전용 git 패널(변경 사항, 히스토리,
-  통합 diff), 클릭하면 바로 고칠 수 있는 에디터가 딸린 파일 트리, 프로젝트
-  전체 내용 검색까지 — 커밋은 여전히 터미널에서 해요.
-- **Git 워크트리.** 사이드바에서 만들면 프로젝트 아래 중첩 폴더로 나타나요.
-  병렬 작업마다 브랜치 하나씩이에요.
-- **Chats.** 어떤 프로젝트에도 속하지 않는 임시 에이전트 대화예요.
-- **사용량 미터.** Claude와 Codex 플랜 한도를 Settings → Usage에서 로컬로
-  읽어요.
-- **테마.** 라이트, 다크, 그리고 시스템을 따라가는 글래스 모드요.
-- **자동 업데이트.** 공증된 DMG를 Sparkle이 업데이트해요.
-- **무료예요.** 계정도, 라이선스 키도, 유료 등급도 없어요. MIT
-  라이선스예요.
-
-## tmux를 배우지 않아도 돼요
-
-다들 tmux를 배우라고 하는 이유는, 에이전트 작업에는 터미널보다 오래 사는 세션이
-필요하기 때문이에요 — 앱을 종료해도, 노트북을 덮어도 에이전트는 계속 돌아야
-하니까요. Termio는 그걸 처음부터 해요. 각 세션의 셸은 데몬인 `termiod` 안에
-살아서, 종료해도 연결만 끊겨요. 앱을 다시 열면 에이전트는 떠났던 그 자리에
-있어요 — 같은 프로세스, 같은 스크롤백으로요. 세션을 끝내는 건
-"세션 닫기"(⌘W)뿐이에요.
-
-tmux가 가르쳐 줬을 나머지는 Mac 단축키거나, 이미 알고 있는 거예요.
-
-- 분할은 ⌘D, 확대는 ⇧⌘↩ — Ctrl-b를 먼저 누를 필요 없어요. ⌘ 단축키는 창 안의
-  프로그램에 닿지 않아서, vim이나 TUI와 키를 두고 싸우지 않아요.
-- 스크롤, 선택, 복사는 트랙패드, 마우스, ⌘C예요. 드나들 copy-mode가 없어요.
-- Linux 머신의 세션도 같은 데몬이 돌고, 어느 셸에서든
-  `termiod attach <session>`으로 붙을 수 있어요.
-- 스크립트는 `termio sessions`(아래 참고)가 `send-keys` 역할을 하고, 에이전트
-  상태는 화면을 긁는 게 아니라 프로토콜 객체예요.
-
-## 쓰던 에이전트 그대로 동작해요
-
-Claude Code, Codex, Gemini CLI, Grok, Cursor Agent, Copilot, Amp, OpenCode,
-Pi, Kimi — 그 밖의 어떤 CLI 에이전트든 쓸 수 있어요. 세션이 그냥 진짜
-터미널이니까요. 내장 지원되는 에이전트는 Termio가 각각의 훅이나 플러그인을
-자동으로 설치해서, 처음 실행하는 순간부터 상태 감지가 동작해요.
+<table>
+<tr>
+<td width="50%" valign="top">
+<h3>프로젝트가 세션을 담아요</h3>
+<p>체크아웃 하나에 프로젝트 하나, 그 아래에 터미널과 에이전트가 놓여요. 채팅은 그 위에 있어요 — 어느 프로젝트에도 속하지 않는 일회성 에이전트 세션이에요.</p>
+<img alt="터미널, 채팅, 프로젝트, worktree와 그 아래 세션들을 보여주는 Termio 사이드바" src="web/landing/public/screenshots/docs/04-project-session-hierarchy.png" />
+</td>
+<td width="50%" valign="top">
+<h3>Git worktree</h3>
+<p>병렬 작업 하나에 브랜치 하나, 사이드바에서 만들어요. worktree는 원래 프로젝트 아래에 붙어요.</p>
+<img alt="Termio 사이드바의 worktree, 그 아래 세션들과 worktree를 추가하는 컨텍스트 메뉴" src="web/landing/public/screenshots/docs/12-worktree-hierarchy.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>페인 분할</h3>
+<p>⌘D는 오른쪽으로, ⇧⌘D는 아래로 나눠요. 에이전트, 개발 서버, 셸을 한 창에 두세요.</p>
+<img alt="Codex 세션과 셸 페인 두 개를 함께 묶은 Termio" src="web/landing/public/screenshots/docs/03-grouped-panes.png" />
+</td>
+<td width="50%" valign="top">
+<h3>한눈에 보이는 상태</h3>
+<p>작업 중, 유휴, 완료, <em>당신이 필요함</em> — 줄마다 표시가 붙어요. 같은 목록이 <code>termio sessions list</code>예요.</p>
+<img alt="작업 중, 완료, 당신이 필요함을 알리는 Termio 사이드바와 터미널의 termio sessions list" src="web/landing/public/screenshots/docs/05-session-statuses.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>파일 편집기</h3>
+<p>트리에서 파일을 누르면 열려요. 문법 강조와 자동 저장이 되고, 커밋은 그대로 터미널에서 해요.</p>
+<img alt="터미널 옆에서 Swift 파일을 문법 강조와 함께 연 Termio 파일 인스펙터" src="web/landing/public/screenshots/docs/06-files-editor.png" />
+</td>
+<td width="50%" valign="top">
+<h3>변경 사항</h3>
+<p>지금의 통합 diff를 보여주는 읽기 전용 git 페인이에요. 커밋, 푸시, PR은 터미널에 남아요.</p>
+<img alt="파일 하나를 고르고 빨강·초록 통합 diff를 터미널 옆에 띄운 Termio 변경 사항 탭" src="web/landing/public/screenshots/docs/07-changes-diff.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>검색</h3>
+<p>프로젝트 전체 내용 검색이에요. 편집기에서 해당 줄로 바로 이동해요.</p>
+<img alt="네 개 파일에 걸친 DiffGapText 검색 결과를 보여주는 Termio 검색 탭" src="web/landing/public/screenshots/docs/09-project-search.png" />
+</td>
+<td width="50%" valign="top">
+<h3>명령 팔레트</h3>
+<p>⌘⇧P. 분할, 포커스 등 메뉴를 뒤져야 했던 건 전부 여기 있어요.</p>
+<img alt="split을 입력해 오른쪽으로 분할을 선택한 Termio 명령 팔레트" src="web/landing/public/screenshots/docs/10-command-palette.png" />
+</td>
+</tr>
+</table>
 
 ## 터미널에서 조종하기
 
-Termio는 `termio` CLI를 함께 제공해서 세션을 스크립트로 다룰 수 있어요 —
-에이전트 스스로도요. Termio 안에서 돌고 있는 에이전트가 형제 세션을 띄우고,
-작업을 넘기고, 답을 읽어올 수 있어요:
+`termio` CLI가 실행 중인 앱을 조종해요. Termio 안에서 돌고 있는 에이전트가 형제
+세션을 띄우고, 작업을 넘기고, 답을 읽어올 수 있어요:
 
 ```sh
 termio .                                    # 현재 디렉터리를 프로젝트로 열기
@@ -122,35 +148,84 @@ termio sessions close ab12cd34              # 닫기
 termio notify "the migration finished"      # macOS 알림 보내기
 ```
 
-나머지는 플래그가 맡아요. `--wait`는 이번 턴이 정리될 때까지 기다렸다가 최종 상태와
-읽어야 할 트랜스크립트 줄 범위를 돌려주고, `--json`은 어떤 `sessions` 명령이든 기계가
-읽을 수 있게 만들고, `--agent`는 `spawn`이 띄울 에이전트를 고르고,
-`--direction` / `--ratio`는 새 페인이 어디에 얼마나 크게 놓일지 정해요.
+`--wait`는 이번 턴이 정리될 때까지 기다렸다가 최종 상태와 읽어야 할 트랜스크립트
+줄 범위를 돌려줘요. `--json`은 어떤 `sessions` 명령이든 기계가 읽을 수 있게 만들고,
+`--agent`는 `spawn`이 띄울 에이전트를 고르고, `--direction` / `--ratio`는 새 페인이
+어디에 얼마나 크게 놓일지 정해요.
 
 ```sh
 termio sessions spawn "run the migration" --agent codex --wait
 ```
 
+세션 제어는 각 에이전트의 스킬 폴더(`~/.claude/skills`, `~/.codex/skills`)에
+`termio` [에이전트 스킬](https://termio.sh/skill.md)을 설치하고, 실행할 때마다 최신
+상태로 유지해요. 다른 에이전트도 이 저장소에서 같은 스킬을 받을 수 있어요:
+
+```sh
+npx skills add termio-sh/termio --skill termio
+```
+
 ## iPhone에서
 
-컴패니언 앱이 Mac의 모든 세션을 휴대폰에 실시간으로 미러링해요 — 채팅
-요약이 아니라 TUI 전체를 그대로요. 키 바가 esc, tab, ctrl, 화살표 키를
-키보드 위에 놓아주고, 길게 눌러 말하면 음성이 그대로 프롬프트에 입력돼요.
-무료이고 공개 베타 중이에요:
-[TestFlight에서 참여해주세요](https://testflight.apple.com/join/1Arf1UKR).
+컴패니언 앱이 모든 세션을 실시간으로 미러링해요 — 채팅 요약이 아니라 TUI 전체를
+그대로요. 키 바가 esc, tab, ctrl, 화살표 키를 키보드 위에 놓아주고, 길게 눌러
+말하면 음성이 그대로 프롬프트에 입력돼요. 공개 베타는
+[TestFlight](https://testflight.apple.com/join/1Arf1UKR)에서 참여할 수 있어요.
+
+<table>
+  <tr>
+    <td><img alt="iPhone의 Termio: 홈 화면, 프로젝트 위에 놓인 당신이 필요한 세션" src="web/landing/public/screenshots/iphone-home.webp" width="230" /></td>
+    <td><img alt="iPhone의 Termio: 프로젝트 안의 세션들이 각자 상태를 알리고 있어요" src="web/landing/public/screenshots/iphone-sessions.webp" width="230" /></td>
+    <td><img alt="iPhone의 Termio: 키보드 위에 키 바가 놓인 실시간 에이전트 세션" src="web/landing/public/screenshots/iphone-session-keys.webp" width="230" /></td>
+  </tr>
+</table>
+
+## 아키텍처
+
+모든 세션은 `termiod` 안에 살아요. 클라이언트는 붙기만 해요. 클라이언트를 닫아도
+에이전트는 죽지 않고요. 프로토콜은 하나, 바뀌는 건 파이프뿐이에요.
+
+```
+  ┌─────────────────┐ unix  ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ unix  │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ unix  │   (Mac)    │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
+
+  ┌─────────────────┐ ssh   ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ ssh   │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ ssh   │  (Linux)   │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
+```
+
+휴대폰은 Mac을 거치지 않고 머신 위의 `termiod`에 바로 붙어요. VPS의 세션과
+노트북의 세션은 같은 객체예요.
+
+그 배경은 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md)에 적어 뒀어요.
 
 ## 로드맵
 
-- **Linux 원격 서버** — VPS나 개발 머신 등 내 Linux 머신에서 세션을 돌리고,
-  Mac 앱에서 관리할 수 있어요.
-- **Mux 서버** — 세션이 연결이 아니라 머신에 살아 있는 영속 세션 호스트예요.
-  노트북을 덮어도 에이전트는 계속 일하고, 다시 붙으면 화면이 그대로 돌아와요.
 - **이슈 트리아지** — GitHub, GitLab, Linear 이슈를 앱 안에서 보고 바로
   에이전트에게 맡겨요.
+- **TUI 클라이언트** — tmux에 붙듯이, 어느 터미널에서든 붙을 수 있어요.
 - **모바일 TUI → GUI** — 라이브 미러 위에 에이전트 세션을 GUI로 보여주는
   옵션이에요.
+- **Android** — iPhone과 같은 컴패니언 앱이에요.
 - **Windows 지원** — 네이티브 Windows 앱이에요. 같은 철학, 같은 터미널 코어로,
-  Electron 포팅이 아니에요.
+  Electron은 쓰지 않아요.
 - **웹 지원** — 어느 브라우저에서든 세션에 붙을 수 있어요. 터미널은 링크로
   공유할 수 있고요.
 
@@ -159,8 +234,8 @@ termio sessions spawn "run the migration" --agent codex --wait
 ## 커뮤니티
 
 **Termio는 오래 함께할 메인테이너를 찾고 있어요.** Termio를 즐겨 쓰고 있고 위
-로드맵의 한 영역 — Linux 원격 서버, 웹 클라이언트, Windows, iOS 컴패니언 앱 —
-을 맡아 보고 싶다면, Discord에서 인사하거나 이슈를 하나 집어 보세요.
+로드맵의 한 영역 — 웹 클라이언트, Windows, iOS 컴패니언 앱 — 을 맡아 보고 싶다면,
+Discord에서 인사하거나 이슈를 하나 집어 보세요.
 
 - **[Discord](https://discord.gg/H9DKVwsE5f)** — 개발자, 다른 사용자들과 이야기 나눠요
 - **[GitHub Issues](https://github.com/termio-sh/termio/issues)** — 버그 제보와 기능 요청은 여기로요

--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@
 
 </div>
 
-## What it is
-
-Termio is a native Mac app for coding agents. Sessions run on this Mac or on a Linux VPS you own, survive closing the window, and show up on your iPhone.
-
-### Terminal-first ADE
+## What it is Terminal-first ADE
 
 When agents write most of the code, the environment's job is to run them and to tell you which one needs you. Termio is that environment, and it's a real terminal because that's where the agents already live.
 
@@ -42,13 +38,12 @@ The session lives on the box, not in the connection. Drop the link and the agent
 
 ## Compared with
 
-**[Ghostty](https://ghostty.org)** is the terminal. Termio uses its core, [libghostty](https://ghostty.org), for rendering — it is not a fork. Ghostty does not track agents, persist sessions, or run them on a VPS. If you want a fast terminal, that is Ghostty. Termio is the environment the agents run in.
-
-**[cmux](https://cmux.com)** is the closest cousin: native Swift, libghostty, notification rings when an agent needs you, an iPhone companion. cmux remote is an SSH workspace — a relay on the box, tmux if you want it — and the phone pairs with the Mac. In Termio every session runs on `termiod`, this Mac or a Linux VPS, and the phone attaches to that host directly. Termio also puts status in a menu-bar tray, and projects and worktrees in the sidebar. cmux has an in-app scriptable browser and reads your Ghostty config; Termio does not.
-
-**[herdr](https://herdr.dev)** is a multiplexer that runs inside the terminal you already use. Same persistence idea — a server owns the PTYs — and it marks each agent working, blocked, or idle. It is tmux-shaped: prefix keys, a TUI, attach over SSH, macOS / Linux / Windows. Termio is a native Mac app with Mac shortcuts, an iPhone companion, and the VPS as a workspace in the sidebar, not a TUI you attach to.
-
-**[Otty](https://otty.sh)** is a native Mac terminal tuned for agents: tab badges, a composer, session restore that resumes Claude / Codex / OpenCode. It sits between a terminal and an ADE. Termio is the ADE side of that: the session lives in `termiod`, survives quitting the app, and is the same object on a Linux VPS and on your iPhone.
+| | What it is | How Termio differs |
+| --- | --- | --- |
+| **[Ghostty](https://ghostty.org)** | The terminal. Termio renders with its core, [libghostty](https://ghostty.org) — not a fork. | Ghostty does not track agents, persist sessions, or run them on a VPS. If you want a fast terminal, that is Ghostty. Termio is the environment the agents run in. |
+| **[cmux](https://cmux.com)** | The closest cousin: native Swift, libghostty, notification rings when an agent needs you, an iPhone companion. Remote is an SSH workspace — a relay on the box, tmux if you want it — and the phone pairs with the Mac. | Every session runs on `termiod`, this Mac or a Linux VPS, and the phone attaches to that host directly. Status sits in a menu-bar tray, projects and worktrees in the sidebar. cmux has an in-app scriptable browser and reads your Ghostty config; Termio does not. |
+| **[herdr](https://herdr.dev)** | A multiplexer inside the terminal you already use. Same persistence idea — a server owns the PTYs — and it marks each agent working, blocked, or idle. tmux-shaped: prefix keys, a TUI, attach over SSH, macOS / Linux / Windows. | A native Mac app with Mac shortcuts, an iPhone companion, and the VPS as a workspace in the sidebar — not a TUI you attach to. |
+| **[Otty](https://otty.sh)** | A native Mac terminal tuned for agents: tab badges, a composer, session restore that resumes Claude / Codex / OpenCode. It sits between a terminal and an ADE. | The ADE side of that: the session lives in `termiod`, survives quitting the app, and is the same object on a Linux VPS and on your iPhone. |
 
 ## Install
 
@@ -162,31 +157,29 @@ The companion mirrors every session live — the full TUI, not a chat summary. A
 Every session lives in `termiod`. Clients only attach. Closing a client does not kill the agent. One protocol; only the pipe changes.
 
 ```
-  ┌──────────────┐  unix   ┌────────────┐         ┌─────────────────┐
-  │ Mac app      │────────►│            │         │                 │
-  ├──────────────┤  unix   │            │         │                 │
-  │ Windows *    │────────►│            │         │                 │
-  ├──────────────┤  wss    │            │         │                 │
-  │ iPhone       │────────►│  termiod   │── PTY ─►│  shell / agent  │
-  ├──────────────┤  unix   │   (Mac)    │         │                 │
-  │ TUI *        │────────►│            │         │                 │
-  ├──────────────┤  wss    │            │         │                 │
-  │ Android *    │────────►│            │         │                 │
-  └──────────────┘         └────────────┘         └─────────────────┘
+  ┌─────────────────┐ unix  ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ unix  │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ unix  │   (Mac)    │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
 
-  ┌──────────────┐  ssh    ┌────────────┐         ┌─────────────────┐
-  │ Mac app      │────────►│            │         │                 │
-  ├──────────────┤  ssh    │            │         │                 │
-  │ Windows *    │────────►│            │         │                 │
-  ├──────────────┤  wss    │            │         │                 │
-  │ iPhone       │────────►│  termiod   │── PTY ─►│  shell / agent  │
-  ├──────────────┤  ssh    │  (Linux)   │         │                 │
-  │ TUI *        │────────►│            │         │                 │
-  ├──────────────┤  wss    │            │         │                 │
-  │ Android *    │────────►│            │         │                 │
-  └──────────────┘         └────────────┘         └─────────────────┘
-
-  * coming soon
+  ┌─────────────────┐ ssh   ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ ssh   │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ ssh   │  (Linux)   │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
 ```
 
 The phone attaches to `termiod` on the box, not through the Mac. A session on a VPS is the same object as one on your laptop.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,21 +12,40 @@
 
 <p><a href="README.md">English</a> | 简体中文 | <a href="README.zh-TW.md">繁體中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a></p>
 
-<br />
-
-在真实的 Mac 终端里并排跑 Claude Code、Codex 和任意 CLI Agent——<br />
-Swift 加 libghostty，没有 Electron。菜单栏的圆点告诉你哪个在等你，<br />
-人不在桌前的时候，iPhone 来告诉你。
-
-<br />
-
 [**下载 macOS 版**](https://downloads.termio.sh/termio.dmg) &nbsp;&bull;&nbsp; [官网](https://termio.sh) &nbsp;&bull;&nbsp; [文档](https://termio.sh/docs) &nbsp;&bull;&nbsp; [更新日志](https://termio.sh/changelog) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/H9DKVwsE5f)
-
-<br />
 
 <img alt="深色模式下的 Termio：一个正在运行的 Claude Code 会话，旁边是项目侧栏" src="web/landing/public/screenshots/hero1.png" width="100%" />
 
 </div>
+
+## 终端优先的 ADE
+
+代码大半改由 Agent 写之后，开发环境的职责就是把它们跑起来，并告诉你哪一个需要你。Termio 就是这样一个环境，而它是一个真实的终端——因为 Agent 本来就住在终端里。
+
+它在第一次启动时自动接好每个 Agent 自带的 hook。会话会报告工作中、空闲，还是*需要你*——侧栏一个状态点，菜单栏托盘在有 Agent 被挡住时出声，手机上是同一个信号。Claude Code、Codex、OpenCode、Pi、Amp、Cursor、Copilot、Kimi、Antigravity、Crush、Grok，以及任何其他 CLI Agent。
+
+更完整的论述：[*From IDE to ADE*](docs/essays/from-ide-to-ade.md)。
+
+### tmux 的替代品
+
+所有人劝你学 tmux 的理由，Termio 让你不用学。每个会话的 shell 都活在守护进程 `termiod` 里，退出 app 只是断开连接。合上笔记本，再打开 Termio，Agent 还在你离开的地方——同一个进程，同一份回滚历史。只有「关闭会话」（⌘W）会结束它。
+
+分屏是 ⌘D，放大是 ⇧⌘↩。不用 Ctrl-b 前缀：⌘ 快捷键根本不会传进窗格里的程序，所以永远不会和 vim 或 TUI 抢键。翻历史、选文本、复制，用触控板和 ⌘C。没有 copy-mode。
+
+### 远程 VPS
+
+任何你能 `ssh` 上去的 Linux VPS。Termio 读 `~/.ssh/config`，从不改写它。**设置 ▸ 设备 ▸ 设置**会通过 SSH 把一个二进制文件复制到 `~/.local/bin`，启动守护进程，并在那台机器上装好 Agent 的 hook。本地会话和远程会话走的是同一套宿主。
+
+会话活在机器上，不在连接里。断开链接，Agent 继续干活；重新附着，屏幕原样回来。Zed Remote 和 VS Code Remote 则把远程工作困在一条活着的连接里。
+
+## 横向对比
+
+| | 它是什么 | Termio 有什么不同 |
+| --- | --- | --- |
+| **[Ghostty](https://ghostty.org)** | 终端本身。Termio 用它的内核 [libghostty](https://ghostty.org) 渲染，不是 fork。 | Ghostty 不跟踪 Agent，不持久化会话，也不在 VPS 上跑它们。你要的是一个快终端，那就用 Ghostty。Termio 是 Agent 跑在里面的环境。 |
+| **[cmux](https://cmux.com)** | 最接近的同类：原生 Swift、libghostty、Agent 需要你时响铃、iPhone 伴侣应用。它的远程是一个 SSH 工作区——机器上跑一个中继，愿意的话再加 tmux——手机与 Mac 配对。 | 每个会话都跑在 `termiod` 上，这台 Mac 或一台 Linux VPS，手机直接附着到那台宿主。状态放在菜单栏托盘，项目和 worktree 放在侧栏。cmux 有内置的可脚本化浏览器，也会读你的 Ghostty 配置；Termio 没有。 |
+| **[herdr](https://herdr.dev)** | 跑在你现有终端里的多路复用器。同样的持久化思路——一个服务端持有 PTY——并且会标记每个 Agent 工作中、被挡住还是空闲。形状是 tmux 式的：前缀键、TUI、通过 SSH 附着，支持 macOS / Linux / Windows。 | 一个原生 Mac 应用，有 Mac 快捷键、iPhone 伴侣应用，VPS 作为侧栏里的一个工作区——不是一个你去附着的 TUI。 |
+| **[Otty](https://otty.sh)** | 为 Agent 调过的原生 Mac 终端：标签徽标、输入框、能恢复 Claude / Codex / OpenCode 的会话还原。它介于终端和 ADE 之间。 | Termio 是这件事的 ADE 那一侧：会话活在 `termiod` 里，退出 app 也不会消失，在 Linux VPS 上和在你 iPhone 上都是同一个对象。 |
 
 ## 安装
 
@@ -41,59 +60,62 @@ brew install --cask termio-sh/tap/termio
 [TestFlight](https://testflight.apple.com/join/1Arf1UKR) 装伴侣应用的公测版，
 再扫 Mac 应用 **设置 ▸ 手机** 里的二维码配对。
 
-## 为 Agent 编程而造
+## 你会得到什么
 
-IDE 是围绕一个人敲代码设计的。代码大半改由 Agent 写之后，开发环境的职责跟着变：
-它既是 Agent 干活的地方，也是你指挥、审阅、给它们解困的地方。Termio 就是这样一个
-环境——终端优先，因为 Agent 本来就住在终端里——它对着工作的新形状造：几个 Agent
-同时在跑，大多数不用你管，有一个卡住了。（更完整的论述见
-[*From IDE to ADE*](docs/essays/from-ide-to-ade.md)。）
-
-- **真实的终端，不是网页视图。** Swift + AppKit，跑在
-  [libghostty](https://ghostty.org)（Ghostty 的终端内核）上，用 Metal 渲染。
-  没有 Electron，也没有 xterm.js。
-- **项目 → 会话。** 侧栏映射你实际的工作方式：每个项目装着自己的终端和 Agent，
-  git worktree 嵌在项目下面，一条分支对应一项并行任务。
-- **状态不用配。** Termio 自动接好每个 Agent 自带的 hook，读它们本来就会发出的
-  信号。工作中、空闲，还是*需要你*——每个会话一个状态点；菜单栏托盘平时安静，
-  Agent 干活时脉动，有 Agent 被你挡住时出声。
-- **审阅不必离开。** 只读的 git 面板（更改、历史、统一 diff）、点击即编辑的文件树、
-  项目级内容搜索——提交仍然在终端里做。
-- **Git worktree。** 从侧栏创建，以嵌套文件夹出现在项目下，一条分支对应一项并行任务。
-- **聊天。** 不属于任何项目的一次性 Agent 会话。
-- **用量仪表。** Claude 和 Codex 的套餐额度，在 **设置 ▸ 用量** 里本地读取。
-- **主题。** 浅色、深色，以及跟随系统的玻璃外观。
-- **自动更新。** 经过公证的 DMG，由 Sparkle 更新。
-- **免费。** 不用账号，没有许可证密钥，也没有付费档位。MIT 许可。
-
-## 不需要学 tmux 了
-
-所有人劝你学 tmux 的理由，是跑 Agent 需要比终端活得久的会话——退出 app、合上
-笔记本，Agent 得继续干活。这件事 Termio 开箱就做了：每个会话的 shell 都活在
-守护进程 `termiod` 里，退出 app 只是断开连接。再打开，Agent 还在你离开的地方——
-同一个进程，同一份回滚历史。只有"关闭会话"（⌘W）会结束它。
-
-tmux 剩下要教你的东西，要么是一个 Mac 快捷键，要么你本来就会：
-
-- 分屏：⌘D，放大：⇧⌘↩——不用先按 Ctrl-b。⌘ 快捷键根本不会传进窗格里的程序，
-  所以永远不会和 vim 或 TUI 抢键。
-- 翻历史、选文本、复制：触控板、鼠标、⌘C。没有 copy-mode 要进出。
-- Linux 机器上的会话：同一个守护进程跑在那边，任何 shell 里
-  `termiod attach <session>` 就能接上。
-- 脚本化：`termio sessions`（见下文）干的就是 `send-keys` 脚本干的事，而且
-  Agent 状态是协议对象，不用抓屏。
-
-## 和你现有的 Agent 一起用
-
-Claude Code、Codex、Antigravity、Grok、Cursor Agent、Copilot、Amp、OpenCode、
-Pi、Kimi——以及任何其他 CLI Agent，因为会话本来就是一个真实终端。
-内置的那些，Termio 会自动装上它们各自的 hook 或插件，你第一次启动它们时状态检测
-就已经在了。
+<table>
+<tr>
+<td width="50%" valign="top">
+<h3>项目装着会话</h3>
+<p>一个 checkout 一个项目，它的终端和 Agent 都在下面。聊天排在项目上方——不属于任何项目的一次性 Agent 会话。</p>
+<img alt="Termio 侧栏，显示终端、聊天、项目、worktree 及其嵌套的会话" src="web/landing/public/screenshots/docs/04-project-session-hierarchy.png" />
+</td>
+<td width="50%" valign="top">
+<h3>Git worktree</h3>
+<p>一条分支对应一项并行任务，从侧栏创建。Worktree 嵌在它来自的项目下面。</p>
+<img alt="Termio 侧栏里的一个 worktree，带着嵌套的会话和一个新增 worktree 的右键菜单" src="web/landing/public/screenshots/docs/12-worktree-hierarchy.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>分屏面板</h3>
+<p>⌘D 向右分屏，⇧⌘D 向下分屏。一个 Agent、一个开发服务器、一个 shell，同一个窗口。</p>
+<img alt="Termio 里一个 Codex 会话和两个 shell 面板并排成组" src="web/landing/public/screenshots/docs/03-grouped-panes.png" />
+</td>
+<td width="50%" valign="top">
+<h3>状态一眼看清</h3>
+<p>工作中、空闲、完成，还是<em>需要你</em>——每一行都有标记。同一份列表就是 <code>termio sessions list</code>。</p>
+<img alt="Termio 侧栏报告工作中、完成和需要你，终端里同时跑着 termio sessions list" src="web/landing/public/screenshots/docs/05-session-statuses.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>文件编辑器</h3>
+<p>在文件树里点一个文件。语法高亮，自动保存。提交仍然在终端里做。</p>
+<img alt="Termio 的文件检查器里打开了一个 Swift 文件，语法高亮的编辑器旁边是终端" src="web/landing/public/screenshots/docs/06-files-editor.png" />
+</td>
+<td width="50%" valign="top">
+<h3>更改</h3>
+<p>只读的 git 面板，显示当前的统一 diff。提交、推送和开 PR 仍然在终端里。</p>
+<img alt="Termio 的更改标签页选中了一个文件，红绿统一 diff 显示在终端旁边" src="web/landing/public/screenshots/docs/07-changes-diff.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>搜索</h3>
+<p>项目级内容搜索，点一下就跳到编辑器里匹配的那一行。</p>
+<img alt="Termio 的搜索标签页列出 DiffGapText 在四个文件里的匹配" src="web/landing/public/screenshots/docs/09-project-search.png" />
+</td>
+<td width="50%" valign="top">
+<h3>命令面板</h3>
+<p>⌘⇧P。分屏、聚焦，一切你本来要翻菜单找的东西。</p>
+<img alt="Termio 的命令面板输入 split，选中了向右分屏" src="web/landing/public/screenshots/docs/10-command-palette.png" />
+</td>
+</tr>
+</table>
 
 ## 从终端驱动
 
-Termio 附带 `termio` 命令行工具，会话因此可以脚本化——Agent 自己也能调。跑在 Termio
-里的 Agent 可以派生一个同伴，交给它一个任务，再把回复读回来：
+`termio` 命令行工具驱动正在运行的应用。跑在 Termio 里的 Agent 可以派生一个同伴，交给它一个任务，再把回复读回来：
 
 ```sh
 termio .                                    # 把当前目录作为项目打开
@@ -108,18 +130,13 @@ termio sessions close ab12cd34              # 关掉它
 termio notify "the migration finished"      # 发一条 macOS 通知
 ```
 
-剩下的交给参数：`--wait` 一直等到这一轮结束，回来时带上最终状态和可以去读的记录行
-范围；`--json` 让任何 `sessions` 命令输出机器可读的结果；`--agent` 决定 `spawn`
-启动哪个 Agent；`--direction` / `--ratio` 决定新面板落在哪、占多大。
+`--wait` 一直等到这一轮结束，回来时带上最终状态和可以去读的记录行范围。`--json` 让任何 `sessions` 命令输出机器可读的结果。`--agent` 决定 `spawn` 启动哪个 Agent。`--direction` / `--ratio` 决定新面板落在哪、占多大。
 
 ```sh
 termio sessions spawn "run the migration" --agent codex --wait
 ```
 
-Agent 自己会学会这套：会话控制会往每个 Agent 的技能目录（`~/.claude/skills`、
-`~/.codex/skills`）装一个 `termio`
-[Agent 技能](https://termio.sh/skill.md)，并在每次启动时保持它最新。
-其他 Agent 也可以直接从这个仓库装同一个技能：
+会话控制会往每个 Agent 的技能目录（`~/.claude/skills`、`~/.codex/skills`）装一个 `termio` [Agent 技能](https://termio.sh/skill.md)，并在每次启动时保持它最新。其他 Agent 也可以直接从这个仓库装同一个技能：
 
 ```sh
 npx skills add termio-sh/termio --skill termio
@@ -127,9 +144,7 @@ npx skills add termio-sh/termio --skill termio
 
 ## 在你的 iPhone 上
 
-伴侣应用把每个 Mac 会话实时镜像到手机上——是完整的 TUI，不是聊天摘要。按键条把
-esc、tab、ctrl 和方向键放在键盘上方，按住说话把语音直接转写进提示词。免费，公测中：
-[加入 TestFlight](https://testflight.apple.com/join/1Arf1UKR)。
+伴侣应用把每个会话实时镜像过来——是完整的 TUI，不是聊天摘要。按键条把 esc、tab、ctrl 和方向键放在键盘上方，按住说话把语音直接转写进提示词。公测中：[TestFlight](https://testflight.apple.com/join/1Arf1UKR)。
 
 <table>
   <tr>
@@ -141,49 +156,52 @@ esc、tab、ctrl 和方向键放在键盘上方，按住说话把语音直接转
 
 ## 架构
 
-Termio 的每个会话都跑在 `termiod` 上——一个小小的 Rust daemon，在活儿实际跑的那台
-机器上持有 PTY。每个界面——Mac 应用、手机、浏览器——都是通过同一套带版本的协议附着
-上去的客户端。
+每个会话都活在 `termiod` 里。客户端只是附着上去。关掉一个客户端不会杀死 Agent。一套协议，变的只有管道。
 
 ```
-  web     ─WSS──┐
-  iPhone  ─WSS──┼─► termiod (Mac)    ─► PTY ─► shell / agent
-  Mac app ─unix─┘
+  ┌─────────────────┐ unix  ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ unix  │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ unix  │   (Mac)    │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
 
-  web     ─WSS──┐
-  iPhone  ─WSS──┼─► termiod (Linux)  ─► PTY ─► shell / agent
-  Mac app ─ssh──┘
+  ┌─────────────────┐ ssh   ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ ssh   │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ ssh   │  (Linux)   │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
 ```
 
-变的只有管道，每一段上的帧完全一样。没有哪个客户端要穿过另一个客户端才能拿到会话
-——手机因此不是 Mac 的卫星，VPS 上的会话和笔记本上的会话也因此是同一种东西。
+手机直接附着到机器上的 `termiod`，不经过 Mac。VPS 上的会话和你笔记本上的会话是同一种东西。
 
-**已经有的：** daemon 和它的协议、`unix`、`ssh`、`wss` 三种传输、附着时的快照、
-回滚、文件和 git 平面，以及 launchd/systemd 托管。Mac 应用的每个会话都跑在它上面，
-手机通过 WSS 附着到 Mac 或 Linux 机器。**还没有的：** 浏览器客户端。
-
-推导过程写在 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) 和
-[`docs/`](docs/README.md) 下的设计笔记里。
+推导过程写在 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) 里。
 
 ## 路线图
 
-- **Linux 远程服务器** — 会话跑在你自己的 Linux 机器上（VPS、开发机），在 Mac
-  应用里统一带。
-- **Mux 服务器** — 持久的会话宿主：会话活在机器上，不在连接里。合上笔记本，Agent
-  继续干活；重新附着，屏幕原样回来。
 - **Issue 分诊** — GitHub、GitLab、Linear 的 issue 直接进应用，随手交给 Agent。
+- **TUI 客户端** — 从任意终端附着，像你附着 tmux 那样。
 - **手机上的 TUI → GUI** — 在实时镜像之上，把 Agent 会话可选地渲染成 GUI。
-- **Windows 支持** — 原生 Windows 应用。同样的想法，同样的终端内核，不是 Electron
-  移植。
+- **Android** — 和 iPhone 一样的伴侣应用。
+- **Windows 支持** — 原生 Windows 应用。同样的想法，同样的终端内核，不是 Electron。
 - **Web 支持** — 从任意浏览器附着到你的会话，终端还能用链接分享。
 
 在 [GitHub Issues](https://github.com/termio-sh/termio/issues) 关注进展或参与讨论。
 
 ## 社区
 
-**Termio 正在找长期维护者。** 如果你喜欢用它，也想认领路线图里的某一块——Linux
-远程服务器、Web 客户端、Windows，或者 iOS 伴侣应用——来 Discord 打个招呼，或者
-直接捡一个 issue。
+**Termio 正在找长期维护者。** 如果你喜欢用它，也想认领上面路线图里的某一块——Web 客户端、Windows，或者 iOS 伴侣应用——来 Discord 打个招呼，或者直接捡一个 issue。
 
 - **[Discord](https://discord.gg/H9DKVwsE5f)** — 和开发者以及其他用户交流
 - **微信群** — 中文用户扫下面的二维码

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,21 +12,40 @@
 
 <p><a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 繁體中文 | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a></p>
 
-<br />
-
-在真正的 Mac 終端機裡並排跑 Claude Code、Codex 和任何 CLI Agent —<br />
-Swift 加 libghostty，沒有 Electron。選單列的圓點告訴你哪一個在等你，<br />
-人不在桌前的時候，iPhone 來告訴你。
-
-<br />
-
 [**下載 macOS 版**](https://downloads.termio.sh/termio.dmg) &nbsp;&bull;&nbsp; [官方網站](https://termio.sh) &nbsp;&bull;&nbsp; [文件](https://termio.sh/docs) &nbsp;&bull;&nbsp; [更新日誌](https://termio.sh/changelog) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/H9DKVwsE5f)
-
-<br />
 
 <img alt="深色模式下的 Termio：一個正在執行的 Claude Code 工作階段，旁邊是專案側邊欄" src="web/landing/public/screenshots/hero1.png" width="100%" />
 
 </div>
+
+## 終端機優先的 ADE
+
+程式碼大半改由 Agent 寫之後，開發環境的職責就是把它們跑起來，並告訴你哪一個在等你。Termio 就是這樣一個環境，而它是一個真正的終端機——因為 Agent 本來就住在終端機裡。
+
+它在第一次啟動時自動接好每個 Agent 自帶的 hook。工作階段會回報工作中、閒置，還是*需要你*——側邊欄一個狀態點，選單列的常駐圖示在有 Agent 被擋住時出聲，手機上是同一個訊號。Claude Code、Codex、OpenCode、Pi、Amp、Cursor、Copilot、Kimi、Antigravity、Crush、Grok，以及任何其他 CLI Agent。
+
+更完整的論述：[*From IDE to ADE*](docs/essays/from-ide-to-ade.md)。
+
+### tmux 的替代品
+
+所有人勸你學 tmux 的理由，Termio 讓你不用學。每個工作階段的 shell 都活在常駐程式 `termiod` 裡，結束 app 只是中斷連線。闔上筆電，再打開 Termio，Agent 還在你離開的地方——同一個行程，同一份捲動紀錄。只有「關閉工作階段」（⌘W）會結束它。
+
+分割是 ⌘D，放大是 ⇧⌘↩。不用 Ctrl-b 前綴鍵：⌘ 快速鍵根本不會傳進窗格裡的程式，所以永遠不會和 vim 或 TUI 搶按鍵。捲動、選取、複製，用觸控板和 ⌘C。沒有 copy-mode。
+
+### 遠端 VPS
+
+任何你能 `ssh` 上去的 Linux VPS。Termio 讀 `~/.ssh/config`，從不改寫它。**設定 ▸ 裝置 ▸ 設定**會透過 SSH 把一個執行檔複製到 `~/.local/bin`，啟動常駐程式，並在那台機器上裝好 Agent 的 hook。本機和遠端的工作階段走的是同一套主機。
+
+工作階段活在機器上，不在連線裡。斷線之後 Agent 繼續工作；重新接上，畫面原樣回來。Zed Remote 和 VS Code Remote 則把遠端工作困在一條活著的連線裡。
+
+## 橫向比較
+
+| | 它是什麼 | Termio 有什麼不同 |
+| --- | --- | --- |
+| **[Ghostty](https://ghostty.org)** | 終端機本身。Termio 用它的核心 [libghostty](https://ghostty.org) 算繪，不是 fork。 | Ghostty 不追蹤 Agent，不保存工作階段，也不在 VPS 上跑它們。你要的是一個快的終端機，那就用 Ghostty。Termio 是 Agent 跑在裡面的環境。 |
+| **[cmux](https://cmux.com)** | 最接近的同類：原生 Swift、libghostty、Agent 需要你時響鈴、iPhone 配套應用程式。它的遠端是一個 SSH 工作區——機器上跑一個中繼，想要的話再加 tmux——手機與 Mac 配對。 | 每個工作階段都跑在 `termiod` 上，這台 Mac 或一台 Linux VPS，手機直接接上那台主機。狀態放在選單列，專案和 worktree 放在側邊欄。cmux 有內建的可指令稿化瀏覽器，也會讀你的 Ghostty 設定；Termio 沒有。 |
+| **[herdr](https://herdr.dev)** | 跑在你現有終端機裡的多工器。同樣的持久化想法——一個伺服器持有 PTY——而且會標記每個 Agent 工作中、被擋住還是閒置。形狀是 tmux 式的：前綴鍵、TUI、透過 SSH 接上，支援 macOS / Linux / Windows。 | 一個原生 Mac 應用程式，有 Mac 快速鍵、iPhone 配套應用程式，VPS 是側邊欄裡的一個工作區——不是一個你去接上的 TUI。 |
+| **[Otty](https://otty.sh)** | 為 Agent 調校過的原生 Mac 終端機：分頁標記、輸入框、能恢復 Claude / Codex / OpenCode 的工作階段還原。它介於終端機和 ADE 之間。 | Termio 是這件事的 ADE 那一側：工作階段活在 `termiod` 裡，結束 app 也不會消失，在 Linux VPS 上和在你 iPhone 上都是同一個物件。 |
 
 ## 安裝
 
@@ -41,86 +60,83 @@ brew install --cask termio-sh/tap/termio
 [TestFlight](https://testflight.apple.com/join/1Arf1UKR) 取得配套應用程式
 測試版，再掃 Mac 應用程式「設定 ▸ 手機」裡的 QR code 完成配對。
 
-## 為 Agent 寫程式而造
+## 你會得到什麼
 
-IDE 是圍繞著一個人打字寫程式設計的。程式碼大半改由 Agent 寫之後，開發環境的職責
-跟著變：它既是 Agent 幹活的地方，也是你下指令、審閱、幫它們排除障礙的地方。Termio
-就是這樣一個環境 — 終端機優先，因為 Agent 本來就住在終端機裡 — 它對著工作的新形狀
-造：好幾個 Agent 同時在跑，大多數不用你管，有一個卡住了。（完整論述請見
-[*From IDE to ADE*](docs/essays/from-ide-to-ade.md)。）
-
-- **真正的終端機，不是網頁視圖。** Swift + AppKit，跑在
-  [libghostty](https://ghostty.org)（Ghostty 的終端機核心）上，用 Metal 渲染。
-  沒有 Electron，也沒有 xterm.js。
-- **專案 → 工作階段。** 側邊欄對應你實際的工作方式：每個專案裝著自己的終端機和
-  Agent，Git worktree 巢狀收在專案底下，一條分支對應一項平行任務。
-- **狀態不用設定。** Termio 自動接上每個 Agent 自己的 hook，讀它們本來就會發出的
-  訊號。工作中、閒置，還是*需要你* — 每個工作階段一個狀態圓點；選單列圖示平時安靜，
-  Agent 幹活時脈動，有 Agent 被你擋住時出聲。
-- **審閱不必離開。** 唯讀的 git 窗格（變更、歷史、統一 diff）、點按即編輯的檔案樹、
-  全專案內容搜尋 — 提交仍然在終端機裡做。
-- **Git worktree。** 從側邊欄建立，以巢狀資料夾出現在專案底下，一條分支對應一項
-  平行任務。
-- **聊天。** 不隸屬任何專案的一次性 Agent 工作階段。
-- **用量儀表。** Claude 與 Codex 的方案額度，在「設定 ▸ 用量」本機讀取。
-- **佈景主題。** 淺色、深色，以及跟隨系統的玻璃外觀。
-- **自動更新。** 經公證的 DMG，透過 Sparkle 更新。
-- **免費。** 不需帳號、沒有授權金鑰、沒有付費方案。採 MIT 授權。
-
-## 不需要學 tmux 了
-
-所有人勸你學 tmux 的理由，是跑 Agent 需要比終端機活得久的工作階段——退出 app、
-闔上筆電，Agent 得繼續做事。這件事 Termio 開箱就做了：每個工作階段的 shell 都
-活在常駐程式 `termiod` 裡，退出 app 只是斷開連線。再打開，Agent 還在你離開的
-地方——同一個程序，同一份捲動歷史。只有「關閉工作階段」（⌘W）會結束它。
-
-tmux 剩下要教你的東西，要麼是一個 Mac 快捷鍵，要麼你本來就會：
-
-- 分割：⌘D，放大：⇧⌘↩——不用先按 Ctrl-b。⌘ 快捷鍵根本不會傳進窗格裡的程式，
-  所以永遠不會和 vim 或 TUI 搶鍵。
-- 捲歷史、選文字、複製：觸控板、滑鼠、⌘C。沒有 copy-mode 要進出。
-- Linux 機器上的工作階段：同一個常駐程式跑在那邊，任何 shell 裡
-  `termiod attach <session>` 就能接上。
-- 腳本化：`termio sessions`（見下文）做的就是 `send-keys` 腳本做的事，而且
-  Agent 狀態是協定物件，不用抓畫面。
-
-## 和你現有的 Agent 一起用
-
-Claude Code、Codex、Antigravity、Grok、Cursor Agent、Copilot、Amp、OpenCode、
-Pi、Kimi — 以及任何其他 CLI Agent，因為工作階段本來就是一個真正的終端機。
-內建的那些，Termio 會自動裝上它們各自的 hook 或外掛，你第一次啟動它們時狀態偵測
-就已經在了。
+<table>
+<tr>
+<td width="50%" valign="top">
+<h3>專案裝著工作階段</h3>
+<p>一個 checkout 一個專案，它的終端機和 Agent 都在下面。聊天排在專案上方——不屬於任何專案的一次性 Agent 工作階段。</p>
+<img alt="Termio 側邊欄，顯示終端機、聊天、專案、worktree 及其巢狀的工作階段" src="web/landing/public/screenshots/docs/04-project-session-hierarchy.png" />
+</td>
+<td width="50%" valign="top">
+<h3>Git worktree</h3>
+<p>一條分支對應一項並行任務，從側邊欄建立。Worktree 巢狀在它來自的專案下面。</p>
+<img alt="Termio 側邊欄裡的一個 worktree，帶著巢狀的工作階段和一個新增 worktree 的快捷選單" src="web/landing/public/screenshots/docs/12-worktree-hierarchy.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>分割窗格</h3>
+<p>⌘D 向右分割，⇧⌘D 向下分割。一個 Agent、一個開發伺服器、一個 shell，同一個視窗。</p>
+<img alt="Termio 裡一個 Codex 工作階段和兩個 shell 窗格並排成群組" src="web/landing/public/screenshots/docs/03-grouped-panes.png" />
+</td>
+<td width="50%" valign="top">
+<h3>狀態一眼看清</h3>
+<p>工作中、閒置、完成，還是<em>需要你</em>——每一列都有標記。同一份清單就是 <code>termio sessions list</code>。</p>
+<img alt="Termio 側邊欄回報工作中、完成和需要你，終端機裡同時跑著 termio sessions list" src="web/landing/public/screenshots/docs/05-session-statuses.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>檔案編輯器</h3>
+<p>在檔案樹裡點一個檔案。語法高亮、自動儲存。提交仍然在終端機裡做。</p>
+<img alt="Termio 的檔案檢閱器裡開著一個 Swift 檔案，語法高亮的編輯器旁邊是終端機" src="web/landing/public/screenshots/docs/06-files-editor.png" />
+</td>
+<td width="50%" valign="top">
+<h3>變更</h3>
+<p>唯讀的 git 面板，顯示目前的統一 diff。提交、推送和開 PR 仍然在終端機裡。</p>
+<img alt="Termio 的變更分頁選中了一個檔案，紅綠統一 diff 顯示在終端機旁邊" src="web/landing/public/screenshots/docs/07-changes-diff.png" />
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<h3>搜尋</h3>
+<p>專案層級的內容搜尋，點一下就跳到編輯器裡符合的那一行。</p>
+<img alt="Termio 的搜尋分頁列出 DiffGapText 在四個檔案裡的結果" src="web/landing/public/screenshots/docs/09-project-search.png" />
+</td>
+<td width="50%" valign="top">
+<h3>命令面板</h3>
+<p>⌘⇧P。分割、聚焦，一切你本來要翻選單找的東西。</p>
+<img alt="Termio 的命令面板輸入 split，選中了向右分割" src="web/landing/public/screenshots/docs/10-command-palette.png" />
+</td>
+</tr>
+</table>
 
 ## 從終端機驅動
 
-Termio 附帶 `termio` 命令列工具，工作階段因此可以用腳本操作 — Agent 自己也能呼叫。
-跑在 Termio 裡的 Agent 可以生出一個同儕，交給它一項任務，再把回覆讀回來：
+`termio` 命令列工具驅動正在執行的應用程式。跑在 Termio 裡的 Agent 可以衍生一個同伴，交給它一個任務，再把回覆讀回來：
 
 ```sh
-termio .                                    # 把目前目錄當成專案打開
-termio sessions list                        # 誰在工作、閒置，或正在等你
+termio .                                    # 把目前目錄當作專案開啟
+termio sessions list                        # 誰在工作、閒置，或在等你
 termio sessions spawn "fix the flaky test"  # 用一段提示啟動新的 Agent 工作階段
-termio sessions run "pnpm test --watch"     # 用一條指令啟動一般終端機工作階段
-termio sessions send ab12cd34 "1"           # 回答同儕的權限確認
+termio sessions run "pnpm test --watch"     # 用一條命令啟動一般終端機工作階段
+termio sessions send ab12cd34 "1"           # 回答同伴的權限確認
 termio sessions read ab12cd34 --lines 40    # 印出某個工作階段目前的畫面
 termio sessions watch                       # 即時串流狀態變化
 termio sessions focus ab12cd34              # 在應用程式裡把某個工作階段切到前景
 termio sessions close ab12cd34              # 關掉它
-termio notify "the migration finished"      # 發一則 macOS 通知
+termio notify "the migration finished"      # 送出一則 macOS 通知
 ```
 
-其餘的交給參數：`--wait` 會一路等到這一輪結束，回來時帶著最終狀態和可以去讀的紀錄
-行範圍；`--json` 讓任何 `sessions` 指令輸出機器可讀的結果；`--agent` 決定 `spawn`
-啟動哪個 Agent；`--direction` / `--ratio` 決定新面板落在哪、佔多大。
+`--wait` 一直等到這一輪結束，回來時帶上最終狀態和可以去讀的紀錄行範圍。`--json` 讓任何 `sessions` 命令輸出機器可讀的結果。`--agent` 決定 `spawn` 啟動哪個 Agent。`--direction` / `--ratio` 決定新窗格落在哪、佔多大。
 
 ```sh
 termio sessions spawn "run the migration" --agent codex --wait
 ```
 
-Agent 自己會學會這套：工作階段控制會往每個 Agent 的技能目錄（`~/.claude/skills`、
-`~/.codex/skills`）裝一個 `termio`
-[Agent 技能](https://termio.sh/skill.md)，並在每次啟動時保持它最新。
-其他 Agent 也可以直接從這個儲存庫裝同一個技能：
+工作階段控制會往每個 Agent 的技能目錄（`~/.claude/skills`、`~/.codex/skills`）裝一個 `termio` [Agent 技能](https://termio.sh/skill.md)，並在每次啟動時保持它最新。其他 Agent 也可以直接從這個儲存庫裝同一個技能：
 
 ```sh
 npx skills add termio-sh/termio --skill termio
@@ -128,77 +144,77 @@ npx skills add termio-sh/termio --skill termio
 
 ## 在你的 iPhone 上
 
-配套應用程式把每個 Mac 工作階段即時鏡射到手機上 — 呈現的是完整 TUI，不是聊天摘要。
-按鍵列把 esc、tab、ctrl 和方向鍵放在鍵盤上方，按住說話把語音直接轉寫進提示。免費，
-公開測試中：[在 TestFlight 上加入](https://testflight.apple.com/join/1Arf1UKR)。
+配套應用程式把每個工作階段即時鏡像過來——是完整的 TUI，不是聊天摘要。按鍵列把 esc、tab、ctrl 和方向鍵放在鍵盤上方，按住說話把語音直接轉寫進提示詞。公開測試中：[TestFlight](https://testflight.apple.com/join/1Arf1UKR)。
 
 <table>
   <tr>
     <td><img alt="iPhone 上的 Termio：首頁，等你的工作階段排在專案上方" src="web/landing/public/screenshots/iphone-home.webp" width="230" /></td>
-    <td><img alt="iPhone 上的 Termio：一個專案底下的工作階段，每個都在回報自己的狀態" src="web/landing/public/screenshots/iphone-sessions.webp" width="230" /></td>
+    <td><img alt="iPhone 上的 Termio：一個專案下的工作階段，每個都在回報自己的狀態" src="web/landing/public/screenshots/iphone-sessions.webp" width="230" /></td>
     <td><img alt="iPhone 上的 Termio：一個正在執行的 Agent 工作階段，鍵盤上方是按鍵列" src="web/landing/public/screenshots/iphone-session-keys.webp" width="230" /></td>
   </tr>
 </table>
 
 ## 架構
 
-Termio 的每個工作階段都跑在 `termiod` 上 — 一個小小的 Rust daemon，在活兒實際跑
-的那台機器上持有 PTY。每個介面 — Mac 應用程式、手機、瀏覽器 — 都是透過同一套帶版本
-的協定附著上去的用戶端。
+每個工作階段都活在 `termiod` 裡。用戶端只是接上去。關掉一個用戶端不會殺死 Agent。一套協定，變的只有管道。
 
 ```
-  web     ─WSS──┐
-  iPhone  ─WSS──┼─► termiod (Mac)    ─► PTY ─► shell / agent
-  Mac app ─unix─┘
+  ┌─────────────────┐ unix  ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ unix  │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ unix  │   (Mac)    │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
 
-  web     ─WSS──┐
-  iPhone  ─WSS──┼─► termiod (Linux)  ─► PTY ─► shell / agent
-  Mac app ─ssh──┘
+  ┌─────────────────┐ ssh   ┌────────────┐         ┌─────────────────┐
+  │ Mac app         │──────►│            │         │                 │
+  ├─────────────────┤ ssh   │            │         │                 │
+  │ Windows (soon)  │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ iPhone          │──────►│  termiod   │── PTY ─►│  shell / agent  │
+  ├─────────────────┤ ssh   │  (Linux)   │         │                 │
+  │ TUI (soon)      │──────►│            │         │                 │
+  ├─────────────────┤ wss   │            │         │                 │
+  │ Android (soon)  │──────►│            │         │                 │
+  └─────────────────┘       └────────────┘         └─────────────────┘
 ```
 
-變的只有管線，每一段上的訊框完全一樣。沒有哪個用戶端要穿過另一個用戶端才能拿到工作
-階段 — 手機因此不是 Mac 的衛星，VPS 上的工作階段和筆電上的工作階段也因此是同一種
-東西。
+手機直接接上機器上的 `termiod`，不經過 Mac。VPS 上的工作階段和你筆電上的工作階段是同一種東西。
 
-**已經有的：** daemon 和它的協定、`unix`、`ssh`、`wss` 三種傳輸、附著時的快照、
-回捲、檔案和 git 平面，以及 launchd/systemd 託管。Mac 應用的每個工作階段都跑在
-它上面，手機透過 WSS 附著到 Mac 或 Linux 機器。**還沒有的：** 瀏覽器客戶端。
-
-推導過程寫在 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) 和
-[`docs/`](docs/README.md) 底下的設計筆記裡。
+推導過程寫在 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) 裡。
 
 ## 路線圖
 
-- **Linux 遠端伺服器** — 工作階段跑在你自己的 Linux 機器上（VPS、開發機），在 Mac
-  應用程式裡統一帶。
-- **Mux 伺服器** — 持久的工作階段主機：工作階段活在機器上，不在連線裡。闔上筆電，
-  Agent 繼續工作；重新附著，畫面原樣回來。
 - **Issue 分流** — GitHub、GitLab、Linear 的 issue 直接進應用程式，隨手交給 Agent。
-- **手機上的 TUI → GUI** — 在即時鏡射之上，把 Agent 工作階段選擇性地渲染成 GUI。
-- **Windows 支援** — 原生 Windows 應用程式。同樣的想法，同樣的終端機核心，不是
-  Electron 移植。
-- **Web 支援** — 從任何瀏覽器附著到你的工作階段，終端機還能用連結分享。
+- **TUI 用戶端** — 從任意終端機接上，像你接上 tmux 那樣。
+- **手機上的 TUI → GUI** — 在即時鏡像之上，把 Agent 工作階段選擇性地算繪成 GUI。
+- **Android** — 和 iPhone 一樣的配套應用程式。
+- **Windows 支援** — 原生 Windows 應用程式。同樣的想法，同樣的終端機核心，不是 Electron。
+- **Web 支援** — 從任意瀏覽器接上你的工作階段，終端機還能用連結分享。
 
 在 [GitHub Issues](https://github.com/termio-sh/termio/issues) 追蹤進展或參與討論。
 
 ## 社群
 
-**Termio 正在找長期維護者。** 如果你喜歡用它，也想認領路線圖裡的某一塊 — Linux
-遠端伺服器、Web 用戶端、Windows，或者 iOS 配套應用程式 — 來 Discord 打聲招呼，
-或者直接撿一個 issue。
+**Termio 正在找長期維護者。** 如果你喜歡用它，也想認領上面路線圖裡的某一塊——Web 用戶端、Windows，或者 iOS 配套應用程式——來 Discord 打個招呼，或者直接接一個 issue。
 
 - **[Discord](https://discord.gg/H9DKVwsE5f)** — 和開發者以及其他使用者交流
-- **微信群** — 中文使用者掃下面的 QR Code
-- **[GitHub Issues](https://github.com/termio-sh/termio/issues)** — 錯誤回報與功能建議
+- **微信群** — 中文使用者掃下面的 QR code
+- **[GitHub Issues](https://github.com/termio-sh/termio/issues)** — bug 和功能需求
 
-<img alt="微信群 QR Code" src="web/landing/public/wechat-group.png" width="220" />
+<img alt="微信群 QR code" src="web/landing/public/wechat-group.png" width="220" />
 
-微信 QR Code 每幾天失效一次。失效了就在 Discord 說一聲，會換上新的。
+微信 QR code 每幾天失效一次。失效了就在 Discord 說一聲，會換上新的。
 
 ## 貢獻者
 
 <a href="https://github.com/termio-sh/termio/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=termio-sh/termio" alt="貢獻者" />
+  <img src="https://contrib.rocks/image?repo=termio-sh/termio" alt="Contributors" />
 </a>
 
 ## 授權


### PR DESCRIPTION
The four "Compared with" paragraphs each already split into what the tool is and how Termio differs, so the table only makes that seam explicit. No claim changed.

The translated READMEs were stuck at 413154ce, two English rewrites back: no comparison section, no feature grid, and an architecture and roadmap still describing the remote server and mux host as future work. All four now mirror the English structure — same sections, same images, same table.

Release Notes:
- README: the tool comparison is now a table, and the Simplified Chinese, Traditional Chinese, Japanese, and Korean READMEs match the current English one.