### PR TITLE
Fix the split inspector divider and the sidebar's jump on toggle

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -72,12 +72,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var pendingOpenURLs: [URL] = []
     // The split controller (sidebar + terminal + inspector). The navigator toggle reaches its
     // `toggleSidebar(_:)` through the responder chain, so this is just a weak handle on the
-    // window content controller's child.
+    // window's content view controller.
     private weak var splitViewController: NSSplitViewController?
-    // The split normally meets the window edge, but fullscreen keeps a small breathing room above
-    // both the sidebar and terminal. Held so fullscreen transitions can adjust it without
-    // rebuilding panes or their terminal surfaces.
-    private var splitTopInsetConstraint: NSLayoutConstraint?
     // The trailing file-browser inspector item, retained so the toolbar button and the
     // View menu can collapse/expand it. Starts collapsed (see `makeContentSplitViewController`).
     private var filesInspectorItem: NSSplitViewItem?
@@ -265,7 +261,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // The autosaved frame can restore straight into fullscreen, so seed the mirror rather
         // than waiting for a transition that already happened.
         store.windowIsFullScreen = window.styleMask.contains(.fullScreen)
-        updateSplitTopInset()
         // Empty the sidebar's toolbar region (sort + new-terminal) whenever the navigator collapses
         // and restore it when it reopens — the sidebar's own buttons ride with the sidebar, the way
         // Finder/Xcode drop theirs. KVO catches every collapse path (toolbar toggle, View menu,
@@ -599,7 +594,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// lights and the title-bar tracking separator. The panes no longer bridge their toolbars —
     /// the window owns a real `NSToolbar` (see `installToolbar`) so it can carry the native
     /// `.toggleSidebar` item. The standard `toggleSidebar(_:)` responder action collapses the item.
