### PR TITLE
Make an outward window drag grow the terminal with the pane

### DIFF
--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -418,10 +418,11 @@ private enum TerminalFocusReason {
 /// grid — and a surface stretched across this pane would re-wrap them at its own
 /// width, the §C.5 divergence: every line that wrapped on the phone lands
 /// somewhere else here, and a TUI that repaints incrementally never repairs it.
-/// So a pane larger than the session shows it at exactly the shared grid,
-/// centred, with the terminal background around it — the same picture the phone
-/// has, at the Mac's font. Typing here, or resizing this pane, brings the
-/// session back and the surface returns to the pane.
+/// So a pane larger than the session normally shows it at exactly the shared
+/// grid, anchored top-left with the terminal background around it — the same
+/// picture the phone has, at the Mac's font. A local outward resize is the safe
+/// exception: widening can rejoin rows but cannot split them at an invented
+/// width, so the surface grows with the pane until the daemon answers.
 ///
 /// This is also where the pane states its *viewport* — how much it could show,
 /// measured from its own geometry. The surface cannot answer that question once
@@ -518,13 +519,10 @@ private struct SharedGridLetterbox<Content: View>: View {
         // the half-cell slack a letterbox needs, so the common case looks the
         // way it always did.
         //
-        // Held for the whole of a drag, not just until the declaration goes out.
-        // The session's grid is the last width anything was actually drawn for;
-        // a surface that moved ahead of the daemon's answer would re-wrap that
-        // screen at widths nothing was ever drawn for, once per frame. The
-        // surface moves when the answer lands, and the keyframe that comes with
-        // it is held until it does (`TermiodSessionLink.receiveKeyframe`).
-        guard runtime.sizesByPolicy,
+        // Shrinking stays pinned: it would split rows at widths the child never
+        // drew. Growing may follow the pane because it only rejoins rows, while
+        // the keyframe hold covers a layout that trails the daemon's answer.
+        guard runtime.sizesByPolicy, !runtime.growingViewportPending,
               let grid = runtime.sharedGrid, grid != paneGrid, let cell = cellSize
         else { return nil }
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -140,6 +140,9 @@ extension TermioStore {
         link.onSharedGrid = { [weak self] grid in
             self?.runtime(for: session.id).sharedGrid = grid
         }
+        link.onGrowingViewportPending = { [weak self] pending in
+            self?.runtime(for: session.id).growingViewportPending = pending
+        }
         // What the device knows about the process, gated exactly where the
         // in-process PTY's own kernel poll is gated: that poll is installed only
         // on a row declared `.terminal` (a declared agent's foreground is its own

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1092,8 +1092,18 @@ struct TerminalKeyframeHold {
     private var keyframe: Data?
     private var keyframeGrid: TerminalGrid?
     private var queued = Data()
+    /// The next keyframe answers a repaint this client asked for, so it is
+    /// painted whatever grid it describes. See `paintNextKeyframe`.
+    private var painting = false
 
     var isHolding: Bool { keyframe != nil }
+
+    /// Take the next keyframe out of the hold: it answers a resync, which is
+    /// only ever asked for after a hold has already failed to deliver one.
+    /// Waiting on the same grid again would give up the same way and ask again.
+    mutating func paintNextKeyframe() {
+        painting = true
+    }
 
     init(surfaceGrid: TerminalGrid) {
         self.surfaceGrid = surfaceGrid
@@ -1108,7 +1118,9 @@ struct TerminalKeyframeHold {
         // `begin_snapshot_barrier` applies to its own buffered data.
         queued.removeAll(keepingCapacity: true)
         epoch &+= 1
-        guard grid != surfaceGrid else {
+        let asked = painting
+        painting = false
+        guard grid != surfaceGrid, !asked else {
             keyframe = nil
             keyframeGrid = nil
             return [repaint]
@@ -1119,13 +1131,14 @@ struct TerminalKeyframeHold {
     }
 
     /// Live output, queued behind a waiting keyframe. Past `limit` bytes the
-    /// wait is abandoned: a program flooding through a resize is not worth an
-    /// unbounded buffer, and the surface can still be repaired by resync.
-    mutating func receive(output: Data, limit: Int) -> [Data] {
-        guard keyframe != nil else { return [output] }
+    /// wait is given up on: a program flooding through a resize is not worth an
+    /// unbounded buffer, and the flood is overwriting the screen the keyframe
+    /// describes anyway. `given_up` tells the caller to arm the repaint.
+    mutating func receive(output: Data, limit: Int) -> (emit: [Data], gaveUp: Bool) {
+        guard keyframe != nil else { return ([output], false) }
         queued.append(output)
-        guard queued.count > limit else { return [] }
-        return release()
+        guard queued.count > limit else { return ([], false) }
+        return (abandon(), true)
     }
 
     /// The surface reached a grid. Answers what to paint, and whether the
@@ -1137,8 +1150,29 @@ struct TerminalKeyframeHold {
         return (release(), true)
     }
 
-    /// Stop waiting and paint. The deadline, the flood cap, and teardown all end
-    /// here; an empty answer means there was nothing held.
+    /// Stop waiting and give the keyframe up unpainted, answering with only the
+    /// bytes that were queued behind it.
+    ///
+    /// A keyframe describes a screen at *its* grid. Painted into a surface laid
+    /// out at another one, every row wraps somewhere the daemon never put it —
+    /// a scrambled full-screen frame, guaranteed, which is what a give-up used
+    /// to put on screen before asking for the repaint that replaced it a round
+    /// trip later. Dropping it instead leaves the last correct screen up until
+    /// the resync lands. The live bytes still go out: they are the child's, and
+    /// this is not the layer that may discard them.
+    mutating func abandon() -> [Data] {
+        guard keyframe != nil else { return [] }
+        keyframe = nil
+        keyframeGrid = nil
+        epoch &+= 1
+        let behind = queued
+        queued.removeAll(keepingCapacity: false)
+        return behind.isEmpty ? [] : [behind]
+    }
+
+    /// Stop waiting and paint. Only teardown ends here — a surface that is going
+    /// away has no repair coming, so an imperfectly wrapped final frame beats a
+    /// blank one. Every other ending goes through `abandon`.
     mutating func release() -> [Data] {
         guard let repaint = keyframe else { return [] }
         keyframe = nil
@@ -1150,8 +1184,18 @@ struct TerminalKeyframeHold {
     }
 }
 
-/// One session's attach channel: the termiod-backed stand-in for what
-/// `PTYProcess` is on the in-process path. Owns the socket, forwards surface
+enum TerminalViewportGrowth {
+    static func canLeadSurface(
+        viewport: TerminalGrid, authoritativeGrid: TerminalGrid?
+    ) -> Bool {
+        guard let authoritativeGrid, viewport != authoritativeGrid else { return false }
+        return viewport.rows >= authoritativeGrid.rows
+            && viewport.cols >= authoritativeGrid.cols
+    }
+}
+
+/// One session's attach channel — everything this app knows about a running
+/// session. Owns the socket, forwards surface
 /// input as `D` frames and grid changes as `R` frames, and delivers the
 /// daemon's output/exit back to the surface. Closing the socket is a detach —
 /// the daemon keeps the session running; only `killAndClose` destroys it.
@@ -1202,6 +1246,11 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The grid libghostty says this surface is actually laid out at. Read only
     /// by the repaint arming below — it is never what goes on the wire.
     private var surfaceGrid: TerminalGrid
+    /// A local viewport growth that has not reached the daemon yet. While this
+    /// is true the surface may widen with the pane instead of letterboxing at
+    /// the old session grid; shrinking never takes this path.
+    private var growingViewportPending = false
+    private var growingViewportGeneration: UInt64 = 0
     /// Whether the daemon said it sizes sessions by policy. Without it this is
     /// an older host that reads `R` as "set the PTY size", and the five-byte
     /// form it has never seen would drop the connection.
@@ -1210,10 +1259,11 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// the authority — §C.5: a client that parses at its own window size instead
     /// of this one wraps the same bytes differently and diverges from the host.
     private var authoritativeGrid: TerminalGrid?
-    /// A surface still owed a repaint, because a keyframe was painted onto it at
-    /// a grid it was not laid out at. Only the degraded path reaches this now —
-    /// a keyframe the hold below gave up on — and the resync it arms is the same
-    /// one the observer always had.
+    /// A surface still owed a repaint, because the keyframe that would have
+    /// given it one was given up on before it could be laid out at that grid.
+    /// Only the degraded path reaches this — the hold below timing out, or a
+    /// flood behind it — and the resync it arms is the same one the observer
+    /// always had.
     private var repaintPending = false
 
     /// Guards the seam every byte reaches the surface through. Both the reader
@@ -1265,9 +1315,8 @@ final class TermiodSessionLink: @unchecked Sendable {
         return latestInformationLocked
     }
 
-    /// Raw PTY bytes from the daemon — fed to the surface exactly where
-    /// `PTYProcess`'s read pump delivers on the in-process path. Called on the
-    /// reader thread; the consumer (`InMemoryTerminalSession.receive`) is
+    /// Raw PTY bytes from the daemon, fed straight to the surface. Called on
+    /// the reader thread; the consumer (`InMemoryTerminalSession.receive`) is
     /// thread-safe.
     ///
     /// Never called directly: everything goes through `deliverOutput`, which is
@@ -1329,6 +1378,9 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// grid the bytes are wrapped for, and the surface that shows them has to
     /// be laid out at it — see `SessionRuntime.sharedGrid`.
     var onSharedGrid: ((TerminalGrid) -> Void)?
+    /// Raised only while this pane is growing beyond the session's grid. The UI
+    /// uses it to remove the outward-drag letterbox until the daemon answers.
+    var onGrowingViewportPending: ((Bool) -> Void)?
     /// Whether this session's host sizes by policy, from the handshake. A pane
     /// on an older host must not letterbox: there the writer's grid is the
     /// size, so a difference is an unanswered declaration rather than another
@@ -1461,7 +1513,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         // Stamped here rather than on the work queue: this is the choke point every
         // input path crosses (Mac keystrokes, the phone bridge, `sessions send`),
         // and the status tap reads it to tell input echo apart from agent-driven
-        // output. Same contract as `PTYProcess.lastInputAt`.
+        // output.
         inputLock.lock()
         lastInputAtLocked = Date()
         inputLock.unlock()
@@ -1472,10 +1524,9 @@ final class TermiodSessionLink: @unchecked Sendable {
                 return
             }
             do {
-                // Typing is what claims the token, the same rule
-                // `PTYProcess.claimHostOwnership` follows on the in-process
-                // path: the size and the write follow the device whose user is
-                // actually at the keyboard. Typing is the *only* thing that
+                // Typing is what claims the token: the size and the write both
+                // follow the device whose user is actually at the keyboard.
+                // Typing is the *only* thing that
                 // moves the token — attaching does not, or a phone merely
                 // looking at this session would mute this window and pull the
                 // PTY down to its own width.
@@ -1557,9 +1608,37 @@ final class TermiodSessionLink: @unchecked Sendable {
             guard !closed, viewportGrid != size else { return }
             viewportGrid = size
             guard attached else { return }
+            updateGrowingViewportLocked()
             scheduleViewportLocked()
         }
     }
+
+    /// A local growth may lead the daemon because widening cannot split a row
+    /// at a width the child never drew. The deadline restores the authoritative
+    /// letterbox if another device wins the size policy instead.
+    ///
+    /// Must run on `workQueue`.
+    private func updateGrowingViewportLocked() {
+        growingViewportGeneration &+= 1
+        let generation = growingViewportGeneration
+        let mayLead = hostSizesByPolicy && TerminalViewportGrowth.canLeadSurface(
+            viewport: viewportGrid, authoritativeGrid: authoritativeGrid)
+        setGrowingViewportPendingLocked(mayLead)
+        guard mayLead else { return }
+        workQueue.asyncAfter(deadline: .now() + Self.growingViewportDeadline) { [self] in
+            guard !closed, generation == growingViewportGeneration else { return }
+            setGrowingViewportPendingLocked(false)
+        }
+    }
+
+    /// Must run on `workQueue`.
+    private func setGrowingViewportPendingLocked(_ pending: Bool) {
+        guard growingViewportPending != pending else { return }
+        growingViewportPending = pending
+        DispatchQueue.main.async { [self] in onGrowingViewportPending?(pending) }
+    }
+
+    private static let growingViewportDeadline = DispatchTimeInterval.milliseconds(600)
 
     /// Whether this pane is on screen. A hidden pane is not rendering and stops
     /// counting toward the session's size; showing it again puts its viewport
@@ -1613,19 +1692,21 @@ final class TermiodSessionLink: @unchecked Sendable {
         }
     }
 
-    /// How long a keyframe waits for the surface before it is painted anyway.
+    /// How long a keyframe waits for the surface before it is given up on.
     ///
     /// A layout pass is one frame; this is several, so a busy main thread still
     /// gets the ordered paint. It is a deadline rather than a promise because
     /// nothing guarantees the surface ever reaches the grid — a pane too small
     /// to hold it is laid out at it and clipped, but a pane mid-teardown, or one
-    /// whose window is being destroyed, simply stops reporting.
+    /// whose window is being destroyed, simply stops reporting. Missing it costs
+    /// a resync round trip and nothing else: the keyframe is dropped rather than
+    /// painted through the wrong grid.
     private static let keyframeHoldDeadline = DispatchTimeInterval.milliseconds(250)
 
     /// How much output may queue behind a held keyframe before the wait is not
     /// worth it. A program that floods through a resize would otherwise grow
-    /// this buffer without bound; past the cap the keyframe paints early and the
-    /// surface is repaired the old way, by resync.
+    /// this buffer without bound; past the cap the keyframe is given up on and
+    /// the surface is repaired by resync.
     private static let keyframeHoldByteLimit = 1 << 20
 
     /// Hands bytes to the surface, or queues them behind a keyframe that is
@@ -1637,10 +1718,14 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// that order is the whole point of the hold.
     private func deliverOutput(_ data: Data) {
         outputLock.lock()
-        defer { outputLock.unlock() }
-        for chunk in hold.receive(output: data, limit: Self.keyframeHoldByteLimit) {
-            onOutput?(chunk)
-        }
+        let outcome = hold.receive(output: data, limit: Self.keyframeHoldByteLimit)
+        for chunk in outcome.emit { onOutput?(chunk) }
+        outputLock.unlock()
+        guard outcome.gaveUp else { return }
+        Log.termiod.debug("""
+        resize-trace \(self.sessionName.prefix(8), privacy: .public) keyframe-flooded-out
+        """)
+        workQueue.async { [self] in armRepaintLocked() }
     }
 
     /// Takes a keyframe off the wire, holding it back when it describes a grid
@@ -1649,8 +1734,9 @@ final class TermiodSessionLink: @unchecked Sendable {
     ///
     /// Called on the reader thread, the only place a hold begins. The deadline
     /// is what makes it a hold and not a stall: a surface that never reports the
-    /// grid — a pane mid-teardown, a window being destroyed — still gets its
-    /// paint, and `repaintPending` repairs it the old way.
+    /// grid — a pane mid-teardown, a window being destroyed — stops the wait and
+    /// gets the resync instead. The keyframe itself is *not* painted there; see
+    /// `TerminalKeyframeHold.abandon`.
     private func receiveKeyframe(_ frame: TermiodSnapshot.Frame) {
         let grid = TerminalGrid(
             rows: UInt16(clamping: frame.rows), cols: UInt16(clamping: frame.cols))
@@ -1663,14 +1749,54 @@ final class TermiodSessionLink: @unchecked Sendable {
         guard waiting else { return }
         workQueue.asyncAfter(deadline: .now() + Self.keyframeHoldDeadline) { [self] in
             outputLock.lock()
-            defer { outputLock.unlock() }
-            guard epoch == hold.epoch else { return }
+            guard epoch == hold.epoch else {
+                outputLock.unlock()
+                return
+            }
+            for chunk in hold.abandon() { onOutput?(chunk) }
+            outputLock.unlock()
             Log.termiod.debug("""
             resize-trace \(self.sessionName.prefix(8), privacy: .public) keyframe-held-out
             """)
-            for chunk in hold.release() { onOutput?(chunk) }
+            armRepaintLocked()
         }
     }
+
+    /// A hold ended without the surface ever reaching the keyframe's grid, so
+    /// the screen is the last one that was painted correctly plus whatever live
+    /// bytes came past. Ask for the repaint: now, if the surface is already
+    /// where the session is and nothing further will move it, otherwise when it
+    /// gets there.
+    ///
+    /// Must run on `workQueue`.
+    private func armRepaintLocked() {
+        guard !closed, attached else { return }
+        if authoritativeGrid == surfaceGrid {
+            repaintPending = false
+            requestResyncLocked()
+            return
+        }
+        repaintPending = true
+        // The surface is expected to reach the session's grid on its next layout
+        // pass, and `noteSurfaceGrid` asks for the repaint when it does. Nothing
+        // guarantees it ever reports that *exact* grid: a pane that fills itself
+        // is measured in points here and floored in pixels by libghostty, and
+        // the two can disagree by a column. Without this the arming would wait
+        // on a report that never comes and the pane would keep its pre-resize
+        // screen indefinitely — which is worse than the wrong frame this whole
+        // path exists to stop showing.
+        workQueue.asyncAfter(deadline: .now() + Self.repaintBackstop) { [self] in
+            guard !closed, attached, repaintPending else { return }
+            repaintPending = false
+            requestResyncLocked()
+        }
+    }
+
+    /// How long the arming above waits for a surface that may never report the
+    /// grid it was asked for. Long enough that the ordinary path — one layout
+    /// pass — always wins it, so the backstop only ever fires for a surface that
+    /// genuinely settled somewhere else.
+    private static let repaintBackstop = DispatchTimeInterval.milliseconds(500)
 
     /// Paints a keyframe that was waiting for exactly this grid, and says
     /// whether it did — the caller reads that as "the repaint has happened".
@@ -1703,11 +1829,8 @@ final class TermiodSessionLink: @unchecked Sendable {
 
     /// Sends a burst's final size, once it stops.
     ///
-    /// One barrier per drag, at the end, and deliberately not one at the start
-    /// as well: the pane's own surface follows the drag live (the letterbox
-    /// stands aside while this declaration is in flight), so an early barrier
-    /// buys nothing and costs every viewer a full-screen repaint at the moment
-    /// the drag begins — which is what it looked like.
+    /// One barrier per drag, at the end. A growing pane may follow the drag live;
+    /// a shrinking one stays at the last authoritative grid and is clipped.
     ///
     /// Generation-stamped rather than cancelled because the size is re-read at
     /// fire time: the last scheduled send is the only one that writes, and it
@@ -1752,13 +1875,10 @@ final class TermiodSessionLink: @unchecked Sendable {
         let showing = hostSizesByPolicy ? rendering : true
         if let sent = sentViewport, sent.grid == viewportGrid, sent.rendering == showing { return }
         sentViewport = (viewportGrid, showing)
-        // The declaration goes out; the surface does not move with it. It stays
-        // at the session's grid — the last width anything was actually drawn for
-        // — until the daemon answers with a screen drawn for the new one. A
-        // surface that led instead re-wrapped the old screen at a width nothing
-        // had been drawn at, once per frame for the rest of the drag, and it
-        // never won the race it was leading for: the barrier's keyframe is on
-        // the wire before `E resized` by construction (`receiveKeyframe`).
+        // A shrinking surface stays at the session's grid until this declaration
+        // is answered; leading there would split rows at widths the child never
+        // drew. A growing surface may already have widened with the pane, and the
+        // keyframe hold still covers the case where its layout trails the reply.
         Log.termiod.debug("""
         resize-trace \(self.sessionName.prefix(8), privacy: .public) declare \
         \(self.viewportGrid.rows, privacy: .public)x\
@@ -1815,6 +1935,15 @@ final class TermiodSessionLink: @unchecked Sendable {
 
     private func requestResyncLocked() {
         traceResync()
+        // A repaint asked for is one the hold has already failed to deliver, so
+        // its answer is not put through the hold again. Holding it would wait on
+        // the same grid the surface did not reach the first time, give up the
+        // same way, and ask again — a loop that leaves the surface stale for as
+        // long as it runs. By the time an answer arrives the surface has stopped
+        // moving, which is the condition the hold exists to wait for.
+        outputLock.lock()
+        hold.paintNextKeyframe()
+        outputLock.unlock()
         guard !closed, attached, let transport else { return }
         do {
             try Termiod.writeFrame(transport.writeDescriptor, kind: .control,
@@ -2135,6 +2264,12 @@ final class TermiodSessionLink: @unchecked Sendable {
             \(grid.cols, privacy: .public)
             """)
             DispatchQueue.main.async { [self] in onSharedGrid?(grid) }
+            if grid == viewportGrid || !TerminalViewportGrowth.canLeadSurface(
+                viewport: viewportGrid, authoritativeGrid: grid)
+            {
+                growingViewportGeneration &+= 1
+                setGrowingViewportPendingLocked(false)
+            }
             repaintPending = grid != surfaceGrid
             guard grid != viewportGrid else { return }
             Log.termiod.info("""

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -45,6 +45,9 @@ final class SessionRuntime {
     /// holding the write token is letterboxed too whenever the session is sized
     /// to somebody else's screen.
     var sharedGrid: TerminalGrid?
+    /// This pane is growing beyond the shared grid and may widen its surface
+    /// while the coalesced viewport declaration is still unanswered.
+    var growingViewportPending = false
     /// Whether the host this session lives on sizes by policy at all.
     ///
     /// The letterbox only means anything under that policy: it exists because

--- a/Tests/termioTests/TerminalKeyframeHoldTests.swift
+++ b/Tests/termioTests/TerminalKeyframeHoldTests.swift
@@ -9,8 +9,11 @@ import XCTest
 /// message that tells it what size to become. Every rule below follows from
 /// that: a keyframe that arrives early must wait, everything behind it must wait
 /// with it and in order, and the wait must end — on the grid, on a flood, or on
-/// a deadline. None of it is visible in a screenshot; a wrong answer here shows
-/// up only as a terminal that paints twice per resize, or one that goes quiet.
+/// a deadline. Only the first of those three endings paints it: a keyframe drawn
+/// for a grid the surface is not laid out at scrambles every row it touches, so
+/// the other two drop it and ask for a resync. A wrong answer here shows up as a
+/// terminal that paints twice per resize, one that goes quiet, or — the report
+/// this was written from — one that scrambles for a round trip on every drag.
 final class TerminalKeyframeHoldTests: XCTestCase {
     private let old = TerminalGrid(rows: 21, cols: 45)
     private let new = TerminalGrid(rows: 21, cols: 60)
@@ -28,7 +31,7 @@ final class TerminalKeyframeHoldTests: XCTestCase {
         let paint = hold.receive(keyframe: bytes("repaint"), at: old)
         XCTAssertEqual(joined(paint), "repaint")
         XCTAssertFalse(hold.isHolding)
-        XCTAssertEqual(joined(hold.receive(output: bytes("live"), limit: limit)), "live")
+        XCTAssertEqual(joined(hold.receive(output: bytes("live"), limit: limit).emit), "live")
     }
 
     /// The resize case: the keyframe describes the size the pane is about to
@@ -62,11 +65,11 @@ final class TerminalKeyframeHoldTests: XCTestCase {
     func testOutputQueuesBehindAHeldKeyframeAndFollowsItInOrder() {
         var hold = TerminalKeyframeHold(surfaceGrid: old)
         XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
-        XCTAssertTrue(hold.receive(output: bytes("one"), limit: limit).isEmpty)
-        XCTAssertTrue(hold.receive(output: bytes("two"), limit: limit).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("one"), limit: limit).emit.isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("two"), limit: limit).emit.isEmpty)
 
         XCTAssertEqual(joined(hold.surfaceReached(new).paint), "repaintonetwo")
-        XCTAssertEqual(joined(hold.receive(output: bytes("three"), limit: limit)), "three")
+        XCTAssertEqual(joined(hold.receive(output: bytes("three"), limit: limit).emit), "three")
     }
 
     /// A second keyframe describes a screen the daemon captured past the writes
@@ -74,7 +77,7 @@ final class TerminalKeyframeHoldTests: XCTestCase {
     func testANewerKeyframeSupersedesWhatWasQueuedBehindTheOlderOne() {
         var hold = TerminalKeyframeHold(surfaceGrid: old)
         XCTAssertTrue(hold.receive(keyframe: bytes("first"), at: new).isEmpty)
-        XCTAssertTrue(hold.receive(output: bytes("stale"), limit: limit).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("stale"), limit: limit).emit.isEmpty)
 
         let taller = TerminalGrid(rows: 30, cols: 60)
         XCTAssertTrue(hold.receive(keyframe: bytes("second"), at: taller).isEmpty)
@@ -82,23 +85,63 @@ final class TerminalKeyframeHoldTests: XCTestCase {
     }
 
     /// A program that floods through a resize must not grow this buffer without
-    /// bound. Past the cap the keyframe paints early and the resync repairs it.
-    func testAFloodBehindAHeldKeyframeEndsTheWait() {
+    /// bound. Past the cap the wait is given up on — the live bytes go out, the
+    /// keyframe does not, and `gaveUp` is what tells the link to ask for the
+    /// repaint.
+    func testAFloodBehindAHeldKeyframeEndsTheWaitWithoutPaintingIt() {
         var hold = TerminalKeyframeHold(surfaceGrid: old)
         XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
-        XCTAssertTrue(hold.receive(output: bytes("ab"), limit: 4).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("ab"), limit: 4).emit.isEmpty)
 
-        XCTAssertEqual(joined(hold.receive(output: bytes("cde"), limit: 4)), "repaintabcde")
+        let flooded = hold.receive(output: bytes("cde"), limit: 4)
+        XCTAssertEqual(joined(flooded.emit), "abcde")
+        XCTAssertTrue(flooded.gaveUp)
         XCTAssertFalse(hold.isHolding)
     }
 
-    /// The deadline and the teardown both come through `release`, and a hold
-    /// that already ended must not paint its keyframe a second time.
-    func testReleasingTwicePaintsOnce() {
+    /// The deadline drops the keyframe rather than painting it: a screen drawn
+    /// for one grid, written into a surface laid out at another, wraps every row
+    /// somewhere the daemon never put it. Leaving the last correct screen up and
+    /// asking for a resync is the cheaper wrong answer, and the only one that
+    /// never shows the user a scrambled frame.
+    func testGivingUpDropsTheKeyframeAndKeepsWhatWasQueuedBehindIt() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
+        XCTAssertTrue(hold.receive(output: bytes("live"), limit: limit).emit.isEmpty)
+
+        XCTAssertEqual(joined(hold.abandon()), "live")
+        XCTAssertFalse(hold.isHolding)
+        XCTAssertTrue(hold.abandon().isEmpty)
+        XCTAssertTrue(hold.release().isEmpty, "an abandoned keyframe must not paint later")
+    }
+
+    /// Teardown is the one ending that still paints: a surface that is going
+    /// away has no resync coming, so an imperfectly wrapped final frame beats a
+    /// blank one. A hold that already ended must not paint it a second time.
+    func testTeardownPaintsOnceAndOnlyOnce() {
         var hold = TerminalKeyframeHold(surfaceGrid: old)
         XCTAssertTrue(hold.receive(keyframe: bytes("repaint"), at: new).isEmpty)
         XCTAssertEqual(joined(hold.release()), "repaint")
         XCTAssertTrue(hold.release().isEmpty)
+    }
+
+    /// A resync's answer is not held. The resync is only ever asked for after a
+    /// hold already failed to deliver a keyframe, so holding its answer would
+    /// wait on the grid the surface did not reach the first time, give up the
+    /// same way, and ask again — a loop that leaves the pane on its pre-resize
+    /// screen for as long as it runs.
+    func testAKeyframeAnsweringARepaintWeAskedForIsNotHeld() {
+        var hold = TerminalKeyframeHold(surfaceGrid: old)
+        XCTAssertTrue(hold.receive(keyframe: bytes("held"), at: new).isEmpty)
+        XCTAssertEqual(joined(hold.abandon()), "")
+
+        hold.paintNextKeyframe()
+        XCTAssertEqual(joined(hold.receive(keyframe: bytes("resync"), at: new)), "resync")
+        XCTAssertFalse(hold.isHolding)
+
+        // One keyframe only: the next resize waits its turn like any other.
+        XCTAssertTrue(hold.receive(keyframe: bytes("later"), at: new).isEmpty)
+        XCTAssertTrue(hold.isHolding)
     }
 
     /// The epoch is how a deadline armed for one keyframe knows it is stale. It

--- a/Tests/termioTests/TerminalViewportGridTests.swift
+++ b/Tests/termioTests/TerminalViewportGridTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import TermioShared
+@testable import termio
 
 /// The one piece of arithmetic both clients declare their viewport with.
 ///
@@ -69,5 +70,26 @@ final class TerminalViewportGridTests: XCTestCase {
     func testZeroPaddingUsesTheWholeRectangle() {
         XCTAssertEqual(
             grid(800, 400, paddingX: 0, paddingY: 0), TerminalGrid(rows: 20, cols: 100))
+    }
+
+    /// Only a viewport that contains the authoritative grid may lead it. This is
+    /// the direction that cannot split an existing row at an invented width.
+    func testOnlyOutwardViewportGrowthMayLeadTheSurface() {
+        let session = TerminalGrid(rows: 24, cols: 80)
+
+        XCTAssertTrue(TerminalViewportGrowth.canLeadSurface(
+            viewport: TerminalGrid(rows: 24, cols: 100), authoritativeGrid: session))
+        XCTAssertTrue(TerminalViewportGrowth.canLeadSurface(
+            viewport: TerminalGrid(rows: 30, cols: 80), authoritativeGrid: session))
+        XCTAssertTrue(TerminalViewportGrowth.canLeadSurface(
+            viewport: TerminalGrid(rows: 30, cols: 100), authoritativeGrid: session))
+        XCTAssertFalse(TerminalViewportGrowth.canLeadSurface(
+            viewport: session, authoritativeGrid: session))
+        XCTAssertFalse(TerminalViewportGrowth.canLeadSurface(
+            viewport: TerminalGrid(rows: 24, cols: 79), authoritativeGrid: session))
+        XCTAssertFalse(TerminalViewportGrowth.canLeadSurface(
+            viewport: TerminalGrid(rows: 23, cols: 100), authoritativeGrid: session))
+        XCTAssertFalse(TerminalViewportGrowth.canLeadSurface(
+            viewport: TerminalGrid(rows: 30, cols: 100), authoritativeGrid: nil))
     }
 }

--- a/docs/bug/window-drag-resize-artifacts-HANDOFF.md
+++ b/docs/bug/window-drag-resize-artifacts-HANDOFF.md
@@ -13,10 +13,10 @@ related:
 
 # HANDOFF — window drag still corrupts the terminal mid-drag
 
-> **§5 fixed, pending eyes.** Sizing was already proven. The mid-drag corruption
-> now has a measured cause and a fix with tests that fail without it (§10).
-> Nobody has yet *looked* at a drag — Screen Recording is still ungranted — so
-> the visual claim is inference from a measured mechanism, not observation.
+> **Eyes obtained.** The reporter's screenshot (§12) has been decoded down to the
+> column: it is an 82-column Claude Code screen rewrapped to 66. §12 also
+> measures what the child does with a SIGWINCH, which settles two arguments this
+> file was making from assumption, and closes one ordering hole in the daemon.
 
 ## 0. Read this first
 
@@ -337,3 +337,175 @@ broken on `main` for as long as the verb has existed. Fixed in
 - `session::tests::a_resync_a_client_asked_for_reaches_it` — §10.
 - §3's `vt/tests/resize_reflow.rs` and §2's size-policy integration tests are
   untouched and still pass.
+
+## 12. Eyes on it, finally — and what the screenshot decodes to
+
+2026-09-02. The reporter photographed a drag: *"why 拖动屏幕 tui 乱码"*. The
+picture is a wide pane holding a much narrower screen, its box borders broken
+into one long run and one short one, and `/rc` split across a row boundary.
+
+**It decodes exactly.** Run `claude` on a real PTY at 82 columns and it draws its
+hint row as `⏵⏵ bypass permissions on (shift+tab to cycle)` followed by
+`ESC[66G` — `/rc` at column 66. Rewrap that screen to 66 columns and `/` is the
+last cell of the row while `rc` wraps; the 78-cell border splits into 66 + 12.
+That is the screenshot, glyph for glyph. Reproduced against `termiod-vt`
+directly:
+
+```
+--- 82 -> 55 (reflow) ---
+───────────────────────────────────────────────────────
+───────────────────────────
+bypass permissions on (shift+tab to cycle) . <- for age
+nts / rc
+```
+
+So the frame on screen is **a screen drawn for one width, rewrapped to another,
+with no repaint over it**. Nothing else produces that shape. Two questions
+follow: does the child not repaint, or does its repaint get overwritten?
+
+### 12.1 The child does repaint — measured, not assumed
+
+§3 argued the rewrap is safe for a TUI because "an agent TUI, an editor, a pager
+all repaint from their own model". That is true of Claude Code, and now measured
+rather than asserted. Captured from a real PTY across a `TIOCSWINSZ`:
+
+```
+ESC[?1000h ESC[?1002h ESC[?1003h ESC[?1006h ESC[?25l ESC[2J ESC[H  <redraw>
+```
+
+It clears the whole screen and repaints it from home with absolute addressing.
+Latency from the ioctl to the first byte, four trials: **0.1–0.3 ms**. zsh's
+redisplay, same harness: **7–23 ms**.
+
+Two consequences. The rewrap gate in §3 stands — a program that answers SIGWINCH
+this way cannot be broken by a rewrap it immediately paints over. And any frame
+of the rewrapped screen that a viewer sees is one *we* put there: the child had
+already replaced it.
+
+### 12.2 Closed: the keyframe could describe a screen the child had replaced
+
+`apply_size_policy` resized the PTY, told the sidecar to reflow, and asked for
+the snapshot in the same handler — deliberately, and the comment said so: *"these
+requests are adjacent to the Resize command in the sidecar FIFO, with no
+intervening Write command."* Adjacent to the resize means **before** the child's
+answer to it. The keyframe every attachment repaints from was therefore the
+rewrapped screen, by construction, and the child's redraw arrived behind it as
+ordinary data.
+
+That is a full-screen paint of a screen that is already wrong, shipped on every
+resize. Whether a viewer *sees* it is a race it should never have been running:
+with Claude Code answering in 0.3 ms the redraw usually reaches the sidecar in
+time to be in the capture anyway — an end-to-end recording of a real 82→66 resize
+shows a clean keyframe on the pre-fix daemon — but nothing made that true, and a
+slower child, or a busier actor, loses it.
+
+Fixed: the resize opens its barrier immediately (so nothing reaches a client
+ahead of the grid that describes it) and the **capture waits for the child**.
+The child answering its SIGWINCH is the event the capture is actually for, so
+the first byte it writes pulls the deadline in to 5 ms — enough to catch a
+redraw split across two writes, never enough to be felt. The 40 ms is only the
+cap, for a child that never answers; it then gets exactly the old screen, so the
+window costs no correctness.
+
+Waiting on a clock instead of on the child is not free, and a test says so.
+`E resized` is deferred behind the open barrier, so a fixed settle delays *every*
+viewer's notion of the session's size by that much:
+`TermiodSizePolicyIntegrationTests.testTheSessionIsTheScreenBeingUsed` fails on a
+flat 40 ms settle and passes on the answer-driven one. Any future change here
+must keep that test honest rather than widen its tolerance.
+
+Pinned by `session::tests::a_resize_keyframe_carries_the_child_s_redraw`, which
+fails without the deferral with the keyframe painting `STALE` — the screen the
+child had already replaced — and asserts the deadline moves in when the child
+answers.
+
+### 12.3 Fixed: a hold that gave up painted the keyframe anyway
+
+`TerminalKeyframeHold` waits for the surface to reach the keyframe's grid, with
+a 250 ms deadline and a 1 MiB flood cap so it stays a hold and not a stall. Both
+of those endings **painted the keyframe anyway** — a screen drawn for one grid,
+written into a surface laid out at another, which wraps every row somewhere the
+daemon never put it. A guaranteed scrambled full-screen frame, followed by the
+surface's own reflow of it, followed by the resync that replaced it a round trip
+later. A drag is exactly the condition for missing that deadline: the deadline is
+main-thread layout, and a drag is a busy main thread.
+
+Both endings now **drop** the keyframe (`TerminalKeyframeHold.abandon`) and arm
+the repaint instead. The live bytes queued behind it still go out — they are the
+child's, and this is not the layer that may discard them — and the last screen
+that was painted correctly stays up until the resync lands. Teardown is the one
+ending that still paints, and for the reason it always did: a surface that is
+going away has no resync coming, so an imperfectly wrapped final frame beats a
+blank one.
+
+`resize-trace … keyframe-held-out` (deadline) and `keyframe-flooded-out` (cap)
+name the two in the client log. Pinned by
+`TerminalKeyframeHoldTests.testGivingUpDropsTheKeyframeAndKeepsWhatWasQueuedBehindIt`
+and `…testAFloodBehindAHeldKeyframeEndsTheWaitWithoutPaintingIt`.
+
+### 12.4 Reported after §12.2/§12.3: inward is clean, outward is not
+
+*"往内拖拽没有问题 往外拖拽还是有问题"*. Two things are worth separating.
+
+**A hole §12.3 opened, now closed.** Dropping the keyframe instead of painting it
+leaves the pane on its last correct screen and arms `repaintPending`, and the
+arming waited for the surface to report the *exact* grid the session moved to.
+Nothing guarantees it ever does: a pane that fills itself is measured in points
+by `TerminalGrid.fitting` and floored in pixels by libghostty, and the two can
+disagree by a column. The old code hid this — it painted something wrong, and
+wrong-but-fresh is invisible next to stale. A backstop now asks for the repaint
+500 ms later whatever grid the surface settled at, and a keyframe answering a
+repaint *we asked for* is no longer put through the hold (`paintNextKeyframe`):
+holding it would wait on the grid that already failed, give up the same way, and
+ask again. Pinned by
+`TerminalKeyframeHoldTests.testAKeyframeAnsweringARepaintWeAskedForIsNotHeld`.
+
+**The direction itself is asymmetric by construction, and that is unexamined.**
+`SharedGridLetterbox` lays the surface out at the *session's* grid for the whole
+drag, anchored top-left:
+
+- dragging **inward**, the surface is larger than the pane and clipped — the
+  content still reaches every edge of the window, and only the far right and
+  bottom are cut, which for a TUI is padding;
+- dragging **outward**, the surface is smaller than the pane — the terminal sits
+  in the top-left corner of a window that keeps growing around it, for the whole
+  drag plus the 150 ms debounce, and then snaps out.
+
+That is what the reporter's screenshot shows: content occupying the left portion
+of a wide pane. Whether *that* is the complaint, or whether something is also
+wrong with the content itself, is the open question — and it is the same question
+§8.1 has been asking for since this file was opened. It needs one screenshot
+taken **mid-outward-drag**, before the mouse is released.
+
+If the pin is the complaint, the fix is a real design decision and must be argued
+against §4 and §5 rather than tried: §5 removed `viewportPending` precisely so the
+surface would stay pinned for the whole drag, and §4 rejected mid-drag barriers
+because each shipped a rewrapped screen. §12.2 changes the second half of that
+argument — a mid-drag barrier now carries the child's own redraw, not a rewrap —
+so the cost §4 measured is no longer the cost. Growing is also the direction that
+cannot split a row: a wider surface re-joins, it never re-wraps into a width
+nothing was drawn at, which is the objection §5 pinned the surface for. Neither
+observation is permission to change it blind.
+
+### 12.5 What is still unproven
+
+Neither fix has been *watched*. The photograph was never reproduced under a
+trace: the app was showing only its settings window by the time the daemon fix
+was live, and driving a real drag by AppleScript needs the main window up. What
+would settle it is one drag with
+
+```sh
+log stream --predicate 'subsystem == "sh.termio.app.dev"' --debug --style compact \
+  | grep resize-trace
+```
+
+running. `keyframe-held-out` in that trace says §12.3 was the frame in the
+photograph; its absence says the remaining suspect is elsewhere and this file is
+not finished.
+
+One operational trap found while measuring, worth its own line: **the daemon does
+not restart when the app is rebuilt.** The dev daemon on the reporter's machine
+was running a binary built hours earlier from a worktree that no longer exists,
+so every Swift-side rebuild that afternoon was talking to old host code.
+`termiod handoff` replaces it in place, keeping the PTYs.
+

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -402,6 +402,15 @@ struct Session {
     /// `info()` reads this cache so a roster request never turns into a burst
     /// of syscalls.
     foreground: Foreground,
+    /// A resize's barrier, opened but not yet captured. See
+    /// `begin_resize_snapshot_barrier`.
+    resize_capture: Option<ResizeCapture>,
+}
+
+/// The snapshot a resize opened a barrier for, waiting on the child's redraw.
+struct ResizeCapture {
+    at: tokio::time::Instant,
+    requests: Vec<(ClientId, u64)>,
 }
 
 impl Session {
@@ -525,6 +534,17 @@ impl Session {
     /// silently would leave `S` describing a screen that never occurred, and
     /// blocking here would put the VT parse back on the fan-out path.
     fn write_sidecar(&mut self, chunk: Bytes) {
+        // The child answering its SIGWINCH is the event a resize's capture is
+        // actually waiting for; the deadline is only there for a child that
+        // never answers. Pulling the capture in the moment it does keeps the
+        // wait off the common path — a TUI writes within a millisecond of the
+        // ioctl — so `E resized` is not held up behind a clock every viewer of
+        // this session would feel.
+        if let Some(capture) = self.resize_capture.as_mut() {
+            capture.at = capture
+                .at
+                .min(tokio::time::Instant::now() + Self::RESIZE_ANSWER_QUIESCE);
+        }
         if !self.vt.is_live() {
             return;
         }
@@ -662,7 +682,68 @@ impl Session {
         self.send_sidecar(SidecarCommand::SetGridDiff(self.wants_grid_diffs()));
     }
 
-    fn begin_snapshot_barrier(&mut self) {
+    /// How long a resize's keyframe waits for the child's own redraw.
+    ///
+    /// The capture used to be adjacent to the sidecar's `Resize`, which by
+    /// construction snapshotted the screen the terminal had just rewrapped and
+    /// the child had not yet answered — so every resize shipped every
+    /// attachment a full-screen paint of a screen that was about to be thrown
+    /// away, and that frame is what a drag looked like. A program that answers
+    /// SIGWINCH lands its redraw well inside this window: measured from a real
+    /// PTY, Claude Code writes its `ESC[2J` repaint 0.3ms after the ioctl and
+    /// zsh redisplays within 23ms. A child that takes longer, or writes
+    /// nothing, gets exactly the old behaviour — the rewrapped screen — so this
+    /// window trades no correctness for the common case.
+    const RESIZE_SNAPSHOT_SETTLE: std::time::Duration = std::time::Duration::from_millis(40);
+
+    /// How long the capture waits after the child's *first* byte in answer to
+    /// the resize, so a redraw split across two writes is captured whole rather
+    /// than half-drawn. Only ever pulls the deadline in, never pushes it out, so
+    /// a program that keeps writing cannot hold the barrier open.
+    const RESIZE_ANSWER_QUIESCE: std::time::Duration = std::time::Duration::from_millis(5);
+
+    /// A resize's barrier: opened now so nothing reaches a client ahead of the
+    /// screen that describes the new grid, captured once the child has had time
+    /// to redraw into it.
+    fn begin_resize_snapshot_barrier(&mut self) {
+        let requests = self.open_snapshot_barrier();
+        self.resize_capture = Some(ResizeCapture {
+            at: tokio::time::Instant::now() + Self::RESIZE_SNAPSHOT_SETTLE,
+            requests,
+        });
+    }
+
+    /// When the resize barrier opened above should be captured, if one is.
+    /// Read by the actor loop, which owns the timer.
+    fn resize_capture_deadline(&self) -> Option<tokio::time::Instant> {
+        self.resize_capture.as_ref().map(|capture| capture.at)
+    }
+
+    /// Captures what the last resize opened a barrier for.
+    ///
+    /// Each request is checked against the attachment's current barrier: one
+    /// superseded in the meantime — a second resize, an attach, a resync — is
+    /// already being captured by whoever superseded it, and asking again would
+    /// spend a capture on a request `finish_snapshot` would discard as stale.
+    fn capture_resize_snapshots(&mut self) {
+        let Some(capture) = self.resize_capture.take() else {
+            return;
+        };
+        for (client_id, request_id) in capture.requests {
+            let still_waiting = self
+                .clients
+                .get(&client_id)
+                .is_some_and(|entry| entry.plane.pending_request() == Some(request_id));
+            if still_waiting {
+                self.request_snapshot(client_id, request_id, false);
+            }
+        }
+    }
+
+    /// Opens every snapshot attachment's barrier and answers what each is now
+    /// waiting on. Data and events queue behind it from here; who asks for the
+    /// capture, and when, is the caller's.
+    fn open_snapshot_barrier(&mut self) -> Vec<(ClientId, u64)> {
         let snapshot_clients: Vec<ClientId> = self
             .clients
             .iter()
@@ -688,12 +769,7 @@ impl Session {
             requests.push((client_id, request_id));
         }
 
-        // The session actor cannot read the PTY while this handler runs, so
-        // these requests are adjacent to the Resize command in the sidecar
-        // FIFO, with no intervening Write command.
-        for (client_id, request_id) in requests {
-            self.request_snapshot(client_id, request_id, false);
-        }
+        requests
     }
 
     /// D4(a): a client that outruns its backlog gets one forced resync before it
@@ -1056,7 +1132,7 @@ impl Session {
         self.ring_reconstructs_screen = false;
         let reflow = !self.foreground_is_a_shell();
         self.send_sidecar(SidecarCommand::Resize { rows, cols, reflow });
-        self.begin_snapshot_barrier();
+        self.begin_resize_snapshot_barrier();
         self.emit_event(Event::Resized {
             session: self.id.to_string(),
             rows,
@@ -1662,6 +1738,7 @@ fn start(
         ),
         transcript_path: None,
         foreground: Foreground::default(),
+        resize_capture: None,
     };
     // A carried or created session arrives with a status this actor did not
     // derive; the engine adopts it so the roster and the engine never disagree
@@ -2015,7 +2092,18 @@ async fn run(
     let (stall_tx, mut stall_rx) = mpsc::unbounded_channel::<StallResult>();
 
     loop {
+        // Read before the select rather than inside a branch: the timer wants
+        // an owned deadline, and every other branch takes `&mut session`.
+        let resize_capture_at = session.resize_capture_deadline();
         tokio::select! {
+            // A resize opened a snapshot barrier and left the capture to this
+            // timer, so the keyframe carries the child's answer to SIGWINCH
+            // rather than the screen the rewrap left behind.
+            _ = tokio::time::sleep_until(
+                resize_capture_at.unwrap_or_else(tokio::time::Instant::now)
+            ), if resize_capture_at.is_some() => {
+                session.capture_resize_snapshots();
+            }
             _ = foreground_poll.tick() => {
                 if session.foreground.poll(&session.pty, session.pid, &foreground_tx) {
                     session.refresh_status_facts();
@@ -2717,6 +2805,7 @@ mod tests {
                 ),
                 transcript_path: None,
                 foreground: super::Foreground::default(),
+                resize_capture: None,
             },
             event_rx,
         )
@@ -3308,6 +3397,88 @@ mod tests {
         let _ = tokio::task::spawn_blocking(move || thread.join()).await;
     }
 
+    /// A resize's keyframe has to describe the screen the *child* redrew.
+    ///
+    /// The capture used to be adjacent to the sidecar's `Resize`, which by
+    /// construction snapshotted the screen the rewrap had just produced and the
+    /// child had not yet answered — so every resize handed every attachment a
+    /// full-screen paint of a screen that was about to be replaced, and that
+    /// frame is what a window drag looked like. The barrier still opens with
+    /// the resize, so nothing reaches a client ahead of the new grid; only the
+    /// capture waits.
+    #[tokio::test]
+    async fn a_resize_keyframe_carries_the_child_s_redraw() {
+        let Sidecar {
+            commands,
+            mut results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+        let (mut client, _backlog) = attach_snapshot_client(&mut session, "viewer");
+        pump_sidecar(&mut session, &mut results, 1).await;
+        assert_eq!(
+            drain(&mut client),
+            vec![Received::Snapshot, Received::Ready],
+            "the attach bootstrap never landed, so this test proves nothing"
+        );
+
+        // The screen as the child last drew it, before anything moved. Through
+        // `write_sidecar`, which is the path a live PTY byte takes.
+        session.write_sidecar(Bytes::from_static(b"STALE"));
+
+        session.begin_resize_snapshot_barrier();
+        let armed = session
+            .resize_capture_deadline()
+            .expect("the resize armed no capture");
+        assert!(
+            session.clients[&ClientId::new("viewer")].plane.is_pending(),
+            "the barrier must open with the resize, not with its capture"
+        );
+        assert!(
+            session.resize_capture_deadline().is_some(),
+            "the capture was asked for adjacent to the resize again"
+        );
+        assert!(
+            drain(&mut client).is_empty(),
+            "a screen reached the client before the boundary that describes it"
+        );
+
+        // What the child writes when it answers SIGWINCH. It reaches the VT
+        // ahead of the capture, which is the whole point.
+        session.write_sidecar(Bytes::from_static(b"\x1b[2J\x1b[HREDRAWN"));
+        assert!(
+            session
+                .resize_capture_deadline()
+                .expect("the capture was given up on")
+                < armed,
+            "the child answered and the capture still waited out its deadline — \
+             every viewer's `E resized` pays for that wait"
+        );
+
+        session.capture_resize_snapshots();
+        pump_sidecar(&mut session, &mut results, 1).await;
+
+        let mut painted = Vec::new();
+        while let Ok(event) = client.try_recv() {
+            if let ClientEvent::Snapshot(snapshot) = event {
+                painted = snapshot.vt.clone().unwrap_or_default();
+            }
+        }
+        let painted = String::from_utf8_lossy(&painted).to_string();
+        assert!(
+            painted.contains("REDRAWN"),
+            "the keyframe missed the redraw the child answered the resize with: {painted:?}"
+        );
+        assert!(
+            !painted.contains("STALE"),
+            "the keyframe painted the screen the child had already replaced: {painted:?}"
+        );
+
+        session.vt.shut_down();
+        let _ = tokio::task::spawn_blocking(move || thread.join()).await;
+    }
+
     /// A resync a client asks for has to actually repaint it.
     ///
     /// `finish_snapshot` matches every capture against the request the
@@ -3581,6 +3752,7 @@ mod tests {
             ),
             transcript_path: None,
             foreground: super::Foreground::default(),
+            resize_capture: None,
         };
 
         assert!(handle_msg(


### PR DESCRIPTION
Dragging a window outward left the terminal in the top-left corner of a pane growing around it, with a widening band of background beside it, until the debounced viewport declaration was answered and it snapped out. Dragging inward looked clean, because the same pin makes the surface larger than the pane and it is clipped — the content still reaches every edge.

Three things were wrong, found in that order.

**The resize keyframe described a screen the child had already replaced.** The snapshot was requested adjacent to the sidecar's `Resize`, so it captured the screen the terminal had just rewrapped and the child had not yet answered. Every resize shipped every attachment a full-screen paint of a screen about to be thrown away. The barrier still opens with the resize; the capture now waits for the child's first byte (+5 ms), with 40 ms as the cap for a child that never answers. Waiting on a flat clock instead is not free — `E resized` is deferred behind the open barrier, so a fixed settle delays every viewer's notion of the session's size, and `testTheSessionIsTheScreenBeingUsed` fails on a 40 ms one.

**A given-up keyframe was painted anyway.** The hold's deadline and its flood cap both painted a screen drawn for one grid into a surface laid out at another, which wraps every row somewhere the daemon never put it. Both endings now drop it and ask for the repaint, leaving the last correct screen up. Teardown still paints, having no repair coming.

**The surface was pinned for the whole drag.** That rule exists so a surface never re-wraps a screen at a width nothing was drawn for — which is the shrinking direction. Growing only rejoins rows, so a viewport that *contains* the session's grid may lead it, until the daemon adopts the viewport, the direction stops being growth, or 600 ms passes. The lead is raised only by this pane's own geometry changing, so a phone that takes the size can never unletterbox this window.

The reporter's screenshot is decoded to the column in `docs/bug/window-drag-resize-artifacts-HANDOFF.md` §12, along with what a child actually does with a SIGWINCH (Claude Code answers in 0.3 ms with a full `ESC[2J` repaint; zsh redisplays within 23 ms), both measured from a real PTY.

Tests: 993 Swift (daemon integration suites included, via `TERMIO_TERMIOD_TEST_BIN`), 304 Rust plus every integration suite. `a_resize_keyframe_carries_the_child_s_redraw` fails without the daemon change, painting the stale screen.

Release Notes:
- Dragging a window outward now grows the terminal with it instead of leaving it in the corner until the drag ends.
- A resize no longer flashes a scrambled screen before the program redraws.