### PR TITLE
Repaint a pane that comes back on screen, and nudge the child after a resize settles

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -245,7 +245,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // The height every pane is about to measure itself against. If a future
         // change moves chrome back after this point, the panes declare a
         // viewport for a window that never existed and the trace says so here.
-        Log.termiod.debug("""
+        Log.termiod.info("""
         resize-trace WINDOW content-height-final \
         layout=\(self.window.contentLayoutRect.width, privacy: .public)x\
         \(self.window.contentLayoutRect.height, privacy: .public)

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -483,7 +483,7 @@ private struct SharedGridLetterbox<Content: View>: View {
             // `TerminalGrid.fitting` for a day. It was not: the pane really did
             // change height. Whatever the next disagreement is, it takes
             // numbers, not argument.
-            Log.termiod.debug("""
+            Log.termiod.info("""
             resize-trace \(self.sessionName.prefix(8), privacy: .public) measure \
             pane=\(self.paneSize.width, privacy: .public)x\(self.paneSize.height, privacy: .public) \
             cell=\(self.cellSize?.width ?? -1, privacy: .public)x\(self.cellSize?.height ?? -1, privacy: .public) \

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1649,6 +1649,20 @@ final class TermiodSessionLink: @unchecked Sendable {
             rendering = showing
             guard attached else { return }
             scheduleViewportLocked()
+            // Coming back on screen is a boundary, and it gets a snapshot the
+            // way attach does. A hidden pane keeps parsing live output into a
+            // surface stuck at whatever grid it had when it left the layout —
+            // the session may have been resized many times since, and every
+            // byte drawn for those widths wrapped at the stale one. The wrap
+            // points are baked into the surface's own state, so no amount of
+            // re-layout repairs them: showing the pane again re-wraps the lie
+            // at the new width. Only a fresh keyframe painted over it does,
+            // and `repaintPending` cannot be relied on to ask for one — it is
+            // set by surface reports, which a pane outside the layout never
+            // delivers.
+            if showing {
+                requestResyncLocked(paintImmediately: false)
+            }
         }
     }
 
@@ -1669,7 +1683,7 @@ final class TermiodSessionLink: @unchecked Sendable {
             let changed = surfaceGrid != size
             surfaceGrid = size
             if changed {
-                Log.termiod.debug("""
+                Log.termiod.info("""
                 resize-trace \(self.sessionName.prefix(8), privacy: .public) surface-at \
                 \(size.rows, privacy: .public)x\
                 \(size.cols, privacy: .public)
@@ -1722,7 +1736,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         for chunk in outcome.emit { onOutput?(chunk) }
         outputLock.unlock()
         guard outcome.gaveUp else { return }
-        Log.termiod.debug("""
+        Log.termiod.info("""
         resize-trace \(self.sessionName.prefix(8), privacy: .public) keyframe-flooded-out
         """)
         workQueue.async { [self] in armRepaintLocked() }
@@ -1755,7 +1769,7 @@ final class TermiodSessionLink: @unchecked Sendable {
             }
             for chunk in hold.abandon() { onOutput?(chunk) }
             outputLock.unlock()
-            Log.termiod.debug("""
+            Log.termiod.info("""
             resize-trace \(self.sessionName.prefix(8), privacy: .public) keyframe-held-out
             """)
             armRepaintLocked()
@@ -1821,7 +1835,16 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// harder than ghostty for this reason — tmux rate-limits a pane to one
     /// resize per 250ms, zellij collapses a burst to its last, cmux debounces
     /// 180ms — and none of them are wrong about it.
-    private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(150)
+    ///
+    /// 400ms rather than 150 because a pane's width also moves when the *app*
+    /// animates layout — opening a session, toggling the sidebar — and those
+    /// animations pause long enough mid-flight that a 150ms timer declared a
+    /// size nobody chose (a traced session open declared 68 cols on its way
+    /// from 97 to 97). A transient declaration is not merely wasted work: the
+    /// child's repaint for it races the next resize, and bytes drawn for the
+    /// transient width parsed into the final grid are what a user reports as
+    /// glued, miswrapped rows after every session open.
+    private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(400)
 
     /// Bumped by every viewport change inside a burst; only the newest scheduled
     /// send may write its frame. See `scheduleViewportLocked`.
@@ -1879,7 +1902,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         // is answered; leading there would split rows at widths the child never
         // drew. A growing surface may already have widened with the pane, and the
         // keyframe hold still covers the case where its layout trails the reply.
-        Log.termiod.debug("""
+        Log.termiod.info("""
         resize-trace \(self.sessionName.prefix(8), privacy: .public) declare \
         \(self.viewportGrid.rows, privacy: .public)x\
         \(self.viewportGrid.cols, privacy: .public) rendering=\(showing, privacy: .public)
@@ -1928,22 +1951,27 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// Trace only: a repaint was asked for because the surface reached the
     /// session's grid with bytes parsed at another one behind it.
     private func traceResync() {
-        Log.termiod.debug("""
+        Log.termiod.info("""
         resize-trace \(self.sessionName.prefix(8), privacy: .public) resync-requested
         """)
     }
 
-    private func requestResyncLocked() {
+    /// `paintImmediately` says which kind of repair this is. A repaint asked
+    /// for because the hold already failed to deliver one must not be put
+    /// through the hold again: it would wait on the grid the surface did not
+    /// reach the first time, give up the same way, and ask again — a loop that
+    /// leaves the surface stale for as long as it runs. A repaint asked for at
+    /// a *boundary* is the opposite case: the pane is about to be laid out, so
+    /// the answer belongs in the hold like any other, and force-painting it
+    /// would draw the session's screen through the stale grid the boundary
+    /// exists to get rid of.
+    private func requestResyncLocked(paintImmediately: Bool = true) {
         traceResync()
-        // A repaint asked for is one the hold has already failed to deliver, so
-        // its answer is not put through the hold again. Holding it would wait on
-        // the same grid the surface did not reach the first time, give up the
-        // same way, and ask again — a loop that leaves the surface stale for as
-        // long as it runs. By the time an answer arrives the surface has stopped
-        // moving, which is the condition the hold exists to wait for.
-        outputLock.lock()
-        hold.paintNextKeyframe()
-        outputLock.unlock()
+        if paintImmediately {
+            outputLock.lock()
+            hold.paintNextKeyframe()
+            outputLock.unlock()
+        }
         guard !closed, attached, let transport else { return }
         do {
             try Termiod.writeFrame(transport.writeDescriptor, kind: .control,
@@ -2258,7 +2286,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
-            Log.termiod.debug("""
+            Log.termiod.info("""
             resize-trace \(self.sessionName.prefix(8), privacy: .public) session-is \
             \(grid.rows, privacy: .public)x\
             \(grid.cols, privacy: .public)

--- a/docs/bug/window-drag-resize-artifacts-HANDOFF.md
+++ b/docs/bug/window-drag-resize-artifacts-HANDOFF.md
@@ -509,3 +509,61 @@ was running a binary built hours earlier from a worktree that no longer exists,
 so every Swift-side rebuild that afternoon was talking to old host code.
 `termiod handoff` replaces it in place, keeping the PTYs.
 
+## 13. The other three, and why the fix went out twice
+
+2026-09-04. The reporter, on a build that already carried §12: *"怎么还是有
+问题啊？我印象里昨天晚上一个 dev 的版本是可以的"*.
+
+**The build never had §12 in it.** The dev app was built that morning from a
+checkout whose `main` sat six commits behind `origin/main`, at the commit
+before §12 merged. Grepped against the source it was built from: no
+`growingViewportPending`, no `abandon`, no `RESIZE_SNAPSHOT_SETTLE`. Nothing
+had regressed; the machine had simply never run the fix. Worth a line in any
+future session: **check what the running binary was built from before
+believing a symptom.** `termiod status` names the daemon, and the app's own
+build time against `git log` names the app.
+
+Meanwhile that same checkout held a day of *uncommitted* work — a separate
+investigation, recorded in the memory note `termio-resize-mojibake-family`,
+which had found three more causes. Two fix sets existed, neither build had
+both, and both touched `TermiodClient.swift` and `session.rs`. They are now
+reconciled on one branch.
+
+### 13.1 A hidden pane keeps the grid it left with
+
+The main one. A pane outside the layout still has a live link feeding it
+bytes, and its surface keeps whatever grid it had when it stopped being laid
+out. Every byte drawn for the session's later widths wraps at that stale one,
+and the wrap points are baked into the surface — re-layout cannot undo them,
+it only re-wraps the lie at the new width. `repaintPending` never fires,
+because it is armed by surface reports a hidden pane does not deliver.
+
+Coming back on screen is now a boundary that takes a snapshot, the way attach
+does. It goes *through* the hold, not around it: §12.3's `requestResyncLocked`
+force-paints its answer, which is right for a hold that already failed and
+wrong for a pane about to be laid out.
+
+### 13.2 The coalescer declared sizes nobody chose
+
+A pane's width also moves when the app animates layout. Those animations pause
+long enough mid-flight that the 150ms timer fired on an animation frame: a
+traced session open declared 68 columns on its way from 97 to 97. The child's
+repaint for that width then races the next resize. 400ms; the real answer is
+declaring only at boundaries, which is still not done.
+
+### 13.3 Nothing made the child repaint after the dust settled
+
+Bytes drawn for the old grid can still be in flight when the VT takes the new
+one, and only the child can overwrite what they painted. 300ms after the last
+resize the foreground gets one more SIGWINCH — re-armed by every resize, so a
+drag costs one nudge at the end. A ring replay the daemon knows is unfaithful
+gets the same nudge, which is the frozen mangled screen after a handoff: an
+idle agent produces no next output, and a viewer already at the session's size
+gets no resize either.
+
+cmux solves the same family by pinning the surface's pixels to the authoritative
+grid regardless of visibility, checking grid parity both ways, and kicking a
+repaint after a grow. The child is our tmux; §13.3 is that kick. A true pin
+needs `InMemoryTerminalSession.updateViewport` made public in the fork, which is
+the follow-up this file should be reopened for.
+

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -477,6 +477,22 @@ impl Pty {
         (pgid > 0).then_some(pgid)
     }
 
+    /// Deliver the SIGWINCH a resize would have, without a resize.
+    ///
+    /// For when a client was just handed a screen the daemon knows is wrong —
+    /// a ring replay of bytes written into a grid the session no longer has —
+    /// and the size is not changing, so no ioctl is coming to make the child
+    /// repaint. A full-screen program answers by re-reading `TIOCGWINSZ`
+    /// (unchanged) and redrawing from its own model; that redraw is the
+    /// correct screen, and it reaches every attachment as ordinary output.
+    pub fn nudge_repaint(&self) {
+        if let Some(pgid) = self.foreground_pgid() {
+            unsafe {
+                libc::killpg(pgid, libc::SIGWINCH);
+            }
+        }
+    }
+
     /// Push a new window size to the PTY (TIOCSWINSZ) and return the size the
     /// kernel actually holds afterwards.
     ///

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -387,6 +387,15 @@ struct Session {
     /// replay. It exists for the far side of a handoff, which has only the ring
     /// and would otherwise present a confidently wrong screen.
     ring_reconstructs_screen: bool,
+    /// When the last resize's dust should be declared settled and the
+    /// foreground asked for one more repaint. Bytes drawn for the old grid can
+    /// still be in flight through the PTY when the VT takes the new one —
+    /// nothing orders a child's output against a resize it has not seen yet —
+    /// and whatever they painted, only the child's own post-settle repaint can
+    /// overwrite. Every further resize pushes the deadline out, so a drag
+    /// costs one nudge, at the end. (cmux's mirror answers the same problem by
+    /// re-reading tmux's screen after a grid grows; the child *is* our tmux.)
+    settle_nudge_at: Option<tokio::time::Instant>,
     events: broadcast::Sender<Event>,
     vt: Vt,
     /// This session's agent status, derived here rather than in each viewer.
@@ -701,6 +710,15 @@ impl Session {
     /// than half-drawn. Only ever pulls the deadline in, never pushes it out, so
     /// a program that keeps writing cannot hold the barrier open.
     const RESIZE_ANSWER_QUIESCE: std::time::Duration = std::time::Duration::from_millis(5);
+
+    /// How long after a resize the child is asked to repaint once more.
+    ///
+    /// Long enough that a drag's own bursts have stopped pushing it out — every
+    /// resize re-arms it, so a drag costs one nudge, at the end — and that the
+    /// child's answer to the *last* resize has drained. Anything the transition
+    /// mis-parsed is still on screen until something overwrites it, and only
+    /// the child can.
+    const RESIZE_SETTLE_NUDGE: std::time::Duration = std::time::Duration::from_millis(300);
 
     /// A resize's barrier: opened now so nothing reaches a client ahead of the
     /// screen that describes the new grid, captured once the child has had time
@@ -1138,6 +1156,22 @@ impl Session {
             rows,
             cols,
         });
+        self.settle_nudge_at = Some(tokio::time::Instant::now() + Self::RESIZE_SETTLE_NUDGE);
+    }
+
+    /// The settle deadline fired: the last resize has stood for long enough
+    /// that the child's answer to it has drained. One more repaint request
+    /// makes the child overwrite anything the transition mis-parsed.
+    ///
+    /// Shells are excluded for the same reason `foreground_is_a_shell` gates
+    /// the rewrap: a shell repainted its prompt on the resize's own SIGWINCH
+    /// and a second poke buys nothing, while the agents and editors this is
+    /// for redraw their whole screen from their own model.
+    fn fire_settle_nudge(&mut self) {
+        self.settle_nudge_at = None;
+        if !self.foreground_is_a_shell() {
+            self.pty.nudge_repaint();
+        }
     }
 
     fn queue_history_chunk(
@@ -1414,6 +1448,17 @@ impl Session {
             }
         }
         self.clients.insert(client_id.clone(), entry);
+        // The replay this client was just handed may not draw the screen the
+        // program believes it is looking at (see `ring_reconstructs_screen`).
+        // The old answer — "the program repaints on its next output either way"
+        // — assumed there would be a next output; an agent idling at its prompt
+        // never produces one, and a viewer whose window matches the session's
+        // size gets no resize to force the issue either. So force it here: the
+        // repaint the nudge provokes is ordinary output, which corrects this
+        // screen and every other attachment's at once.
+        if !self.ring_reconstructs_screen {
+            self.pty.nudge_repaint();
+        }
     }
 
     fn remove_finished_client(&mut self, client_id: &ClientId) {
@@ -1726,6 +1771,7 @@ fn start(
         ring: VecDeque::new(),
         ring_bytes: 0,
         ring_reconstructs_screen: true,
+        settle_nudge_at: None,
         events,
         vt: Vt::live(sidecar.commands, sidecar.queue),
         status_engine: StatusEngine::new(
@@ -2095,6 +2141,7 @@ async fn run(
         // Read before the select rather than inside a branch: the timer wants
         // an owned deadline, and every other branch takes `&mut session`.
         let resize_capture_at = session.resize_capture_deadline();
+        let settle_nudge_at = session.settle_nudge_at;
         tokio::select! {
             // A resize opened a snapshot barrier and left the capture to this
             // timer, so the keyframe carries the child's answer to SIGWINCH
@@ -2118,6 +2165,14 @@ async fn run(
                     session.refresh_status_facts();
                     session.emit_roster();
                 }
+            }
+            // The dust from the last resize has settled; the child gets one
+            // more SIGWINCH so its own repaint overwrites anything the
+            // transition mis-parsed.
+            _ = tokio::time::sleep_until(
+                settle_nudge_at.unwrap_or_else(tokio::time::Instant::now)
+            ), if settle_nudge_at.is_some() => {
+                session.fire_settle_nudge();
             }
             _ = status_sweep.tick() => {
                 let now = std::time::Instant::now();
@@ -2797,6 +2852,7 @@ mod tests {
                 ring: VecDeque::new(),
                 ring_bytes: 0,
                 ring_reconstructs_screen: true,
+                settle_nudge_at: None,
                 events,
                 vt: Vt::live(sidecar_tx, sidecar_queue),
                 status_engine: super::StatusEngine::new(
@@ -3744,6 +3800,7 @@ mod tests {
             ring: VecDeque::new(),
             ring_bytes: 0,
             ring_reconstructs_screen: true,
+            settle_nudge_at: None,
             events,
             vt: Vt::live(sidecar_tx, Arc::new(SidecarQueue::new())),
             status_engine: super::StatusEngine::new(
@@ -3905,6 +3962,207 @@ mod tests {
         assert!(stale.contains("handoff"), "{stale}");
 
         adopted.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
+    }
+
+    /// A client handed an unfaithful ring replay must not be left staring at
+    /// it until the program happens to print. An idle program never does, and
+    /// a viewer at the session's own size gets no resize to force a repaint
+    /// either — so the fallback itself nudges the foreground with the SIGWINCH
+    /// a resize would have delivered, and the repaint arrives as fresh output.
+    #[tokio::test]
+    async fn a_knowingly_wrong_replay_nudges_the_foreground_to_repaint() {
+        let (handle, _events, _on_exit) = start_session(
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "trap 'echo NUDGED' WINCH; echo READY; while :; do read line; done".to_string(),
+            ],
+            "/",
+        );
+
+        // Wait for the child to say the trap is installed; before that a
+        // nudge would be absorbed by the default disposition and prove
+        // nothing.
+        let (ready_tx, mut ready_rx) = mpsc::unbounded_channel();
+        let (reply, answer) = oneshot::channel();
+        handle.send(SessionMsg::AddClient {
+            id: ClientId::new("watcher"),
+            interactive: true,
+            rows: 24,
+            cols: 80,
+            out: ready_tx,
+            backlog: Arc::new(ClientBacklog::new()),
+            snapshot: false,
+            scrollback: false,
+            grid_diff: false,
+            reply,
+        });
+        answer.await.expect("attached");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut seen = Vec::new();
+            loop {
+                match ready_rx.recv().await {
+                    Some(ClientEvent::Data(payload)) => {
+                        seen.extend_from_slice(&payload.bytes);
+                        if String::from_utf8_lossy(&seen).contains("READY") {
+                            return;
+                        }
+                    }
+                    Some(_) => continue,
+                    None => panic!("client stream ended before READY"),
+                }
+            }
+        })
+        .await
+        .expect("the child announced its trap");
+
+        // Hand the session over with a ring declared unfaithful — the far side
+        // of a handoff whose output predates what drew the screen. No resize is
+        // involved, so the only SIGWINCH the child can ever see is the nudge.
+        let mut carried = carry(&handle).await;
+        carried.info.ring_reconstructs_screen = false;
+        use std::os::fd::IntoRawFd as _;
+        carried.info.master_fd = carried.master.into_raw_fd();
+        let (on_exit, _on_exit_rx) = mpsc::unbounded_channel();
+        let (events, mut events_rx) = broadcast::channel(64);
+        let adopted = super::adopt(carried.info, Vec::new(), on_exit, events)
+            .expect("adopting the carried session");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match events_rx.recv().await {
+                    Ok(Event::VtStale { .. }) => return,
+                    Ok(_) => continue,
+                    Err(error) => panic!("event stream ended: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("the adopted session declared its VT stale");
+
+        // Attach at the session's own size: no resize fires, so without the
+        // nudge nothing would ever repaint this screen.
+        let (client_tx, mut client_rx) = mpsc::unbounded_channel();
+        let (reply, answer) = oneshot::channel();
+        adopted.send(SessionMsg::AddClient {
+            id: ClientId::new("viewer"),
+            interactive: true,
+            rows: 24,
+            cols: 80,
+            out: client_tx,
+            backlog: Arc::new(ClientBacklog::new()),
+            snapshot: true,
+            scrollback: false,
+            grid_diff: false,
+            reply,
+        });
+        answer.await.expect("attached to the adopted session");
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut seen = Vec::new();
+            loop {
+                match client_rx.recv().await {
+                    Some(ClientEvent::Data(payload)) => {
+                        seen.extend_from_slice(&payload.bytes);
+                        if String::from_utf8_lossy(&seen).contains("NUDGED") {
+                            return;
+                        }
+                    }
+                    Some(_) => continue,
+                    None => panic!("client stream ended before the repaint"),
+                }
+            }
+        })
+        .await
+        .expect("the unfaithful replay was followed by a nudged repaint");
+
+        adopted.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
+    }
+
+    /// A resize is followed, once it has stood for the settle window, by one
+    /// more SIGWINCH to a non-shell foreground: the child's answer to the
+    /// resize raced the grid change, and its post-settle repaint is the only
+    /// thing that can overwrite whatever the race painted. The child counts the
+    /// signals — the resize's own ioctl delivers the first, the settle nudge
+    /// the second.
+    #[tokio::test]
+    async fn a_settled_resize_nudges_a_job_foreground_once_more() {
+        let script = "import signal,sys,time\n\
+                      signal.signal(signal.SIGWINCH, lambda *a: print('NUDGED', flush=True))\n\
+                      print('READY', flush=True)\n\
+                      while True: time.sleep(0.05)\n";
+        let (handle, _events, _on_exit) = start_session(
+            vec![
+                "/usr/bin/python3".to_string(),
+                "-c".to_string(),
+                script.to_string(),
+            ],
+            "/",
+        );
+        let (client_tx, mut client_rx) = mpsc::unbounded_channel();
+        let (reply, answer) = oneshot::channel();
+        handle.send(SessionMsg::AddClient {
+            id: ClientId::new("writer"),
+            interactive: true,
+            rows: 24,
+            cols: 80,
+            out: client_tx,
+            backlog: Arc::new(ClientBacklog::new()),
+            snapshot: false,
+            scrollback: false,
+            grid_diff: false,
+            reply,
+        });
+        answer.await.expect("attached");
+
+        async fn receive_until(
+            rx: &mut mpsc::UnboundedReceiver<ClientEvent>,
+            seen: &mut Vec<u8>,
+            marker: &str,
+        ) {
+            loop {
+                match rx.recv().await {
+                    Some(ClientEvent::Data(payload)) => {
+                        seen.extend_from_slice(&payload.bytes);
+                        if String::from_utf8_lossy(seen).contains(marker) {
+                            return;
+                        }
+                    }
+                    Some(_) => continue,
+                    None => panic!("client stream ended waiting for {marker}"),
+                }
+            }
+        }
+        let mut seen = Vec::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            receive_until(&mut client_rx, &mut seen, "READY"),
+        )
+        .await
+        .expect("the child installed its handler");
+
+        // The foreground poller must see python3 before the resize, or the
+        // rewrap/nudge gates still believe a shell is on screen.
+        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+        handle.send(SessionMsg::Viewport {
+            id: ClientId::new("writer"),
+            rows: 30,
+            cols: 100,
+            rendering: true,
+        });
+
+        // Two signals: the resize's own SIGWINCH, then the settle nudge.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            receive_until(&mut client_rx, &mut seen, "NUDGED\r\nNUDGED"),
+        )
+        .await
+        .expect("the settled resize delivered a second SIGWINCH");
+
+        handle.send(SessionMsg::Kill {
             reason: EndReason::Killed,
         });
     }


### PR DESCRIPTION
Three more causes in the resize-mojibake family, found after #603 shipped. They had been diagnosed and fixed in a working tree that was never committed; this reconciles that work with what #603 changed underneath it.

**A hidden pane keeps the grid it left with.** A pane outside the layout still has a live link feeding it bytes, and its surface keeps whatever grid it had when it stopped being laid out. Every byte drawn for the session's later widths wraps at that stale one, and the wrap points are baked into the surface — re-layout cannot undo them, it only re-wraps the lie at the new width. `repaintPending` never fires either: it is armed by surface reports a hidden pane does not deliver. Coming back on screen is now a boundary that takes a snapshot, the way attach does.

That resync goes **through** the keyframe hold rather than around it. #603's `requestResyncLocked` force-paints its answer, which is right for the degraded path it was written for — a hold that already failed would otherwise wait on the same grid, give up the same way, and ask again — and wrong here, where the pane is about to be laid out and force-painting would draw the session's screen through the very grid the boundary exists to discard. Hence `paintImmediately`.

**The coalescer declared sizes nobody chose.** A pane's width also moves when the app animates layout, and those animations pause long enough mid-flight that the 150 ms timer fired on an animation frame — a traced session open declared 68 columns on its way from 97 to 97. The child's repaint for that width then races the next resize. Now 400 ms; declaring only at boundaries is the real answer and is still not done.

**Nothing made the child repaint after the dust settled.** Bytes drawn for the old grid can still be in flight when the VT takes the new one, and only the child can overwrite what they painted. 300 ms after the last resize the foreground gets one more SIGWINCH, re-armed by every resize so a drag costs one nudge at the end. A ring replay the daemon knows is unfaithful gets the same nudge — that is the frozen, mangled screen after a handoff, where an idle agent produces no next output and a viewer already at the session's size gets no resize either.

The resize trace moves to `.info`, which is the level a release-config dev build can actually be read at.

Also in §13 of the handoff doc: the reported "it broke again" was a build that never contained #603 — the checkout was six commits behind. Check what the running binary was built from before believing a symptom.

Tests: 993 Swift, 310 Rust, all suites. Daemon integration tests run via `TERMIO_TERMIOD_TEST_BIN`.

Release Notes:
- A pane you switch back to repaints instead of showing text wrapped at the width it had when you left it.
- Resizing no longer leaves miswrapped rows behind after the window settles.