-    private func makeContentSplitViewController() -> NSViewController {
+    private func makeContentSplitViewController() -> NSSplitViewController {
         let sidebar = NSHostingController(rootView: SidebarView()
             .environmentObject(store)
             .environmentObject(settings))
@@ -669,21 +664,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         splitViewController.addSplitViewItem(inspectorItem)
         splitViewController.splitView.autosaveName = "TermioContentSplit"
         self.splitViewController = splitViewController
-
-        let container = NSViewController()
-        container.addChild(splitViewController)
-        let splitView = splitViewController.view
-        splitView.translatesAutoresizingMaskIntoConstraints = false
-        container.view.addSubview(splitView)
-        let topInset = splitView.topAnchor.constraint(equalTo: container.view.topAnchor)
-        NSLayoutConstraint.activate([
-            splitView.leadingAnchor.constraint(equalTo: container.view.leadingAnchor),
-            splitView.trailingAnchor.constraint(equalTo: container.view.trailingAnchor),
-            splitView.bottomAnchor.constraint(equalTo: container.view.bottomAnchor),
-            topInset,
-        ])
-        splitTopInsetConstraint = topInset
-        return container
+        return splitViewController
     }
 
     /// Keeps the native window title in step with the selected session's working directory.
@@ -805,7 +786,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// `windowDidEnterFullScreen` corrects it.
     func windowWillEnterFullScreen(_ notification: Notification) {
         window?.titlebarAppearsTransparent = false
-        updateSplitTopInset(fullScreen: true)
         // Flip before the animation, so a maximized detail's header drops its traffic-light gap
         // as the window grows rather than snapping inward once it lands.
         store.windowIsFullScreen = true
@@ -814,7 +794,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// The twin of `windowWillEnterFullScreen` for the maximized detail's header: the buttons come
     /// back with the window, so the gap that clears them is restored before the animation ends.
     func windowWillExitFullScreen(_ notification: Notification) {
-        updateSplitTopInset(fullScreen: false)
         store.windowIsFullScreen = false
     }
 
@@ -825,24 +804,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func windowDidEnterFullScreen(_ notification: Notification) {
         applyChromeAppearance()
         applyWindowTransparency()
-        updateSplitTopInset(fullScreen: true)
         store.windowIsFullScreen = true
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
         applyChromeAppearance()
         applyWindowTransparency()
-        updateSplitTopInset(fullScreen: false)
         updateInspectorMaxThickness()
         store.windowIsFullScreen = false
-    }
-
-    /// Fullscreen's hidden toolbar otherwise lets the split touch the screen's top edge. The same
-    /// inset applies to every split item, keeping the sidebar and terminal visually aligned.
-    private func updateSplitTopInset(fullScreen: Bool? = nil) {
-        guard let splitTopInsetConstraint else { return }
-        let isFullScreen = fullScreen ?? window?.styleMask.contains(.fullScreen) == true
-        splitTopInsetConstraint.constant = isFullScreen ? 8 : 0
     }
 
     /// View ▸ Toggle Full Screen (⌃⌘F).

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -56,9 +56,6 @@ private struct SidebarSectionHeader: View {
     let title: String
     let chrome: ChromeTheme?
     var isCollapsed: Bool = false
-    /// The first section in the list sits right under the toolbar, so its top
-    /// padding is dead space rather than a separator — it gets a tight inset.
-    var isFirstSection: Bool = false
     var toggleCollapsed: () -> Void = {}
     var menuItems: [SidebarMenuItem] = []
     @State private var isMenuOpen = false
@@ -84,8 +81,11 @@ private struct SidebarSectionHeader: View {
         }
         // Generous top padding is the separator between sections — whitespace, not a
         // rule — so each group reads as its own block without a hairline. The first
-        // section has no group above it to separate from, so it stays tight.
-        .padding(.top, isFirstSection ? 0 : 12)
+        // section carries it too: that gap used to come from the list's `contentMargins`,
+        // but a scroll-content inset is recomputed whenever the split view relayouts the
+        // sidebar, so toggling the inspector dropped it for a frame and the rows jumped.
+        // Padding inside a row cannot be recomputed.
+        .padding(.top, 12)
         .padding(.bottom, 2)
         // No `listRowInsets` override — the header keeps the rows' default inset so both
         // share one left baseline. The small leading then lands the label's left edge on
@@ -213,7 +213,6 @@ struct SidebarView: View {
                     title: localized("Pinned"),
                     chrome: chrome,
                     isCollapsed: pinnedCollapsed,
-                    isFirstSection: true,
                     toggleCollapsed: {
                         withAnimation(.easeInOut(duration: 0.18)) { pinnedCollapsed.toggle() }
                     }
@@ -244,7 +243,6 @@ struct SidebarView: View {
                     title: localized("Terminals"),
                     chrome: chrome,
                     isCollapsed: terminalsCollapsed,
-                    isFirstSection: !hasPinned,
                     toggleCollapsed: {
                         withAnimation(.easeInOut(duration: 0.18)) { terminalsCollapsed.toggle() }
                     },
@@ -275,7 +273,6 @@ struct SidebarView: View {
                     title: localized("Chats"),
                     chrome: chrome,
                     isCollapsed: chatsCollapsed,
-                    isFirstSection: !hasPinned && !hasTerminals,
                     toggleCollapsed: {
                         withAnimation(.easeInOut(duration: 0.18)) { chatsCollapsed.toggle() }
                     },
@@ -302,7 +299,6 @@ struct SidebarView: View {
                     title: localized("Projects"),
                     chrome: chrome,
                     isCollapsed: projectsCollapsed,
-                    isFirstSection: !hasPinned && !hasTerminals && !hasChats,
                     toggleCollapsed: {
                         withAnimation(.easeInOut(duration: 0.18)) { projectsCollapsed.toggle() }
                     }
@@ -320,7 +316,7 @@ struct SidebarView: View {
         // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
         // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
         .listStyle(.sidebar)
-        .contentMargins(.vertical, 12, for: .scrollContent)
+        .contentMargins(.bottom, 12, for: .scrollContent)
         .environment(\.defaultMinListRowHeight, 1)
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
     }


### PR DESCRIPTION
Two chrome defects at the inspector's edge, both measured rather than eyeballed.

**The divider read as two lines in fullscreen.** The 8pt split inset added in `8c48fce6` started the split view below the window top, so the terminal ‖ inspector divider began 8pt down while the toolbar's tracking separator still ran from the top edge — a light cap over a black body with a seam between them. Sampling the column showed the colour changing four times inside the 51pt title-bar band. Dropping the inset lets the one divider run unbroken again, and takes the wrapper view controller with it, since that existed only to hold the constraint.

**The sidebar jumped 12pt on every inspector toggle.** The sidebar's top gap came from `contentMargins`, which SwiftUI applies as the scroll view's content inset. Collapsing or expanding the inspector relayouts the sidebar, and the inset is dropped and re-applied a frame later, so every row fell and snapped back. Instrumenting the scroll view showed the offset going −56 → −44 → −56 on each toggle; with the gap moved into the section header it holds at −44 across repeated toggles in both directions. The list keeps `contentMargins` for its bottom margin only, and `isFirstSection` — which existed solely to zero that first header's padding — goes with the change.

Spacing is unchanged in both cases; net −35 lines.

Release Notes:
- Fixed the divider between the terminal and the inspector rendering as two mismatched segments in full screen.
- Fixed the sidebar's rows jumping down and back each time the inspector was opened or closed.