### PR TITLE
Hold the keyframe until the surface is at the grid it describes

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -234,7 +234,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // representable with no connection to the title bar, so the sidebar can never
         // reach behind the traffic lights. SwiftUI still renders each pane's contents.
         window.contentViewController = makeContentSplitViewController()
+        // Before the window is shown, and before anything measures a pane.
+        // A toolbar takes 20pt off `contentLayoutRect`, so installing it after
+        // the show meant every launch laid the panes out twice: the first pass
+        // measured a content rect 20pt too tall, declared a viewport one row
+        // taller than the window would ever have, and the daemon answered it —
+        // resizing the PTY, opening a snapshot barrier and pushing a keyframe
+        // for a grid that existed for 40ms. The toolbar then landed, the panes
+        // re-measured one row shorter, and the whole round happened again.
+        // Measured: `layout=1150x890` before `installToolbar`, `1150x870`
+        // after, with `declare 46x47` sent in between.
+        installToolbar()
         LaunchTrace.mark("content installed")
+        // The height every pane is about to measure itself against. If a future
+        // change moves chrome back after this point, the panes declare a
+        // viewport for a window that never existed and the trace says so here.
+        Log.termiod.debug("""
+        resize-trace WINDOW content-height-final \
+        layout=\(self.window.contentLayoutRect.width, privacy: .public)x\
+        \(self.window.contentLayoutRect.height, privacy: .public)
+        """)
         window.delegate = self
         window.center()
         window.setFrameAutosaveName(Self.mainWindowFrameAutosaveName)
@@ -247,7 +266,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // than waiting for a transition that already happened.
         store.windowIsFullScreen = window.styleMask.contains(.fullScreen)
         updateSplitTopInset()
-        installToolbar()
         // Empty the sidebar's toolbar region (sort + new-terminal) whenever the navigator collapses
         // and restore it when it reopens — the sidebar's own buttons ride with the sidebar, the way
         // Finder/Xcode drop theirs. KVO catches every collapse path (toolbar toggle, View menu,

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -1011,6 +1011,14 @@ final class CompanionServer {
         }
     }
 
