### PR TITLE
Stop the watch ordering test racing its own probe

### DIFF
--- a/Tests/termioTests/TermiodWatchOrderingTests.swift
+++ b/Tests/termioTests/TermiodWatchOrderingTests.swift
@@ -57,6 +57,12 @@ final class TermiodWatchOrderingTests: XCTestCase {
 
         var watch: Termiod.ResourceWatch?
         let watching = WatchedRootReader()
+        // The watch starts delivering on its own queue the moment the
+        // initializer returns, but the probe can only be aimed at the watch
+        // after that — so the handover holds here until it is, or the probe
+        // reads nil out of its own arming race rather than out of the defect
+        // this test exists for.
+        let probeArmed = DispatchSemaphore(value: 0)
         watch = Termiod.ResourceWatch(
             route: .local,
             caps: ["files", Termiod.ResourceWatch.capability],
@@ -75,11 +81,13 @@ final class TermiodWatchOrderingTests: XCTestCase {
             case .reset:
                 seen.append(.reset)
             case .batch(let payload):
+                probeArmed.wait()
                 seen.append(.batch(payload.seq, watching: watching.read()))
             }
             if seen.value.count == 2 { settled.fulfill() }
         }
         watching.source = { [weak watch] in watch?.watchedRoot }
+        probeArmed.signal()
 
         wait(for: [settled], timeout: 5)
         XCTAssertEqual(


### PR DESCRIPTION
The macOS check on main (run 33658710069) failed on
\`TermiodWatchOrderingTests.testABatchArrivingAheadOfTheAckIsHeldUntilTheSubscriptionIsInstalled\`:
the batch was recorded with \`watching: nil\`.

The product ordering held — \`connect()\` installs the subscription before
releasing held batches. What raced was the test's own probe: \`watching.source\`
is aimed at the watch only after the initializer returns, while the watch
delivers on its own queue immediately. On a slow runner the handover can beat
that assignment, and the probe reads nil out of its arming race instead of the
defect the test exists for.

The handover now holds on a semaphore until the probe is armed. The update
closure runs on the watch's queue, not the test thread, so blocking it there
costs nothing. Verified with 15 consecutive runs.

Release Notes:
- No user-facing changes.