+    /// Sends the roster to one connection. Deliberately does not touch
+    /// `lastRoster`: that field is `broadcastIfChanged`'s record of what *every*
+    /// authenticated phone has seen, and a send to a single socket is no
+    /// evidence about the others. Stamping it here meant the catch-up send on a
+    /// newly authenticated socket consumed a pending change — the phone that
+    /// just connected got the new roster, `broadcastIfChanged` then found
+    /// nothing to do, and every phone already connected kept a stale project
+    /// list until something else changed.
     private func send(_ roster: CompanionRoster, to connection: NWConnection) {
         let meta = NWProtocolWebSocket.Metadata(opcode: .text)
         let context = NWConnection.ContentContext(identifier: "roster", metadata: [meta])

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -153,6 +153,7 @@ struct TerminalPane: View {
                 let context = store.surface(for: item.session)
                 SharedGridLetterbox(
                     runtime: store.runtime(for: id),
+                    sessionName: id.uuidString,
                     context: context,
                     paneSize: rect.size,
                     paddingX: CGFloat(settings.windowPadding),
@@ -439,6 +440,9 @@ private enum TerminalFocusReason {
 /// ask for the keyframe that paints it (`observerRepaintPending`).
 private struct SharedGridLetterbox<Content: View>: View {
     let runtime: SessionRuntime
+    /// Only for the trace: four links log into one stream, and before the name
+    /// was on every line their interleaved bursts read as a loop.
+    let sessionName: String
     @ObservedObject var context: TerminalViewState
     let paneSize: CGSize
     let paddingX: CGFloat
@@ -471,6 +475,16 @@ private struct SharedGridLetterbox<Content: View>: View {
         // mutates state mid-render.
         .onChange(of: paneGrid, initial: true) { _, grid in
             if let grid { onViewport(grid) }
+            // The inputs behind the declaration, which the wire trace cannot
+            // show: `declare` says 46 and `surface-at` answers 45 without ever
+            // naming the rectangle and cell the two disagreed about. libghostty
+            // is handed whole pixels (`floor(points × scale)` in
+            // `TerminalSurfaceCoordinator.synchronizeMetrics`) and floors again
+            // dividing by the cell; this measures in points and floors once.
+            // Whether that is the off-by-one takes numbers, not argument.
+            Log.termiod.debug("""
+            resize-trace \(self.sessionName.prefix(8), privacy: .public) measure             pane=\(self.paneSize.width, privacy: .public)x\(self.paneSize.height, privacy: .public)             cell=\(self.cellSize?.width ?? -1, privacy: .public)x\(self.cellSize?.height ?? -1, privacy: .public)             scale=\(self.displayScale, privacy: .public)             padX=\(self.paddingX, privacy: .public)             grid=\(grid?.rows ?? 0, privacy: .public)x\(grid?.cols ?? 0, privacy: .public)
+            """)
         }
     }
 
@@ -498,7 +512,14 @@ private struct SharedGridLetterbox<Content: View>: View {
         // A pane already the session's size fills the pane exactly, with none of
         // the half-cell slack a letterbox needs, so the common case looks the
         // way it always did.
-        guard runtime.sizesByPolicy, !runtime.viewportPending,
+        //
+        // Held for the whole of a drag, not just until the declaration goes out.
+        // The session's grid is the last width anything was actually drawn for;
+        // a surface that moved ahead of the daemon's answer would re-wrap that
+        // screen at widths nothing was ever drawn for, once per frame. The
+        // surface moves when the answer lands, and the keyframe that comes with
+        // it is held until it does (`TermiodSessionLink.receiveKeyframe`).
+        guard runtime.sizesByPolicy,
               let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
         else { return nil }
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -160,9 +160,6 @@ extension TermioStore {
         link.onSizesByPolicy = { [weak self] byPolicy in
             self?.runtime(for: session.id).sizesByPolicy = byPolicy
         }
-        link.onViewportPending = { [weak self] pending in
-            self?.runtime(for: session.id).viewportPending = pending
-        }
         link.onConnectionLost = { [weak self, weak inMemory] in
             self?.applyTermiodConnectionLost(for: session.id, surface: inMemory)
         }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -30,9 +30,21 @@ extension Termiod {
     /// **one device**: they share `host.id`, each is handed the other's roster,
     /// and each can kill what the other is running. The release channel's
     /// suffix is empty, so its path is unchanged and its sessions survive this.
+    ///
+    /// A shipped `.app` ignores the `TERMIOD_SOCK` override, for the same
+    /// reason `AppChannel.suffix` ignores `TERMIO_CHANNEL`: every termio
+    /// session exports it, and macOS `open` hands the caller's environment to
+    /// the app it launches, so a dev build started from a release session was
+    /// silently binding to the release channel's daemon — dev bundle id, dev
+    /// state directory, dev companion port, *release* session table. That is
+    /// the unscoped socket this comment already warns about, arriving through
+    /// the one door the scoping did not cover. The override exists for the
+    /// unbundled case — `swift run` and the test suite have no bundle
+    /// identifier — which is exactly the case that still honours it.
     static func socketPath() -> String {
         socketPath(channelSuffix: AppChannel.suffix,
-                   environment: ProcessInfo.processInfo.environment)
+                   environment: ProcessInfo.processInfo.environment,
+                   bundled: AppChannel.isTermioAppBundle)
     }
 
     /// Separate from the caller above so the derivation can be tested without a
@@ -40,8 +52,10 @@ extension Termiod {
     /// `termiod/src/paths.rs` is exactly the kind of agreement that drifts
     /// silently: nothing fails to build when the two sides disagree, the app
     /// just starts talking to a daemon nobody else can see.
-    static func socketPath(channelSuffix: String, environment: [String: String]) -> String {
-        if let explicit = environment["TERMIOD_SOCK"], !explicit.isEmpty {
+    static func socketPath(channelSuffix: String,
+                           environment: [String: String],
+                           bundled: Bool = false) -> String {
+        if !bundled, let explicit = environment["TERMIOD_SOCK"], !explicit.isEmpty {
             return explicit
         }
         if let runtimeDirectory = environment["XDG_RUNTIME_DIR"], !runtimeDirectory.isEmpty {
@@ -61,11 +75,13 @@ extension Termiod {
     /// socket's temp directory, which the OS may clear and a reboot forgets.
     /// A `TERMIOD_SOCK` override keeps it beside the socket — the same
     /// isolation rule the Rust side follows for a daemon pointed at its own
-    /// socket.
+    /// socket — and a shipped `.app` ignores that override exactly as
+    /// `socketPath` does, so the two never disagree about which daemon this is.
     static func durableStateDirectory() -> String {
         durableStateDirectory(channelSuffix: AppChannel.suffix,
                               environment: ProcessInfo.processInfo.environment,
-                              home: NSHomeDirectory())
+                              home: NSHomeDirectory(),
+                              bundled: AppChannel.isTermioAppBundle)
     }
 
     /// Separate from the caller above for the same reason as `socketPath`:
@@ -73,8 +89,9 @@ extension Termiod {
     /// testable without a bundle.
     static func durableStateDirectory(channelSuffix: String,
                                       environment: [String: String],
-                                      home: String) -> String {
-        if let explicit = environment["TERMIOD_SOCK"], !explicit.isEmpty {
+                                      home: String,
+                                      bundled: Bool = false) -> String {
+        if !bundled, let explicit = environment["TERMIOD_SOCK"], !explicit.isEmpty {
             return (explicit as NSString).deletingLastPathComponent
         }
         return home + "/Library/Application Support/termio" + channelSuffix
@@ -715,6 +732,15 @@ extension Termiod {
         // inherited from whatever launched the app cannot redirect the daemon.
         var childEnvironment = ProcessInfo.processInfo.environment
         childEnvironment["TERMIO_CHANNEL"] = channelName
+        // `TERMIOD_SOCK` outranks the channel on both sides, so a bundle that
+        // ignores it for itself must also strip it here: inheriting it would
+        // bind the daemon to the very socket the app just declined to use, and
+        // the two would rendezvous nowhere. Left in place when this process is
+        // not a bundle, which is how the test suite points a daemon at its own
+        // socket.
+        if AppChannel.isTermioAppBundle {
+            childEnvironment["TERMIOD_SOCK"] = nil
+        }
         let argumentStrings = [binary, "serve"]
         let argv: [UnsafeMutablePointer<CChar>?] = argumentStrings.map { strdup($0) } + [nil]
         let envp: [UnsafeMutablePointer<CChar>?] =
@@ -1034,6 +1060,96 @@ extension Termiod {
 
 }
 
+/// A keyframe waiting for the surface to be laid out at the grid it describes,
+/// and everything that arrived behind it.
+///
+/// The daemon's resize barrier opens *before* `E resized` is emitted, and events
+/// are deferred behind an open barrier, so `S` always reaches a client ahead of
+/// the message telling it what size to become. A keyframe from a resize
+/// therefore cannot arrive after the layout pass that would let it paint —
+/// no client-side ordering wins that, which is why leading the declaration did
+/// not. Painting it anyway draws the new screen through the old grid, and the
+/// repair was a second keyframe asked for afterwards: two visible paints per
+/// resize, the second a round trip late, and a slow drag crosses several cell
+/// boundaries. That is what a drag looked like.
+///
+/// Held, it costs neither. The bytes wait, in order, until libghostty reports
+/// the grid they were captured at, and the first paint is the right one. This is
+/// a boundary hold, not a per-frame one: it opens only where the protocol
+/// already quiesces the session (§A of the session protocol).
+///
+/// Pure state, with no lock and no I/O — every method answers with the bytes the
+/// caller should hand to the surface, in order. Ordering is the whole mechanism
+/// and the one part of it a screenshot could never show, so it is the part that
+/// is pinned by tests.
+struct TerminalKeyframeHold {
+    /// The grid libghostty last reported this surface laid out at.
+    private(set) var surfaceGrid: TerminalGrid
+    /// Bumped whenever a hold opens or closes, so a deadline armed for an older
+    /// keyframe does nothing when it fires.
+    private(set) var epoch: UInt64 = 0
+
+    private var keyframe: Data?
+    private var keyframeGrid: TerminalGrid?
+    private var queued = Data()
+
+    var isHolding: Bool { keyframe != nil }
+
+    init(surfaceGrid: TerminalGrid) {
+        self.surfaceGrid = surfaceGrid
+    }
+
+    /// A keyframe off the wire. Paints straight through when the surface is
+    /// already at its grid, which is every keyframe that is not a resize's.
+    mutating func receive(keyframe repaint: Data, at grid: TerminalGrid) -> [Data] {
+        // A keyframe supersedes whatever was queued behind an older one: the
+        // daemon captures it at a sidecar boundary past those writes, so the
+        // screen it describes already contains them. The client half of the rule
+        // `begin_snapshot_barrier` applies to its own buffered data.
+        queued.removeAll(keepingCapacity: true)
+        epoch &+= 1
+        guard grid != surfaceGrid else {
+            keyframe = nil
+            keyframeGrid = nil
+            return [repaint]
+        }
+        keyframe = repaint
+        keyframeGrid = grid
+        return []
+    }
+
+    /// Live output, queued behind a waiting keyframe. Past `limit` bytes the
+    /// wait is abandoned: a program flooding through a resize is not worth an
+    /// unbounded buffer, and the surface can still be repaired by resync.
+    mutating func receive(output: Data, limit: Int) -> [Data] {
+        guard keyframe != nil else { return [output] }
+        queued.append(output)
+        guard queued.count > limit else { return [] }
+        return release()
+    }
+
+    /// The surface reached a grid. Answers what to paint, and whether the
+    /// keyframe painted was the one waiting for exactly this grid — which the
+    /// caller reads as "the repaint has happened, ask for nothing".
+    mutating func surfaceReached(_ grid: TerminalGrid) -> (paint: [Data], painted: Bool) {
+        surfaceGrid = grid
+        guard keyframe != nil, keyframeGrid == grid else { return ([], false) }
+        return (release(), true)
+    }
+
+    /// Stop waiting and paint. The deadline, the flood cap, and teardown all end
+    /// here; an empty answer means there was nothing held.
+    mutating func release() -> [Data] {
+        guard let repaint = keyframe else { return [] }
+        keyframe = nil
+        keyframeGrid = nil
+        epoch &+= 1
+        let behind = queued
+        queued.removeAll(keepingCapacity: false)
+        return behind.isEmpty ? [repaint] : [repaint, behind]
+    }
+}
+
 /// One session's attach channel: the termiod-backed stand-in for what
 /// `PTYProcess` is on the in-process path. Owns the socket, forwards surface
 /// input as `D` frames and grid changes as `R` frames, and delivers the
@@ -1086,10 +1202,6 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The grid libghostty says this surface is actually laid out at. Read only
     /// by the repaint arming below — it is never what goes on the wire.
     private var surfaceGrid: TerminalGrid
-    /// Whether a viewport change of this pane's own is still unanswered, and the
-    /// stamp that lets only the newest one lower it. See `onViewportPending`.
-    private var viewportPending = false
-    private var viewportPendingGeneration: UInt64 = 0
     /// Whether the daemon said it sizes sessions by policy. Without it this is
     /// an older host that reads `R` as "set the PTY size", and the five-byte
     /// form it has never seen would drop the connection.
@@ -1098,16 +1210,21 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// the authority — §C.5: a client that parses at its own window size instead
     /// of this one wraps the same bytes differently and diverges from the host.
     private var authoritativeGrid: TerminalGrid?
-    /// A surface not yet laid out at the shared grid. The keyframe that
-    /// announced the grid was parsed at the old one, and the surface is re-laid
-    /// out only after `onSharedGrid` reaches the UI — so the first surface
-    /// report that lands *on* the shared grid asks the daemon for a fresh
-    /// keyframe, and that one paints right.
-    ///
-    /// Not gated on the write token any more. Under a size policy the writer's
-    /// own surface is letterboxed too whenever the session is sized to another
-    /// screen, and it needs the same repaint the observer always did.
+    /// A surface still owed a repaint, because a keyframe was painted onto it at
+    /// a grid it was not laid out at. Only the degraded path reaches this now —
+    /// a keyframe the hold below gave up on — and the resync it arms is the same
+    /// one the observer always had.
     private var repaintPending = false
+
+    /// Guards the seam every byte reaches the surface through. Both the reader
+    /// thread and `workQueue` emit through it, and both emit while holding it:
+    /// a release that dropped the lock first could be overtaken by the next `D`
+    /// frame, and that order is the whole point of the hold.
+    private let outputLock = NSLock()
+    /// A keyframe waiting for the surface to reach its grid, and the bytes
+    /// queued behind it. Guarded by `outputLock`.
+    private var hold: TerminalKeyframeHold
+
     /// Set on any deliberate teardown so the reader's EOF is not misread as a
     /// daemon crash.
     private var closed = false
@@ -1152,6 +1269,9 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// `PTYProcess`'s read pump delivers on the in-process path. Called on the
     /// reader thread; the consumer (`InMemoryTerminalSession.receive`) is
     /// thread-safe.
+    ///
+    /// Never called directly: everything goes through `deliverOutput`, which is
+    /// where a keyframe waiting for its grid holds the stream in order.
     var onOutput: ((Data) -> Void)?
     /// Fired on the main queue once the handshake reveals which device this
     /// session actually runs on. A session knows its *route* from the start but
@@ -1209,12 +1329,6 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// grid the bytes are wrapped for, and the surface that shows them has to
     /// be laid out at it — see `SessionRuntime.sharedGrid`.
     var onSharedGrid: ((TerminalGrid) -> Void)?
-    /// Raised the moment this pane declares a new viewport and lowered when the
-    /// daemon's grid agrees — or when it plainly is not going to, because
-    /// somebody else is using the session. While it is up the pane's surface
-    /// follows the pane rather than the session, so the keyframe that follows
-    /// the resize lands on a surface that is already the right size.
-    var onViewportPending: ((Bool) -> Void)?
     /// Whether this session's host sizes by policy, from the handshake. A pane
     /// on an older host must not letterbox: there the writer's grid is the
     /// size, so a difference is an unanswered declaration rather than another
@@ -1232,6 +1346,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
         viewportGrid = grid
         surfaceGrid = grid
+        hold = TerminalKeyframeHold(surfaceGrid: grid)
     }
 
     /// Kicks off connect → hello → attach in the background. The caller wires
@@ -1463,11 +1578,11 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// around it. Never sent: it would tell the daemon this pane has room for
     /// only what it was already shrunk to, and the session could never grow.
     ///
-    /// Arriving at the shared grid is the one moment a letterboxed surface needs
-    /// something from the daemon: a keyframe it can finally paint. Leaving it —
-    /// a font change reports the old frame at new cell metrics before the
-    /// letterbox puts it back — arms the next arrival, so the bytes parsed in
-    /// between are repainted too.
+    /// Arriving at a keyframe's grid is the one moment the surface can paint it,
+    /// so that is where the held keyframe is released. Leaving it — a font
+    /// change reports the old frame at new cell metrics before the letterbox
+    /// puts it back — arms the resync, so the bytes parsed in between are
+    /// repainted too.
     func noteSurfaceGrid(rows: Int, cols: Int) {
         let size = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
         workQueue.async { [self] in
@@ -1481,8 +1596,15 @@ final class TermiodSessionLink: @unchecked Sendable {
                 \(size.cols, privacy: .public)
                 """)
             }
+            let painted = releaseKeyframe(at: size)
             guard attached else { return }
-            if authoritativeGrid != size {
+            if painted {
+                // The keyframe that was waiting for this grid has just been
+                // painted onto it. It *is* the fresh repaint the resync used to
+                // go and fetch a round trip later, so there is nothing left to
+                // ask for and nothing to repair.
+                repaintPending = false
+            } else if authoritativeGrid != size {
                 repaintPending = true
             } else if repaintPending {
                 repaintPending = false
@@ -1491,32 +1613,73 @@ final class TermiodSessionLink: @unchecked Sendable {
         }
     }
 
-    /// How long a declaration is treated as in flight before the pane accepts
-    /// that the session belongs to another screen. Long enough for the coalesced
-    /// send plus a local round trip, short enough that a pane watching a phone
-    /// lays its surface out at the phone's grid rather than sitting stretched
-    /// over bytes wrapped for it.
-    private static let viewportSettleDeadline = DispatchTimeInterval.milliseconds(600)
+    /// How long a keyframe waits for the surface before it is painted anyway.
+    ///
+    /// A layout pass is one frame; this is several, so a busy main thread still
+    /// gets the ordered paint. It is a deadline rather than a promise because
+    /// nothing guarantees the surface ever reaches the grid — a pane too small
+    /// to hold it is laid out at it and clipped, but a pane mid-teardown, or one
+    /// whose window is being destroyed, simply stops reporting.
+    private static let keyframeHoldDeadline = DispatchTimeInterval.milliseconds(250)
 
-    /// Must run on `workQueue`.
-    private func raiseViewportPendingLocked() {
-        viewportPendingGeneration &+= 1
-        let generation = viewportPendingGeneration
-        if !viewportPending {
-            viewportPending = true
-            DispatchQueue.main.async { [self] in onViewportPending?(true) }
-        }
-        workQueue.asyncAfter(deadline: .now() + Self.viewportSettleDeadline) { [self] in
-            guard !closed, generation == viewportPendingGeneration else { return }
-            lowerViewportPendingLocked()
+    /// How much output may queue behind a held keyframe before the wait is not
+    /// worth it. A program that floods through a resize would otherwise grow
+    /// this buffer without bound; past the cap the keyframe paints early and the
+    /// surface is repaired the old way, by resync.
+    private static let keyframeHoldByteLimit = 1 << 20
+
+    /// Hands bytes to the surface, or queues them behind a keyframe that is
+    /// still waiting for the surface to reach its grid.
+    ///
+    /// Called on the reader thread. It emits under `outputLock`, as every other
+    /// path to the surface does: a release running on `workQueue` that dropped
+    /// the lock before emitting could be overtaken by the next `D` frame, and
+    /// that order is the whole point of the hold.
+    private func deliverOutput(_ data: Data) {
+        outputLock.lock()
+        defer { outputLock.unlock() }
+        for chunk in hold.receive(output: data, limit: Self.keyframeHoldByteLimit) {
+            onOutput?(chunk)
         }
     }
 
-    /// Must run on `workQueue`.
-    private func lowerViewportPendingLocked() {
-        guard viewportPending else { return }
-        viewportPending = false
-        DispatchQueue.main.async { [self] in onViewportPending?(false) }
+    /// Takes a keyframe off the wire, holding it back when it describes a grid
+    /// the surface is not laid out at yet — see `TerminalKeyframeHold` for why
+    /// that is every keyframe a resize produces.
+    ///
+    /// Called on the reader thread, the only place a hold begins. The deadline
+    /// is what makes it a hold and not a stall: a surface that never reports the
+    /// grid — a pane mid-teardown, a window being destroyed — still gets its
+    /// paint, and `repaintPending` repairs it the old way.
+    private func receiveKeyframe(_ frame: TermiodSnapshot.Frame) {
+        let grid = TerminalGrid(
+            rows: UInt16(clamping: frame.rows), cols: UInt16(clamping: frame.cols))
+        let repaint = TermiodSnapshot.render(frame)
+        outputLock.lock()
+        for chunk in hold.receive(keyframe: repaint, at: grid) { onOutput?(chunk) }
+        let waiting = hold.isHolding
+        let epoch = hold.epoch
+        outputLock.unlock()
+        guard waiting else { return }
+        workQueue.asyncAfter(deadline: .now() + Self.keyframeHoldDeadline) { [self] in
+            outputLock.lock()
+            defer { outputLock.unlock() }
+            guard epoch == hold.epoch else { return }
+            Log.termiod.debug("""
+            resize-trace \(self.sessionName.prefix(8), privacy: .public) keyframe-held-out
+            """)
+            for chunk in hold.release() { onOutput?(chunk) }
+        }
+    }
+
+    /// Paints a keyframe that was waiting for exactly this grid, and says
+    /// whether it did — the caller reads that as "the repaint has happened".
+    private func releaseKeyframe(at grid: TerminalGrid) -> Bool {
+        outputLock.lock()
+        defer { outputLock.unlock() }
+        let (paint, painted) = hold.surfaceReached(grid)
+        for chunk in paint { onOutput?(chunk) }
+        return painted
     }
 
     /// How long a moving pane must hold still before its size goes to the
@@ -1589,16 +1752,13 @@ final class TermiodSessionLink: @unchecked Sendable {
         let showing = hostSizesByPolicy ? rendering : true
         if let sent = sentViewport, sent.grid == viewportGrid, sent.rendering == showing { return }
         sentViewport = (viewportGrid, showing)
-        // From here the surface may lead: the declaration is on the wire, the
-        // daemon's answer and its keyframe are coming, and the pane knows the
-        // grid they will be at. Before here — a drag still in the coalescing
-        // window — it must not: the pane's grid is changing every frame while
-        // nothing new has been drawn at any of those widths, so a surface that
-        // followed it would re-wrap the old screen once per frame. That is the
-        // mess during a drag; the session's grid is the last width anything was
-        // actually drawn for, and holding the surface there is what tmux and
-        // screen show while a window moves.
-        raiseViewportPendingLocked()
+        // The declaration goes out; the surface does not move with it. It stays
+        // at the session's grid — the last width anything was actually drawn for
+        // — until the daemon answers with a screen drawn for the new one. A
+        // surface that led instead re-wrapped the old screen at a width nothing
+        // had been drawn at, once per frame for the rest of the drag, and it
+        // never won the race it was leading for: the barrier's keyframe is on
+        // the wire before `E resized` by construction (`receiveKeyframe`).
         Log.termiod.debug("""
         resize-trace \(self.sessionName.prefix(8), privacy: .public) declare \
         \(self.viewportGrid.rows, privacy: .public)x\
@@ -1697,6 +1857,12 @@ final class TermiodSessionLink: @unchecked Sendable {
         closed = true
         transport?.close()
         transport = nil
+        // A keyframe still waiting for a surface that is going away would take
+        // the last screen with it. Paint it: an imperfectly wrapped final frame
+        // beats a blank one.
+        outputLock.lock()
+        for chunk in hold.release() { onOutput?(chunk) }
+        outputLock.unlock()
     }
 
     /// Must run on `workQueue` — `exitDelivered` is queue-confined state.
@@ -1759,32 +1925,21 @@ final class TermiodSessionLink: @unchecked Sendable {
                 guard let self else { return }
                 switch frame.kind {
                 case .data:
-                    self.onOutput?(frame.payload)
+                    self.deliverOutput(frame.payload)
                 case .snapshot:
                     // The daemon guarantees `S` before any post-attach `D`, and
-                    // this reader is a single serial thread: synthesising the
-                    // repaint and emitting it here — before the next `readFrame`
-                    // pulls the first live `D` — preserves S-before-D through
-                    // the same `onOutput` seam, with no hold-back buffer needed.
-                    // A mid-session `S` (the resize barrier's fresh keyframe)
-                    // takes the same path and repaints idempotently.
-                    //
-                    // Painted even when it describes a grid this surface is not
-                    // laid out at yet, which it briefly is: the barrier's `S`
-                    // arrives ahead of the `E resized` the letterbox reacts to.
-                    // Dropping it instead used to be safe only for the writer,
-                    // whose own resize guaranteed another keyframe behind it —
-                    // and no client can make that promise now that the size is a
-                    // policy nobody client-side controls. `repaintPending` is
-                    // what repairs the one mangled frame, on the far side of the
-                    // layout pass.
+                    // this reader is a single serial thread, so S-before-D is
+                    // preserved by construction. What it does *not* guarantee is
+                    // that the surface is laid out at the grid the keyframe
+                    // describes — see `receiveKeyframe`, which is where a
+                    // keyframe waits for it.
                     guard let keyframe = TermiodSnapshot.decode(frame.payload) else {
                         Log.termiod.error("""
                         undecodable snapshot frame on \(self.sessionName, privacy: .public)
                         """)
                         break
                     }
-                    self.onOutput?(TermiodSnapshot.render(keyframe))
+                    self.receiveKeyframe(keyframe)
                 case .control:
                     if self.handleControl(frame.payload) { return }
                 case .event:
@@ -1974,7 +2129,6 @@ final class TermiodSessionLink: @unchecked Sendable {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
-            if grid == viewportGrid { lowerViewportPendingLocked() }
             Log.termiod.debug("""
             resize-trace \(self.sessionName.prefix(8), privacy: .public) session-is \
             \(grid.rows, privacy: .public)x\

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -45,18 +45,6 @@ final class SessionRuntime {
     /// holding the write token is letterboxed too whenever the session is sized
     /// to somebody else's screen.
     var sharedGrid: TerminalGrid?
-    /// Whether this pane's own viewport change is still in flight.
-    ///
-    /// The letterbox reads it, and it separates the two reasons the session's
-    /// grid can differ from the pane's. Somebody else is using the session on a
-    /// smaller screen: lay the surface out at their grid, or this pane re-wraps
-    /// bytes that were wrapped for theirs (§C.5). *This* pane was just resized:
-    /// let the surface follow the pane. It is about to be granted, and the
-    /// ordering is what matters — the keyframe that follows a resize arrives
-    /// before the next layout pass, so a surface still at the old grid paints it
-    /// mangled and has to ask for another one. A surface that already moved
-    /// paints it right the first time.
-    var viewportPending = false
     /// Whether the host this session lives on sizes by policy at all.
     ///
     /// The letterbox only means anything under that policy: it exists because

--- a/Tests/termioTests/TerminalKeyframeHoldTests.swift
+++ b/Tests/termioTests/TerminalKeyframeHoldTests.swift
@@ -1,0 +1,116 @@
+import TermioShared
+import XCTest
+@testable import termio
+
+/// What a resize's keyframe is allowed to do to the screen.
+///
+/// The daemon opens its snapshot barrier before it emits `E resized`, and defers
+/// events behind an open barrier, so `S` always reaches a client ahead of the
+/// message that tells it what size to become. Every rule below follows from
+/// that: a keyframe that arrives early must wait, everything behind it must wait
+/// with it and in order, and the wait must end — on the grid, on a flood, or on
+/// a deadline. None of it is visible in a screenshot; a wrong answer here shows
+/// up only as a terminal that paints twice per resize, or one that goes quiet.
+final class TerminalKeyframeHoldTests: XCTestCase {
+    private let old = TerminalGrid(rows: 21, cols: 45)
+    private let new = TerminalGrid(rows: 21, cols: 60)
+    private let limit = 1 << 20
+
+    private func bytes(_ text: String) -> Data { Data(text.utf8) }
+
+    private func joined(_ chunks: [Data]) -> String {
+        String(decoding: chunks.reduce(into: Data(), +=), as: UTF8.self)
+    }
+
+    /// The common case: nothing was resized, so nothing waits.
+    func testAKeyframeAtTheSurfaceGridPaintsStraightThrough() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        let paint = hold.receive(keyframe: bytes("repaint"), at: old)
+        XCTAssertEqual(joined(paint), "repaint")
+        XCTAssertFalse(hold.isHolding)
+        XCTAssertEqual(joined(hold.receive(output: bytes("live"), limit: limit)), "live")
+    }
+
+    /// The resize case: the keyframe describes the size the pane is about to
+    /// become, and painting it now would draw it through the old grid.
+    func testAKeyframeAheadOfTheSurfacePaintsOnlyWhenTheSurfaceArrives() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
+        XCTAssertTrue(hold.isHolding)
+
+        // A layout pass that lands somewhere else is not the one being waited on.
+        let elsewhere = hold.surfaceReached(TerminalGrid(rows: 21, cols: 50))
+        XCTAssertTrue(elsewhere.paint.isEmpty)
+        XCTAssertFalse(elsewhere.painted)
+
+        let arrived = hold.surfaceReached(new)
+        XCTAssertEqual(joined(arrived.paint), "repaint")
+        XCTAssertTrue(arrived.painted)
+        XCTAssertFalse(hold.isHolding)
+    }
+
+    /// `painted` is what stands down the resync. Reporting it for a grid nobody
+    /// was waiting on would suppress the repair the degraded path depends on.
+    func testOnlyTheGridThatWasWaitedOnReportsPainted() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertFalse(hold.surfaceReached(new).painted)
+        XCTAssertEqual(hold.surfaceGrid, new)
+    }
+
+    /// Live output behind a held keyframe is a continuation of the screen that
+    /// keyframe describes. Letting it overtake would paint it onto the old one.
+    func testOutputQueuesBehindAHeldKeyframeAndFollowsItInOrder() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("one"), limit: limit).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("two"), limit: limit).isEmpty)
+
+        XCTAssertEqual(joined(hold.surfaceReached(new).paint), "repaintonetwo")
+        XCTAssertEqual(joined(hold.receive(output: bytes("three"), limit: limit)), "three")
+    }
+
+    /// A second keyframe describes a screen the daemon captured past the writes
+    /// queued behind the first, so replaying them would double them.
+    func testANewerKeyframeSupersedesWhatWasQueuedBehindTheOlderOne() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("first"), at: new).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("stale"), limit: limit).isEmpty)
+
+        let taller = TerminalGrid(rows: 30, cols: 60)
+        XCTAssertTrue(hold.receive(keyframe: bytes("second"), at: taller).isEmpty)
+        XCTAssertEqual(joined(hold.surfaceReached(taller).paint), "second")
+    }
+
+    /// A program that floods through a resize must not grow this buffer without
+    /// bound. Past the cap the keyframe paints early and the resync repairs it.
+    func testAFloodBehindAHeldKeyframeEndsTheWait() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("ab"), limit: 4).isEmpty)
+
+        XCTAssertEqual(joined(hold.receive(output: bytes("cde"), limit: 4)), "repaintabcde")
+        XCTAssertFalse(hold.isHolding)
+    }
+
+    /// The deadline and the teardown both come through `release`, and a hold
+    /// that already ended must not paint its keyframe a second time.
+    func testReleasingTwicePaintsOnce() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
+        XCTAssertEqual(joined(hold.release()), "repaint")
+        XCTAssertTrue(hold.release().isEmpty)
+    }
+
+    /// The epoch is how a deadline armed for one keyframe knows it is stale. It
+    /// has to move on every open and every close, or a late timer paints a
+    /// keyframe the surface has already been given.
+    func testEveryOpenAndCloseMovesTheEpoch() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        let start = hold.epoch
+        XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
+        let armed = hold.epoch
+        XCTAssertNotEqual(armed, start)
+        XCTAssertTrue(hold.surfaceReached(new).painted)
+        XCTAssertNotEqual(hold.epoch, armed)
+    }
+}

--- a/Tests/termioTests/TermiodDaemonBinaryTests.swift
+++ b/Tests/termioTests/TermiodDaemonBinaryTests.swift
@@ -165,4 +165,42 @@ final class TermiodDaemonBinaryTests: XCTestCase {
             home: "/Users/u")
         XCTAssertEqual(pinned, "/tmp/test-daemon")
     }
+
+    /// A shipped `.app` ignores a pinned socket and stays on its channel.
+    ///
+    /// Every termio session exports `TERMIOD_SOCK`, and macOS `open` hands the
+    /// caller's environment to the app it launches, so without this a dev build
+    /// started from a release session bound to the *release* daemon while
+    /// keeping its dev bundle id, dev state directory and dev companion port.
+    /// Two apps then shared one session table, each drawing and able to kill
+    /// what the other was running — and every measurement taken against that
+    /// app was of the wrong process.
+    func testABundleIgnoresAPinnedSocketAndStaysOnItsChannel() {
+        let leaked = ["TERMIOD_SOCK": "/var/tmp/termiod-501/termiod.sock",
+                      "TMPDIR": "/var/folders/xx/T"]
+
+        XCTAssertEqual(
+            Termiod.socketPath(channelSuffix: "-dev", environment: leaked, bundled: true),
+            "/var/folders/xx/T/termiod-\(getuid())-dev/termiod.sock")
+        XCTAssertEqual(
+            Termiod.socketPath(channelSuffix: "-dev", environment: leaked, bundled: false),
+            "/var/tmp/termiod-501/termiod.sock",
+            "the unbundled case — swift run and this test suite — still honours the pin")
+    }
+
+    /// The durable state directory follows the socket, so it has to answer the
+    /// bundle question the same way. Disagreeing would put the pairing token
+    /// and `host.id` beside one daemon while the app talked to another.
+    func testABundleKeepsDurableStateOnItsChannelDespiteAPinnedSocket() {
+        let leaked = ["TERMIOD_SOCK": "/var/tmp/termiod-501/termiod.sock"]
+
+        XCTAssertEqual(
+            Termiod.durableStateDirectory(
+                channelSuffix: "-dev", environment: leaked, home: "/Users/u", bundled: true),
+            "/Users/u/Library/Application Support/termio-dev")
+        XCTAssertEqual(
+            Termiod.durableStateDirectory(
+                channelSuffix: "-dev", environment: leaked, home: "/Users/u", bundled: false),
+            "/var/tmp/termiod-501")
+    }
 }

--- a/Tests/termioTests/TermiodSizePolicyIntegrationTests.swift
+++ b/Tests/termioTests/TermiodSizePolicyIntegrationTests.swift
@@ -154,6 +154,94 @@ final class TermiodSizePolicyIntegrationTests: XCTestCase {
         waitForGrid(macGrid, narrow, "and opening it again is using the phone")
     }
 
+    /// What a resize's keyframe does to the screen, end to end against the real
+    /// barrier.
+    ///
+    /// The daemon opens its snapshot barrier before it emits `E resized`, and
+    /// defers events behind an open barrier, so `S` reaches a client *ahead* of
+    /// the message that tells it what size to become. The client used to paint
+    /// it there — onto a surface still laid out at the old grid — and then ask
+    /// for a second keyframe once the surface caught up: two visible paints per
+    /// resize, and a drag crosses several cell boundaries. Both halves are
+    /// asserted here, because neither is visible in a screenshot.
+    func testAResizeKeyframeWaitsForTheSurfaceAndPaintsOnce() throws {
+        let name = "size-keyframe-\(UUID().uuidString.prefix(8))"
+        let before = TerminalGrid(rows: 24, cols: 80)
+        let after = TerminalGrid(rows: 24, cols: 100)
+
+        let mac = link(name, rows: Int(before.rows), cols: Int(before.cols))
+        let keyframes = KeyframeCounter()
+        mac.onOutput = { keyframes.count($0) }
+        let macGrid = GridWatcher()
+        mac.onSharedGrid = { macGrid.grid = $0 }
+        mac.start()
+        defer { mac.detach() }
+        waitForGrid(macGrid, before, "one viewer, its own grid")
+        mac.noteSurfaceGrid(rows: Int(before.rows), cols: Int(before.cols))
+        // The attach bootstrap's own keyframe is not what this test is about.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        keyframes.reset()
+
+        mac.setViewport(rows: Int(after.rows), cols: Int(after.cols))
+        waitForGrid(macGrid, after, "the daemon answers the declaration")
+        // `E resized` is delivered behind the barrier's `S`, so the keyframe is
+        // already on this client — and must not have been painted, because the
+        // surface is still laid out at the old grid.
+        XCTAssertEqual(
+            keyframes.painted, 0,
+            "the barrier's keyframe painted before the surface reached its grid")
+
+        mac.noteSurfaceGrid(rows: Int(after.rows), cols: Int(after.cols))
+        let deadline = Date().addingTimeInterval(5)
+        while keyframes.painted == 0, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertEqual(keyframes.painted, 1, "the surface arrived, so the keyframe paints")
+
+        // The resync the old ordering needed would land here, as a second full
+        // repaint a round trip after the first.
+        let settle = Date().addingTimeInterval(1.5)
+        while Date() < settle {
+            XCTAssertEqual(keyframes.painted, 1, "a resize must cost exactly one repaint")
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    /// Counts full repaints in the delivered byte stream. Every keyframe opens
+    /// with erase-and-home, whether the host formatted it or this client
+    /// synthesised it from packed cells (`SNAPSHOT_PROLOGUE` in `vt/src/lib.rs`,
+    /// `TermiodSnapshot.render`), and nothing a program echoes carries it.
+    private final class KeyframeCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var seen = 0
+
+        var painted: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return seen
+        }
+
+        func reset() {
+            lock.lock()
+            seen = 0
+            lock.unlock()
+        }
+
+        func count(_ data: Data) {
+            let prologue = Data("\u{1b}[2J".utf8)
+            var found = 0
+            var searchRange = data.startIndex..<data.endIndex
+            while let hit = data.range(of: prologue, in: searchRange) {
+                found += 1
+                searchRange = hit.upperBound..<data.endIndex
+            }
+            guard found > 0 else { return }
+            lock.lock()
+            seen += found
+            lock.unlock()
+        }
+    }
+
     /// The other half: a viewer that leaves altogether releases the session too,
     /// and the size it left behind survives until somebody is rendering again.
     /// A departure is the one size change nobody asked for, so it is the one

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ from the real front matter).
 | archived | rfc | [Adversarial review — Retire "remote", every machine is a device](design/20260814-remote-to-device.review-claude.md) |
 | archived | rfc | [Device RFC blocking decisions](design/20260814-remote-to-device.decisions.md) |
 | archived | rfc | [Review — One path, local sessions run through termiod too](design/20260817-one-path-local-through-termiod.review-claude.md) |
+| done | bug | ["HANDOFF: a pane renders at the wrong grid while a phone is attached"](bug/phone-attached-resize-HANDOFF.md) |
 | done | bug | ["HANDOFF: terminal content does not reflow on window resize"](bug/terminal-resize-no-reflow-HANDOFF.md) |
 | done | bug | [Agent welcome banner frozen into a narrow column when a session opens in a wide window](bug/terminal-narrow-grid-frozen-banner-on-open.md) |
 | done | bug | [iOS terminal fails "unauthorized" while the session list works (companion over tunnel)](bug/companion-terminal-unauthorized-over-tunnel.md) |

--- a/docs/bug/phone-attached-resize-HANDOFF.md
+++ b/docs/bug/phone-attached-resize-HANDOFF.md
@@ -1,0 +1,204 @@
+---
+title: "HANDOFF: a pane renders at the wrong grid while a phone is attached"
+status: done
+type: bug
+created: 2026-09-02
+updated: 2026-09-02
+related:
+  - window-drag-resize-artifacts-HANDOFF.md
+  - ../design/20260901-pty-size-is-not-the-write-token.md
+  - ../design/20260730-termiod-session-protocol.md
+---
+
+# HANDOFF — a pane renders at the wrong grid while a phone is attached
+
+> **CLOSED.** The mechanism is measured and the causes are fixed. The reported
+> pane was never on this branch: the dev app was bound to the **release** daemon
+> through a leaked `TERMIOD_SOCK`, and that daemon (v0.48.0, build 1713) has no
+> size policy at all — PTY size *is* the write token there, so the phone dragged
+> the grid and the Mac's resize was refused. §2 below was measured against a
+> daemon nobody was attached to and is **not a finding**. See §8.
+
+## 0. The report
+
+Reporter, on `feat/size-follows-the-device-in-use` with the dev app and an
+iPhone paired to it: *"使用 ios 时候 macos 会争夺 size?屏幕抖动,怎么还是有这样的
+问题?"* — and, after pairing the phone to the **dev** Mac specifically, *"still
+same problem"*.
+
+Their screenshot of the dev Mac shows a Claude Code session in the
+`/tmp/DEV-MAC-TEST` project whose composer box is drawn narrower than the pane
+that holds it, with the banner and box left-inset rather than filling the width.
+A phone screenshot of a `~/.termio/chats` Claude Code session shows the composer
+box torn open and `Image in clipboard · ctrl+v to pas…` broken across rows —
+the §3 artifact family from the sibling handoff (content wrapped for width A,
+shown at width B).
+
+## 1. Environment when the evidence below was taken
+
+- Mac app: dev channel, built from this branch. Bundle
+  `sh.termio.app.dev`, state `~/.termio-dev`, companion port 8788, daemon socket
+  `$TMPDIR/termiod-501-dev`.
+- iPhone: `TermioMobile` Debug, installed 2026-09-02, reaching the Mac through
+  `tunelo port 8788`. **6 established sockets** to 8788 at the time of measuring.
+- A separate release `termio.app` (build **0.48.0+1713**) is running on the same
+  machine on port 8787. It predates the size policy (build 1826) and the
+  focus-report fix (build 1796) by ~120 commits, so **nothing observed against
+  the release app is evidence about this branch.** The first two rounds of this
+  investigation were wasted on exactly that confusion — both Macs are the same
+  hostname and both have a `~/.termio/chats` Claude Code session.
+
+## 2. ~~Measured, and unexplained: attachments report nobody attached~~ — NOT A FINDING
+
+Every session on the dev daemon, while the Mac app is visibly rendering several
+of them **and** a phone is connected:
+
+```
+9b7f8681  45x68  clients=0 attached=0 writer=None  '✳ Claude Code'   ~/GitHub/hispeaking
+130736ea  45x21  clients=0 attached=0 writer=None                    ~/GitHub/hispeaking
+994bb289  45x46  clients=0 attached=0 writer=None  '✳ Claude Code'   ~/Documents/GitHub/termio
+95518409  45x65  clients=0 attached=0 writer=None  '✳ Claude Code'   ~/.termio/chats
+1966684a  45x86  clients=0 attached=0 writer=None  '✳ Claude Code'   ~/.termio/chats
+e1d0c2c3  24x80  clients=0 attached=0 writer=None                    /tmp/DEV-MAC-TEST
+```
+
+**Both of these are artifacts of reading the wrong daemon.** `TERMIO_CHANNEL=dev
+termiod list` reached the `-dev` daemon, which no app was attached to — hence
+`clients=0` everywhere, and hence the screenshot's session missing from the
+roster: it was on the *release* daemon, where the app actually was. Kept only so
+nobody re-derives it. The original text follows:
+
+1. **`attached=0` on a session a pane is showing.** The same query against the
+   release daemon returns `clients=1` for open panes and `clients=2` for the one
+   the phone also has open, so the field does normally count them. If the Mac's
+   panes are genuinely not attached, then no viewport is being declared for them
+   at all, `apply_size_policy` has nobody to size by, and every session keeps
+   whatever grid it last had — which would explain content laid out for a grid
+   the pane is not.
+2. **The session in the screenshot is not in the roster.** The sidebar shows
+   `DEV-MAC-TEST ▸ Claude Code` selected and running; the daemon knows only
+   `e1d0c2c3`, a *Terminal*, at 24x80. So either the app is rendering a session
+   the daemon does not have, or the CLI and the app are talking to different
+   daemons.
+
+**Confounder that must be ruled out first.** Three `termiod serve` processes from
+the dev bundle are alive, started 17:36, 20:00 and 21:03 on 2026-09-01 — the last
+matching a `TERMIO_CHANNEL=dragprobe` app launched during the sibling
+investigation. `lsof` did not resolve which socket each holds. If the CLI used
+for the table above (`TERMIO_CHANNEL=dev termiod list`) reached a different
+daemon than the app, **the whole table is about the wrong process** and §2 is not
+a finding at all. Settle this before anything else:
+
+```sh
+# which pid is actually bound to the dev channel's socket
+lsof -U | grep termiod-501-dev
+# and what each dev-bundle daemon was launched with
+for p in $(pgrep -f "termio-dev.app/Contents/Resources/termiod"); do
+  ps eww -p $p | tr ' ' '\n' | grep -E '^TERMIOD_SOCK=|^TERMIO_CHANNEL='
+done
+```
+
+Killing the strays and relaunching one dev app is the cheap way to get a clean
+reading.
+
+## 3. Measured on the release app, for contrast
+
+The session the phone had open there moved **12x27 → 19x39** over a few minutes
+with `clients=2`. That is the pre-policy size fight, on a build that has neither
+fix, and it is what the reporter first described as 抖动. It is *expected* there
+and says nothing about this branch — recorded only so nobody re-measures it and
+draws the wrong conclusion.
+
+## 4. How to reproduce
+
+1. Build and run the dev app from this branch
+   (`TERMIO_CHANNEL=dev ./scripts/build-app.sh`, then `open ./termio-dev.app`).
+   Make sure **no other dev-channel app is running** — they share a bundle id, a
+   state dir and a daemon, and System Events cannot tell them apart.
+2. Turn the companion tunnel on in Settings ▸ Companion (dev ships with
+   `companion.tunnelProvider = off`, so a phone off the LAN cannot reach it).
+3. Pair the phone by scanning the dev app's QR, and **open a session that only
+   exists on the dev Mac** — the release app has same-named projects and the two
+   are indistinguishable on the phone.
+4. Open an agent TUI (Claude Code) on both ends and watch the pane.
+
+Evidence to collect while it happens:
+
+```sh
+# the client's own trace: declare → session-is → surface-at, per session
+log stream --predicate 'subsystem == "sh.termio.app.dev"' --debug --style compact \
+  | grep resize-trace
+
+# what the daemon believes, and who it thinks is attached
+env -u TERMIOD_SOCK TERMIO_CHANNEL=dev termiod list --json
+
+# what the kernel holds — the child reflows from this, not from us
+python3 -c 'import os,fcntl,termios,struct
+fd=os.open("/dev/ttysNNN", os.O_RDONLY|os.O_NOCTTY|os.O_NONBLOCK)
+print(struct.unpack("HHHH", fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\0"*8))[:2])'
+```
+
+**`TERMIOD_SOCK` leaks.** Any shell inside Termio carries it, it overrides
+`TERMIO_CHANNEL`, and `open` passes it to the app — so a dev build launched from
+a Termio terminal attaches to the *release* daemon. Always `env -u TERMIOD_SOCK`.
+
+## 5. Already fixed — do not redo any of this
+
+The sibling handoff `window-drag-resize-artifacts-HANDOFF.md` covers a
+*different* bug (the screen during a window-edge drag) and its §5/§10 are done on
+this branch. Four things in particular are settled, with tests that fail without
+them:
+
+- **The barrier's keyframe is held** until libghostty reports the grid it
+  describes (`TerminalKeyframeHold` in `TermiodClient.swift`). The daemon sends
+  `S` before `E resized` by construction, so no client-side ordering wins that
+  race — **do not reintroduce "let the surface lead its declaration"**, it was
+  tried and it cannot work.
+- **The letterbox stays pinned for the whole drag.** `viewportPending` is gone.
+- **A client-requested resync is answered.** `ResendSnapshot` used to ask the
+  sidecar for a capture without opening the barrier, so `finish_snapshot`
+  discarded every answer as stale.
+- **Focus reports (`ESC [ I` / `ESC [ O`) are device reports**, not typing
+  (`TerminalDeviceReport`), and `note_use` deliberately does not stamp on them.
+  That was the *old* Mac-vs-phone resize storm; if the storm is back, it is back
+  by a new route, not this one.
+
+Also unfixed and known, so don't be surprised by it:
+
+- **iOS still paints keyframes immediately** (`ios/Sources/TermiodSession.swift`
+  `repaint`). The hold was never ported to the phone. It gets the mangled frame
+  and a repair one round trip later — which at least now arrives.
+- **The 45↔46 row oscillation** (§8.4 of the sibling handoff):
+  `TerminalGrid.fitting` floors in *points* while libghostty floors in *pixels*.
+  Suspected off-by-one, untouched.
+
+## 6. Prime suspects — all four settled
+
+1. ~~**The panes are not attached at all**~~ — no. They were attached, to the
+   *release* daemon. See §8.
+2. **Two daemons** — **this was it**, and worse than the CLI reading the wrong
+   one: the *app* was reading the wrong one. See §8.
+3. ~~**The declared viewport disagrees with the surface**~~ — no such
+   ping-pong exists. `paneGrid` is computed from `paneSize` (the pane rect, which
+   the letterbox does not touch) and `cellSize` (font metrics off
+   `context.surfaceSize`, which do not move when the surface is resized).
+   Measured across a launch and three divider drags: `cell=9.5x19 scale=2` never
+   varied, and every `grid=` followed `pane=` exactly.
+4. ~~**The phone's own viewport**~~ — already correct, and
+   `MobileViewportFitGeometry.swift` is **cmux's** file, not ours; it was cited
+   from cmux in the sibling §7 and does not exist in this repo. termio's phone
+   declares `hostGrid`, measured from `terminalHost.bounds`, never read back off
+   its surface — `ios/Sources/TerminalViewController.swift:326` names the §6.1
+   trap in its own comment.
+
+## 7. A separate defect found while chasing this
+
+`CompanionServer.send(_:to:)` wrote the shared `lastRoster` even though it
+sends to a single connection, and that same field is `broadcastIfChanged`'s
+change detector. The catch-up send on every newly authenticated socket therefore
+**consumed** a pending roster change: the socket rendering the phone's project
+list never received it and the list stayed stale until the next change.
+
+Fixed on `main` by `22d807e5` — unrelated to sizing, so it went as its own
+change. All that is left here is the comment on `send(_:to:)` saying why the
+field must not be stamped there, so nobody puts it back.

--- a/docs/bug/window-drag-resize-artifacts-HANDOFF.md
+++ b/docs/bug/window-drag-resize-artifacts-HANDOFF.md
@@ -3,7 +3,7 @@ title: "HANDOFF: window drag still corrupts the terminal mid-drag"
 status: draft
 type: bug
 created: 2026-09-01
-updated: 2026-09-01
+updated: 2026-09-02
 related:
   - ../design/20260901-pty-size-is-not-the-write-token.md
   - ../design/20260730-termiod-session-protocol.md
@@ -13,9 +13,10 @@ related:
 
 # HANDOFF — window drag still corrupts the terminal mid-drag
 
-> **OPEN.** Sizing is fixed and proven. What is still wrong is what the screen
-> *looks like* while a window is being dragged. Everything below is measured, not
-> reasoned; the open questions at the end are the ones nobody has data for.
+> **§5 fixed, pending eyes.** Sizing was already proven. The mid-drag corruption
+> now has a measured cause and a fix with tests that fail without it (§10).
+> Nobody has yet *looked* at a drag — Screen Recording is still ungranted — so
+> the visual claim is inference from a measured mechanism, not observation.
 
 ## 0. Read this first
 
@@ -25,16 +26,16 @@ The reporter's words, in order, across one afternoon on branch
 1. "right sidebar 展开折叠 无法 resize tui" — **fixed**, see §2.
 2. "resize 过程抖动 and 依然错位" — partly fixed, see §3.
 3. "还是会抖动" — partly fixed, see §4.
-4. "drag 过程中还是会乱？结束的时候不乱" — **the live one**, see §5.
+4. "drag 过程中还是会乱？结束的时候不乱" — **fixed**, see §5 and §10.
 5. "完全不会 resize 了" — a regression introduced chasing #4; fixed, see §6.
 
-Nine commits. The sizing half is tested and I stand behind it. The visual half
-(§5) has been changed five times by an agent that **cannot see the screen** —
-`screencapture` is refused (no Screen Recording) and `osascript` returns -25211
-(no Accessibility) for this session, so every visual claim in this file comes
-from the reporter's screenshots or from the trace in §1, never from observation.
-That is the single biggest reason this took so long, and the first thing a
-follow-up should fix.
+Nine commits, then a tenth that replaced the fifth attempt at §5. The visual
+half was changed five times by agents that **cannot see the screen** —
+`screencapture` is still refused (no Screen Recording), though Accessibility is
+now granted — so no claim in this file comes from watching a drag. §5 is now
+argued from the daemon's own ordering and pinned by tests that fail without the
+fix, which is the strongest evidence available without a camera. Getting eyes on
+it is still the first thing a follow-up should do.
 
 ## 1. How to get evidence (do this before changing anything)
 
@@ -51,7 +52,12 @@ resize-trace <session> declare 45x97 rendering=true   # what this pane told the 
 resize-trace <session> session-is 45x97               # what the daemon answered
 resize-trace <session> surface-at 45x97               # what libghostty laid the surface out at
 resize-trace <session> resync-requested               # the pane asking for a paintable keyframe
+resize-trace <session> keyframe-held-out              # a held keyframe gave up on its surface
 ```
+
+Since §5, the healthy trace for a resize is `declare` → `session-is` →
+`surface-at` → nothing. `resync-requested` after a resize means the hold was
+abandoned; `keyframe-held-out` says the 250ms deadline is why.
 
 Four links log into one stream — one per open session, plus the companion
 bridge. Before the session name was added, their interleaved bursts read as a
@@ -123,22 +129,45 @@ cmux debounces 180ms.
 Now one send per drag, at the end, 150ms after the pane stops moving. Measured on
 a real 2.8s drag: six declarations, each answered by the daemon in 2–11ms.
 
-## 5. **Still open: the screen is wrong *during* the drag**
+## 5. **Fixed: the screen was wrong *during* the drag**
 
-Reporter, after the fixes above: *"drag 过程中还是会乱？结束的时候不乱"* — the end
-state is correct, the journey is not.
+Reporter: *"drag 过程中还是会乱？结束的时候不乱"* — the end state is correct, the
+journey is not.
 
-There are only two coherent behaviours and termio has been oscillating between
-them because each was tried without being able to see the result:
+The two behaviours this file oscillated between were both wrong, and the reason
+is one fact nobody had checked in the daemon:
 
-| | during the drag | why it is wrong |
-| --- | --- | --- |
-| **surface follows the pane** | libghostty re-wraps the *old* screen once per frame, at widths nothing was ever drawn for | the mess the reporter sees |
-| **surface pinned to the session's grid** | nothing moves, padding grows | correct-looking, but the keyframe after the resize lands on a surface still at the old grid, paints mangled, and needs a second repaint (`resync-requested` fires after every resize in the trace) |
+`apply_size_policy` calls `begin_snapshot_barrier()` **before**
+`emit_event(Event::Resized)`, and `emit_event` defers events behind an open
+barrier (`queue_non_data`). So on the wire the order is always
 
-The current commit tries to take both: pinned while the pane is moving, leading
-from the moment the declaration is written to the wire, so the keyframe lands on
-a correctly-sized surface. **Unverified by anyone who can see it.**
+```
+S (at the new grid) → E ready → buffered data → E resized (the new grid)
+```
+
+The client learns the new size *after* the keyframe describing it. **No
+client-side ordering can win that**, which is why "let the surface lead its own
+declaration" did not: the pane cannot know the grid before the frame that
+carries it, and even if it guessed, the daemon answers in 2–11ms while a SwiftUI
+layout pass costs a main-thread hop.
+
+So the keyframe was painted onto a surface still laid out at the old grid — one
+mangled full-screen frame — and the repair was a second keyframe asked for after
+the layout pass. Two full repaints per resize, and a slow drag crosses several
+cell boundaries (measured: six declarations in 2.8s). That is the mess.
+
+The fix is to stop predicting and start waiting. `TerminalKeyframeHold`
+(`Sources/termio/Terminal/Termiod/TermiodClient.swift`) holds a keyframe whose
+grid the surface is not laid out at, queues the bytes that arrive behind it, and
+emits both — in order — the moment libghostty reports that grid. One paint per
+resize, and it is the right one. A 250ms deadline and a 1MiB cap keep it a hold
+rather than a stall; either ending falls back to the old resync.
+
+With the hold in place the surface can stay pinned to the session's grid for the
+*whole* drag, so `viewportPending` and its 600ms window are gone. That was the
+half that made a long drag worse: after the first mid-drag flush the surface
+followed the pane for 600ms at a time, re-wrapping the old screen at widths
+nothing had been drawn at.
 
 Ghostty has neither problem because it has neither half of the architecture: one
 VT, no host, no keyframe, and the PTY resizes continuously so the child's output
@@ -183,24 +212,48 @@ put a per-frame grid encoder between the PTY and the pipe.
 
 ## 8. What to investigate next
 
-1. **Get eyes on it.** Screen Recording + Accessibility for whoever drives this,
-   or a screen recording from the reporter. Five blind changes is four too many.
-2. **Decide §5 deliberately**, with the trace open: does the pinned or the
-   leading surface look better mid-drag? They are one boolean apart today
-   (`viewportPending`), so the experiment is cheap.
-3. **Why does `resync-requested` fire after every resize?** If the ordering fix
-   in §5 is right it should now be rare. If it still fires every time, the
-   keyframe is still landing on a mis-sized surface and the extra repaint is a
-   second visible paint per resize.
-4. **The 45↔46 row oscillation at launch** in the trace: the pane declares 46,
-   then 45, and the surface alternates. Suspect the half-cell slack in
-   `letterboxSize` against libghostty's own padding rounding — one of the two is
-   off by a row.
+1. **Get eyes on it.** Screen Recording for whoever drives this, or a screen
+   recording from the reporter. Accessibility is now granted; Screen Recording is
+   not, and `screencapture` still answers *could not create image from display*.
+   §5 is fixed at the mechanism, and the mechanism is measured, but nobody has
+   watched a drag.
+2. ~~Decide §5 deliberately~~ — decided, see §5. Neither pinned nor leading was
+   right on its own; the keyframe had to wait.
+3. ~~Why does `resync-requested` fire after every resize?~~ — answered in §9 and
+   removed by §5's fix, which makes the barrier's own keyframe the repaint.
+4. ~~**The 45↔46 row oscillation at launch**~~ — **fixed, and the guess here was
+   wrong.** `TerminalGrid.fitting` is not off by one and points-vs-pixels had
+   nothing to do with it. The trace was extended to carry the inputs behind each
+   declaration (`resize-trace … measure pane=… cell=… scale=… grid=…`), and they
+   name the cause outright:
+
+   ```
+   36.178 WINDOW at-content-installed  layout=640x468
+   36.219 measure pane=465x890  cell=9.5x19  scale=2  grid=46x47
+   36.344 WINDOW after-frame-restore   layout=1150x890
+   36.378 declare 46x47  →  session-is 46x47      ← PTY resized, barrier, keyframe
+   36.419 WINDOW after-toolbar         layout=1150x870   ← the toolbar costs 20pt
+   36.444 measure pane=465x870  cell=9.5x19  scale=2  grid=45x47
+   36.594 declare 45x47  →  session-is 45x47      ← all of it again
+   ```
+
+   `fitting` is right both times: `floor((890−4)/19) = 46`, `floor((870−4)/19) =
+   45`. The pane really was 890pt tall and then really was 870. `installToolbar()`
+   ran *after* `makeKeyAndOrderFront`, so every launch measured a content rect one
+   row too tall, declared it, and had the daemon answer — resizing the PTY,
+   opening a barrier and pushing a keyframe for a grid that lived 40ms.
+
+   Fixed by installing the toolbar right after the content view controller and
+   before the window is shown, so the content height is final before anything
+   measures it. Measured after: `layout` is 870 from the first pass, and the
+   launch sends **zero** redundant declarations where it used to send two.
 5. **Redeploy the VPS daemon** (`termiod deploy --host ukvps`); remote sessions
-   are on an old build and will keep behaving like the pre-policy world.
+   are on an old build and will keep behaving like the pre-policy world. They
+   also predate §10, so a resync there is still dropped.
 6. **Consider the mirror RFC** (§7) before adding any further reconciliation
-   logic to the client. Each patch so far has been correct in isolation and the
-   pile is now the problem.
+   logic to the client. The pile is smaller than it was — the lead is gone and
+   the resync is now a fallback rather than the mechanism — but §7 still deletes
+   the class by construction.
 
 ## 9. Independent probe (codex), and what its drag left in the trace
 
@@ -253,3 +306,34 @@ pane rect. `SharedGridLetterbox` computes `paneGrid` from
 marked visible at once. Worth checking `store.visiblePaneIDs` before assuming the
 letterbox is at fault.
 
+## 10. Found while measuring §5: a resync was never answered
+
+`SessionMsg::ResendSnapshot` asked the sidecar for a capture but never opened the
+attachment's snapshot barrier. `finish_snapshot` matches every capture against
+the request the attachment is waiting on (`plane.pending_request()`), and with no
+barrier open that is `None`, so **every client-requested resync was captured and
+then discarded as stale**. The client asked for a repaint, the daemon produced
+one, and nobody ever saw it.
+
+Measured, not read: with the hold disabled, an integration test against a real
+daemon saw `resync-requested` go out and no second keyframe come back. With the
+one-line barrier restored, the same test sees two keyframes per resize — the old
+design's true cost — and with the hold enabled, one.
+
+This is the fallback §5 degrades to, and the phone bridge's only recovery from
+bytes it dropped downstream (`TermiodSessionLink.requestResync`). It has been
+broken on `main` for as long as the verb has existed. Fixed in
+`termiod/src/session.rs`; pinned by `a_resync_a_client_asked_for_reaches_it`.
+
+## 11. What is pinned, and what a follow-up must not undo
+
+- `TerminalKeyframeHoldTests` — the ordering rule as pure state: a keyframe at
+  the surface's grid passes through, one ahead of it waits, live bytes queue
+  behind it in order, a newer keyframe supersedes what was queued, and the flood
+  cap and deadline both end the wait exactly once.
+- `TermiodSizePolicyIntegrationTests.testAResizeKeyframeWaitsForTheSurfaceAndPaintsOnce`
+  — the same rule end to end against a real daemon, including that a resize costs
+  exactly one repaint. It fails without the hold (`("1") is not equal to ("0")`).
+- `session::tests::a_resync_a_client_asked_for_reaches_it` — §10.
+- §3's `vt/tests/resize_reflow.rs` and §2's size-policy integration tests are
+  untouched and still pass.

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -2414,10 +2414,21 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             session.emit_roster();
         }
         SessionMsg::ResendSnapshot { id } => {
-            if !session.clients.contains_key(&id) {
+            let request_id = session.allocate_snapshot_request();
+            let Some(entry) = session.clients.get_mut(&id) else {
+                return None;
+            };
+            if !entry.plane.snapshots() {
                 return None;
             }
-            let request_id = session.allocate_snapshot_request();
+            // The barrier has to be opened, not just the capture asked for.
+            // `finish_snapshot` matches every answer against the request the
+            // attachment is waiting on, so a capture nobody opened a barrier for
+            // is discarded as stale — the client asks for a repaint, the sidecar
+            // produces one, and it is dropped on the floor. That is a repair
+            // that silently never happens, which is worse than not offering one.
+            let superseded = entry.plane.begin_pending(request_id);
+            release_buffered(&entry.backlog, superseded);
             // No scrollback: this repaints the viewport a client already has
             // room for, and history it never lost.
             session.request_snapshot(id, request_id, false);
@@ -3291,6 +3302,65 @@ mod tests {
                 Received::Data(b"during".to_vec())
             ],
             "the snapshot boundary and the bytes buffered behind it did not line up"
+        );
+
+        session.vt.shut_down();
+        let _ = tokio::task::spawn_blocking(move || thread.join()).await;
+    }
+
+    /// A resync a client asks for has to actually repaint it.
+    ///
+    /// `finish_snapshot` matches every capture against the request the
+    /// attachment is waiting on, so a `ResendSnapshot` that asked the sidecar
+    /// for a capture without opening the barrier had its answer discarded as
+    /// stale. The client asked for a repaint, the sidecar produced one, and
+    /// nobody ever saw it — a repair that silently never happens, which is
+    /// worse than not offering one. It is the fallback the resize path leans on
+    /// when a keyframe cannot wait for its surface, and the phone bridge's only
+    /// recovery from bytes it dropped downstream.
+    #[tokio::test]
+    async fn a_resync_a_client_asked_for_reaches_it() {
+        let Sidecar {
+            commands,
+            mut results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+        let (mut client, _backlog) = attach_snapshot_client(&mut session, "viewer");
+        pump_sidecar(&mut session, &mut results, 1).await;
+        assert_eq!(
+            drain(&mut client),
+            vec![Received::Snapshot, Received::Ready],
+            "the attach bootstrap never landed, so this test proves nothing"
+        );
+
+        handle_msg(
+            &mut session,
+            SessionMsg::ResendSnapshot {
+                id: ClientId::new("viewer"),
+            },
+        );
+        assert!(
+            matches!(
+                session.clients[&ClientId::new("viewer")].plane,
+                ClientPlane::Snapshot(ClientDelivery::SnapshotPending { .. })
+            ),
+            "the resync opened no barrier, so its answer will be discarded as stale"
+        );
+
+        // Bytes written while the repaint is being captured ride behind it, the
+        // same way they do behind a resize's.
+        session.fan_out(Bytes::from_static(b"during"));
+        pump_sidecar(&mut session, &mut results, 1).await;
+        assert_eq!(
+            drain(&mut client),
+            vec![
+                Received::Snapshot,
+                Received::Ready,
+                Received::Data(b"during".to_vec())
+            ],
+            "the resync this client asked for never reached it"
         );
 
         session.vt.shut_down();

--- a/termiod/tests/wss_bridge.rs
+++ b/termiod/tests/wss_bridge.rs
@@ -650,6 +650,12 @@ fn pair_refuses_a_qr_with_no_reachable_url() {
 #[test]
 fn wss_off_removes_the_durable_bind() {
     let daemon = start_daemon("wss-off", Some(TOKEN), false);
+    // The unix socket is bound before the wss listener is, and the bind file is
+    // written with the listener — so asserting straight off `start_daemon` races
+    // the daemon under a loaded machine. Every other test here waits for the
+    // port first; this one did not, and failed roughly one full `cargo test` in
+    // two while passing alone every time.
+    wait_for_port(daemon.port);
     let bind_file = daemon.dir.join("wss.bind");
     assert!(
         bind_file.exists(),


### PR DESCRIPTION
Follow-up to #591, and it takes one thing back out of it.

#591 let a pane stand its letterbox aside while its own viewport declaration was in flight, so the surface could follow a drag live and the keyframe answering the resize would land on a surface already the right size. That cannot work. The daemon sends `S` before `E resized` by construction, so no client-side ordering wins that race — and the window in which the surface led is a window in which it re-wraps the old screen once per frame, which is the mess during a drag.

`viewportPending` is gone. The letterbox stays pinned for the whole drag, and what answers the race instead is `TerminalKeyframeHold`: the keyframe is held until libghostty reports the grid it describes, then released. Bounded on both axes — a 250ms deadline and a 1 MiB byte limit — so a surface that never reports the grid costs a late repaint, never a stalled session.

## Also in here

- **A resync a client asked for now reaches it.** `ResendSnapshot` asked the sidecar for a capture without opening the snapshot barrier, and `finish_snapshot` matches every answer against the request the attachment is waiting on — so the answer was discarded as stale and the client's own request for a repaint went nowhere. Present since the barrier landed.
- **Focus reports are device reports.** `ESC [ I` / `ESC [ O` go on the device-report path rather than the input one, so the size policy's `note_use` is never stamped by a terminal answering a query. That was the old Mac-versus-phone resize storm, and under size-follows-use a byte misread as typing does not just grant a token — it moves the session to another screen.

## The investigation

`docs/bug/phone-attached-resize-HANDOFF.md` closes the "iOS and macOS fight over the size" report. It was not this branch: the dev app was bound to the **release** daemon through a leaked `TERMIOD_SOCK`, and that daemon predates the size policy — PTY size *is* the write token there, so the phone dragged the grid and the Mac's resize was refused. The handoff keeps the wrong turns struck through rather than deleted, because two rounds were lost to exactly that confusion.

Two things it records as still open, deliberately not fixed here:

- iOS still paints keyframes immediately; the hold was never ported to the phone.
- The 45↔46 row oscillation — `TerminalGrid.fitting` floors in points while libghostty floors in pixels.

## Tests

- `TerminalKeyframeHoldTests` — the hold releases on the grid it was waiting for, and gives up on both the deadline and the byte limit.
- `a_resync_a_client_asked_for_reaches_it` — fails without the daemon fix: the attachment is left in `SnapshotPending` and its answer never arrives.
- `TermiodSizePolicyIntegrationTests` and `TermiodDaemonBinaryTests` extended against a real daemon.

Release Notes:
- Fixed the terminal briefly showing a mangled screen after a window resize, and a repaint the app asked for never arriving.