### PR TITLE
Reflow shell resizes with injected OSC 133 prompt marks

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1,7 +1,46 @@
+import AppKit
 import CryptoKit
 import Darwin
 import Foundation
 import TermioShared
+
+/// Whether any of this app's windows is mid live-resize — the user dragging a
+/// window edge, as AppKit reports it. Consulted by every session link's
+/// viewport scheduling to pick between two cadences: a drag streams throttled
+/// intermediate sizes so the session reflows while the user watches (the way
+/// an in-process terminal does), while everything else keeps the trailing
+/// debounce that protects the daemon from sizes nobody chose — the app's own
+/// layout animations, which are not window live-resizes and never flip this.
+final class WindowLiveResizeTracker: @unchecked Sendable {
+    static let shared = WindowLiveResizeTracker()
+
+    private let lock = NSLock()
+    private var resizingWindows = 0
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return resizingWindows > 0
+    }
+
+    private init() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            forName: NSWindow.willStartLiveResizeNotification, object: nil, queue: nil
+        ) { [self] _ in
+            lock.lock()
+            resizingWindows += 1
+            lock.unlock()
+        }
+        center.addObserver(
+            forName: NSWindow.didEndLiveResizeNotification, object: nil, queue: nil
+        ) { [self] _ in
+            lock.lock()
+            resizingWindows = max(0, resizingWindows - 1)
+            lock.unlock()
+        }
+    }
+}
 
 /// Attach client for the local `termiod` session host (Session Protocol v0.1,
 /// see termiod/src/protocol.rs). The
@@ -1846,6 +1885,20 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// glued, miswrapped rows after every session open.
     private static let viewportCoalescingInterval = DispatchTimeInterval.milliseconds(400)
 
+    /// The cadence a window drag streams at instead. Every size under the
+    /// user's hand is one they chose, so the transient-width argument above
+    /// does not apply — what applies is Ghostty's behaviour, where the screen
+    /// reflows continuously while the edge moves. Per-frame is an in-process
+    /// luxury; over the daemon socket each declaration is a resize barrier
+    /// with a keyframe to every attached device, so the stream is throttled
+    /// to a handful per second, which reads as live.
+    private static let liveResizeStreamInterval = DispatchTimeInterval.milliseconds(150)
+    private static let liveResizeStreamNanoseconds = UInt64(150_000_000)
+
+    /// When the last viewport declaration actually went out, for the throttle's
+    /// leading edge. Must only be touched on `workQueue`.
+    private var lastViewportFlush = DispatchTime(uptimeNanoseconds: 0)
+
     /// Bumped by every viewport change inside a burst; only the newest scheduled
     /// send may write its frame. See `scheduleViewportLocked`.
     private var viewportGeneration: UInt64 = 0
@@ -1863,6 +1916,26 @@ final class TermiodSessionLink: @unchecked Sendable {
     private func scheduleViewportLocked() {
         viewportGeneration &+= 1
         let generation = viewportGeneration
+        // A window drag streams: send now if the throttle window has passed,
+        // otherwise at its end. Everything else debounces — the app's layout
+        // animations produce sizes nobody chose, and only quiet proves the
+        // pane has settled.
+        if WindowLiveResizeTracker.shared.isActive {
+            let now = DispatchTime.now()
+            let elapsed = now.uptimeNanoseconds - lastViewportFlush.uptimeNanoseconds
+            if elapsed >= Self.liveResizeStreamNanoseconds {
+                flushViewportLocked()
+                return
+            }
+            let remainder = Self.liveResizeStreamNanoseconds - elapsed
+            workQueue.asyncAfter(
+                deadline: .now() + .nanoseconds(Int(min(remainder, UInt64(Int.max))))
+            ) { [self] in
+                guard !closed, attached, generation == viewportGeneration else { return }
+                flushViewportLocked()
+            }
+            return
+        }
         workQueue.asyncAfter(deadline: .now() + Self.viewportCoalescingInterval) { [self] in
             guard !closed, attached, generation == viewportGeneration else { return }
             flushViewportLocked()
@@ -1871,6 +1944,7 @@ final class TermiodSessionLink: @unchecked Sendable {
 
     /// Must run on `workQueue`.
     private func flushViewportLocked() {
+        lastViewportFlush = DispatchTime.now()
         do {
             try sendViewportLocked()
         } catch {

--- a/skills/macos-rebuild-dev/SKILL.md
+++ b/skills/macos-rebuild-dev/SKILL.md
@@ -84,8 +84,34 @@ When invoked, execute these steps sequentially:
    echo "launched ./termio-dev.app (logs: /tmp/termio-dev.log)"
    ```
 
-5. **Report** the result: whether the build succeeded and the app relaunched, or
-   what went wrong. If the window doesn't appear, check `/tmp/termio-dev.log`.
+5. **Upgrade the running dev daemon.** `build-app.sh` already rebuilt the
+   daemon into `Resources/termiod`, but a **running** dev daemon keeps its old
+   image: a dev app's launch-time reconcile deliberately refuses to stage
+   (its bundle stamp is a placeholder, and that guard is what keeps a dev
+   build from ever deploying itself over a release daemon). Without this
+   step, a termiod-side change gets "verified" against the previous daemon.
+   The deploy is idempotent — same version reports `current` and does
+   nothing, so it costs nothing on Swift-only rebuilds — and an execve
+   handoff keeps the pid and carries every live session. `TERMIOD_SOCK` must
+   be unset first: a shell inside a termio session carries it pointed at the
+   *release* daemon, and it overrides the channel.
+   ```bash
+   unset TERMIOD_SOCK
+   TERMIO_CHANNEL=dev ./termio-dev.app/Contents/Resources/termiod deploy --json 2>&1 | tail -3
+   ```
+   A daemon that isn't running needs nothing: the first pane starts it from
+   the new bundle.
+
+6. **Report** the result: whether the build succeeded, the app relaunched, and
+   the daemon version the deploy reported. If the window doesn't appear, check
+   `/tmp/termio-dev.log`.
+
+## Verifying a termiod-side change
+
+Sessions carried across the handoff keep the environment and shell their
+**old** daemon spawned them with — a change to session spawning (env,
+injection, PTY setup) is invisible in them by design. Open a **new** session
+to see it.
 
 ## Icons
 

--- a/termiod/src/lib.rs
+++ b/termiod/src/lib.rs
@@ -39,6 +39,7 @@ pub mod remote;
 pub mod resource;
 pub mod service;
 pub mod session;
+pub mod shell_integration;
 pub mod tombstone;
 pub mod version;
 pub mod wss;

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -308,6 +308,17 @@ impl Pty {
             cmd.env("LANG", locale);
             cmd.env("LC_CTYPE", locale);
         }
+        // Route a zsh startup through the daemon's OSC 133 shim so the VT can
+        // reflow resizes under it (see `crate::shell_integration`). The user's
+        // own ZDOTDIR rides along and is restored by the shim before their
+        // configuration loads; a shell that is not zsh, or a shim that cannot
+        // be written, changes nothing.
+        if let Some(shim) = crate::shell_integration::zsh_shim_zdotdir(&program) {
+            if let Some(original) = lookup("ZDOTDIR") {
+                cmd.env("TERMIOD_ZSH_ZDOTDIR", original);
+            }
+            cmd.env("ZDOTDIR", shim);
+        }
         if login_shell {
             // argv[0] = "-<shell>" marks a login shell to the shell itself.
             let base = std::path::Path::new(&program)
@@ -612,6 +623,63 @@ mod tests {
         assert!(!dumped.contains("CLAUDE_CODE_CHILD_SESSION="));
         assert!(dumped.contains("TERM_PROGRAM=termio"));
         assert!(!dumped.contains("TERM_PROGRAM=Apple_Terminal"));
+    }
+
+    /// End to end through the real shell: a zsh spawned by the daemon emits
+    /// the OSC 133 prompt-start mark, because `spawn` routed its startup
+    /// through the shim (`crate::shell_integration`). Without the mark the VT
+    /// can never reflow a resize under the shell, so this is the assertion
+    /// that the whole injection chain — ZDOTDIR handoff, shim install, hook
+    /// registration — actually reaches the byte stream.
+    ///
+    /// Skipped where zsh is not installed; the shim itself is unit-tested in
+    /// `shell_integration`.
+    #[tokio::test]
+    async fn a_spawned_zsh_emits_prompt_marks() {
+        let Some(zsh) = ["/bin/zsh", "/usr/bin/zsh"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+        else {
+            return;
+        };
+
+        // A scratch HOME (and ZDOTDIR, exercising the shim's restore path)
+        // keeps the user's real zsh configuration out of the assertion.
+        let home = std::env::temp_dir().join(format!("termiod-zsh-marks-{}", std::process::id()));
+        std::fs::create_dir_all(&home).expect("scratch home");
+        let overrides = vec![
+            ("HOME".to_string(), home.display().to_string()),
+            ("ZDOTDIR".to_string(), home.display().to_string()),
+        ];
+        let (pty, mut child) = Pty::spawn(
+            &[zsh.to_string(), "-i".to_string()],
+            None,
+            &overrides,
+            24,
+            80,
+        )
+        .expect("spawn zsh");
+
+        const PROMPT_START: &[u8] = b"\x1b]133;A\x07";
+        let marked = |bytes: &[u8]| bytes.windows(PROMPT_START.len()).any(|w| w == PROMPT_START);
+        let mut collected = Vec::new();
+        let mut buffer = [0u8; 4096];
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+        while !marked(&collected) {
+            match tokio::time::timeout_at(deadline, pty.read(&mut buffer)).await {
+                Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+                Ok(Ok(count)) => collected.extend_from_slice(&buffer[..count]),
+            }
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert!(
+            marked(&collected),
+            "no OSC 133 prompt mark in zsh output: {:?}",
+            String::from_utf8_lossy(&collected)
+        );
     }
 
     /// The other half of the launcher problem: the terminal and job-control

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -660,7 +660,11 @@ mod tests {
         )
         .expect("spawn zsh");
 
-        const PROMPT_START: &[u8] = b"\x1b]133;A\x07";
+        // The mark opens with `ESC ] 133 ; A`; what follows is a `;`-separated
+        // option list (the shim's carries `redraw=0`) then the BEL. Match the
+        // opening so the assertion is about the mark being emitted, not about
+        // which options ride it.
+        const PROMPT_START: &[u8] = b"\x1b]133;A";
         let marked = |bytes: &[u8]| bytes.windows(PROMPT_START.len()).any(|w| w == PROMPT_START);
         let mut collected = Vec::new();
         let mut buffer = [0u8; 4096];

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -2025,7 +2025,7 @@ fn spawn_sidecar(rows: u16, cols: u16) -> anyhow::Result<Sidecar> {
                                 let resized = if reflow {
                                     terminal.resize_reflowing(rows, cols)
                                 } else {
-                                    terminal.resize(rows, cols)
+                                    terminal.resize_for_shell(rows, cols)
                                 };
                                 if let Err(error) = resized {
                                     fault = Some(format!("VT resize failed: {error}"));
@@ -3228,9 +3228,11 @@ mod tests {
     /// The rule the reflow policy turns on, and the case that made the previous
     /// one wrong: `zsh -ilc exec claude` leaves no shell in the session at all,
     /// so "is a job running under the shell" was false for exactly the sessions
-    /// a truncating resize mangles.
+    /// a truncating resize mangles. A shell gets the mark-gated resize
+    /// (`resize_for_shell`): reflow when its prompt rows are OSC 133-marked,
+    /// truncation when they are not.
     #[tokio::test]
-    async fn only_a_shell_gets_the_truncating_resize() {
+    async fn only_a_shell_gets_the_mark_gated_resize() {
         let Sidecar {
             commands,
             results: _results,

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1110,17 +1110,51 @@ impl Session {
         if rows == self.rows && cols == self.cols {
             return;
         }
+        // Probe the PTY with the size it already has before anything is
+        // enqueued. Re-asserting an unchanged size raises no SIGWINCH on any
+        // kernel this runs on, so the probe is silent — it only proves the
+        // descriptor can take an ioctl at all. That proof is what lets the VT
+        // resize below go out *first* while keeping the failure contract:
+        // a session whose PTY is gone stays exactly where it was and tells
+        // nobody.
+        if let Err(error) = self.pty.resize(self.rows, self.cols) {
+            // Nobody asked for this, so there is nobody to answer: the size
+            // is a policy over the whole attachment set, not one client's
+            // request. The session stays where it was and the next change
+            // tries again.
+            eprintln!(
+                "termiod: resize of session {} to {rows}x{cols} failed: {error}",
+                self.id
+            );
+            return;
+        }
+        let reflow = !self.foreground_is_a_shell();
+        // The VT's resize is enqueued *before* the ioctl that raises
+        // SIGWINCH. The shell answers that signal by redrawing its prompt,
+        // and those bytes travel the same FIFO as this command — enqueueing
+        // the resize first is what guarantees `resize_for_shell` clears the
+        // *old* prompt and never the one the shell just repainted. With the
+        // order reversed, a redraw that won the race was blanked and nothing
+        // repainted it: the session sat at a bare cursor (the "prompt
+        // disappeared" report), because zsh may skip its redisplay for a
+        // nudge that changes nothing.
+        self.send_sidecar(SidecarCommand::Resize { rows, cols, reflow });
         let applied = match self.pty.resize(rows, cols) {
             Ok(applied) => applied,
             Err(error) => {
-                // Nobody asked for this, so there is nobody to answer: the size
-                // is a policy over the whole attachment set, not one client's
-                // request. The session stays where it was and the next change
-                // tries again.
+                // The probe passed and this did not: the PTY died in between.
+                // Put the VT back on the grid the kernel still holds — a plain
+                // reflow, because no SIGWINCH is coming to repaint anything a
+                // clear would blank — and leave the session's state alone.
                 eprintln!(
                     "termiod: resize of session {} to {rows}x{cols} failed: {error}",
                     self.id
                 );
+                self.send_sidecar(SidecarCommand::Resize {
+                    rows: self.rows,
+                    cols: self.cols,
+                    reflow: true,
+                });
                 return;
             }
         };
@@ -1134,6 +1168,13 @@ impl Session {
                 "termiod: session {} asked for {rows}x{cols} and the kernel kept {}x{}",
                 self.id, applied.0, applied.1
             );
+            // The VT already took the requested grid; align it with the one
+            // the kernel actually kept.
+            self.send_sidecar(SidecarCommand::Resize {
+                rows: applied.0,
+                cols: applied.1,
+                reflow: true,
+            });
         }
         let (rows, cols) = applied;
         // The kernel can have kept the size it already had, in which case the
@@ -1148,8 +1189,6 @@ impl Session {
         // only matters where a replay is all there is — the far side of a
         // handoff.
         self.ring_reconstructs_screen = false;
-        let reflow = !self.foreground_is_a_shell();
-        self.send_sidecar(SidecarCommand::Resize { rows, cols, reflow });
         self.begin_resize_snapshot_barrier();
         self.emit_event(Event::Resized {
             session: self.id.to_string(),

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1163,15 +1163,19 @@ impl Session {
     /// that the child's answer to it has drained. One more repaint request
     /// makes the child overwrite anything the transition mis-parsed.
     ///
-    /// Shells are excluded for the same reason `foreground_is_a_shell` gates
-    /// the rewrap: a shell repainted its prompt on the resize's own SIGWINCH
-    /// and a second poke buys nothing, while the agents and editors this is
-    /// for redraw their whole screen from their own model.
+    /// Shells used to be excluded — a shell repainted its prompt on the
+    /// resize's own SIGWINCH, and while the resize merely truncated, a second
+    /// poke bought nothing. The mark-gated reflow changed that arithmetic:
+    /// the shell's redraw and the sidecar's Resize race through the same
+    /// FIFO, and when the redraw's bytes land first, `resize_for_shell`
+    /// blanks the prompt the shell just painted — with nothing left to paint
+    /// it again, the session sits at a bare cursor. The nudge is that
+    /// something: zsh's WINCH handler redisplays the prompt even when the
+    /// size did not change, and when the redraw won the race after all, the
+    /// extra redisplay repaints the same cells.
     fn fire_settle_nudge(&mut self) {
         self.settle_nudge_at = None;
-        if !self.foreground_is_a_shell() {
-            self.pty.nudge_repaint();
-        }
+        self.pty.nudge_repaint();
     }
 
     fn queue_history_chunk(
@@ -4085,11 +4089,12 @@ mod tests {
     }
 
     /// A resize is followed, once it has stood for the settle window, by one
-    /// more SIGWINCH to a non-shell foreground: the child's answer to the
-    /// resize raced the grid change, and its post-settle repaint is the only
-    /// thing that can overwrite whatever the race painted. The child counts the
-    /// signals — the resize's own ioctl delivers the first, the settle nudge
-    /// the second.
+    /// more SIGWINCH to the foreground: the child's answer to the resize
+    /// raced the grid change, and its post-settle repaint is the only thing
+    /// that can overwrite whatever the race painted — for a shell, that
+    /// includes the prompt `resize_for_shell` blanked after the shell had
+    /// already redrawn it. The child counts the signals — the resize's own
+    /// ioctl delivers the first, the settle nudge the second.
     #[tokio::test]
     async fn a_settled_resize_nudges_a_job_foreground_once_more() {
         let script = "import signal,sys,time\n\

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -3939,6 +3939,140 @@ mod tests {
         (handle, events_rx, on_exit_rx)
     }
 
+    /// The whole reflow pipeline against a real zsh: injection gives the
+    /// prompt its marks, a storm of narrowing viewports drives
+    /// `resize_for_shell` through the same FIFO as the shell's own redraws,
+    /// and at the end the screen must still show a prompt — the exact thing
+    /// the "prompt disappeared after resize" reports lost. Asserted from the
+    /// authoritative snapshot, not the byte stream, because the byte stream
+    /// always contains a redraw; the question is whether a later clear ate it.
+    #[tokio::test]
+    async fn a_real_zsh_keeps_its_prompt_through_a_resize_storm() {
+        let Some(zsh) = ["/bin/zsh", "/usr/bin/zsh"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+        else {
+            return;
+        };
+        let home = std::env::temp_dir().join(format!("termiod-zsh-storm-{}", std::process::id()));
+        std::fs::create_dir_all(&home).expect("scratch home");
+
+        let (on_exit, _on_exit_rx) = mpsc::unbounded_channel();
+        let (events, _events_rx) = broadcast::channel(64);
+        let handle = super::spawn(
+            SessionId::new("zsh-storm"),
+            "test".to_string(),
+            "/".to_string(),
+            "zsh".to_string(),
+            vec![zsh.to_string(), "-i".to_string()],
+            vec![
+                ("HOME".to_string(), home.display().to_string()),
+                ("ZDOTDIR".to_string(), home.display().to_string()),
+            ],
+            24,
+            80,
+            None,
+            on_exit,
+            events,
+        )
+        .expect("spawning zsh");
+
+        let (client_tx, mut client_rx) = mpsc::unbounded_channel();
+        let (reply, answer) = oneshot::channel();
+        handle.send(SessionMsg::AddClient {
+            id: ClientId::new("writer"),
+            interactive: true,
+            rows: 24,
+            cols: 80,
+            out: client_tx,
+            backlog: Arc::new(ClientBacklog::new()),
+            snapshot: true,
+            scrollback: false,
+            grid_diff: false,
+            reply,
+        });
+        answer.await.expect("attached");
+
+        // Wait until the injected shim has marked a prompt, which is also the
+        // signal that zsh is at its prompt and idle.
+        let mut seen = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            let event = tokio::time::timeout_at(deadline, client_rx.recv())
+                .await
+                .expect("zsh reached a marked prompt")
+                .expect("client stream open");
+            if let ClientEvent::Data(payload) = event {
+                seen.extend_from_slice(&payload.bytes);
+                if seen
+                    .windows(7)
+                    .any(|window| window == b"\x1b]133;A")
+                {
+                    break;
+                }
+            }
+        }
+
+        // The streaming cadence of a window drag: several narrowings in
+        // flight, each racing the redraw of the one before it.
+        for cols in [70u16, 60, 50, 40] {
+            handle.send(SessionMsg::Viewport {
+                id: ClientId::new("writer"),
+                rows: 24,
+                cols,
+                rendering: true,
+            });
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        }
+
+        // Poll the authoritative screen until the cursor's row holds a prompt
+        // again. A bare zsh prompt ends in "% ", so the row the cursor sits on
+        // must contain a '%' once the storm settles.
+        let prompt_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut last_row = String::new();
+        loop {
+            assert!(
+                tokio::time::Instant::now() < prompt_deadline,
+                "prompt never came back after the storm; cursor row: {last_row:?}"
+            );
+            handle.send(SessionMsg::ResendSnapshot {
+                id: ClientId::new("writer"),
+            });
+            let snapshot_deadline =
+                tokio::time::Instant::now() + std::time::Duration::from_millis(900);
+            let snapshot = loop {
+                match tokio::time::timeout_at(snapshot_deadline, client_rx.recv()).await {
+                    Ok(Some(ClientEvent::Snapshot(snapshot))) => break Some(snapshot),
+                    Ok(Some(_)) => continue,
+                    Ok(None) => panic!("client stream ended"),
+                    Err(_) => break None,
+                }
+            };
+            let Some(snapshot) = snapshot else { continue };
+            // The attach's own snapshot (and any captured mid-storm) still
+            // carries an earlier width; only the settled grid answers the
+            // question.
+            if snapshot.cols != 40 {
+                continue;
+            }
+            let row_start = usize::from(snapshot.cursor_y) * usize::from(snapshot.cols);
+            let row_end = row_start + usize::from(snapshot.cols);
+            last_row = snapshot.cells[row_start..row_end.min(snapshot.cells.len())]
+                .iter()
+                .map(|cell| char::from_u32(cell.codepoint).unwrap_or(' '))
+                .collect();
+            if last_row.contains('%') {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        }
+
+        handle.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
     /// A resize invalidates the ring as a source of truth for the screen: the
     /// bytes already in it were written into a differently shaped grid, and
     /// replaying them into this one puts them in the wrong places. Nothing in

--- a/termiod/src/session/sidecar.rs
+++ b/termiod/src/session/sidecar.rs
@@ -97,11 +97,12 @@ pub(crate) enum SidecarCommand {
     Resize {
         rows: u16,
         cols: u16,
-        /// Whether the screen may be rewrapped. False while the shell holds the
-        /// terminal, because its SIGWINCH redisplay assumes the old wrap points
-        /// (`termiod_vt::VtTerminal::resize`); true when a job does, which is
-        /// the only case where truncating is visible as a mangled window rather
-        /// than as a clean prompt.
+        /// Whether the screen may be rewrapped unconditionally. True when a
+        /// job holds the terminal, which repaints from its own model. False
+        /// while the shell does, because its SIGWINCH redisplay assumes the
+        /// old wrap points — the VT then reflows only if the screen carries
+        /// OSC 133 prompt marks to clear first, and truncates otherwise
+        /// (`termiod_vt::VtTerminal::resize_for_shell`).
         reflow: bool,
     },
     Snapshot {

--- a/termiod/src/shell_integration.rs
+++ b/termiod/src/shell_integration.rs
@@ -1,0 +1,160 @@
+//! Shell integration: OSC 133 prompt marks for the sessions the daemon spawns.
+//!
+//! A resize while a shell holds the terminal can only reflow safely if the
+//! host knows which rows are the prompt — zsh's SIGWINCH redisplay repaints
+//! against the old wrap points, and rewrapping under it duplicates the prompt
+//! (`termiod_vt::VtTerminal::resize_for_shell` holds the other half of this).
+//! Shells do not announce their prompt rows on their own; Ghostty and Kitty
+//! solve it by pointing one zsh startup at their own `ZDOTDIR` so the shell
+//! sources a hook file that emits the marks. This module is that mechanism
+//! with termiod as the owner: written from scratch, because Ghostty's script
+//! is GPLv3 via Kitty's and this repository is MIT.
+//!
+//! Only zsh is instrumented. It is the login shell these sessions almost
+//! always run, and it is the shell whose redisplay produced the duplicated
+//! prompt this exists to prevent. A shell without marks loses nothing it had:
+//! the VT falls back to the truncating resize that was previously
+//! unconditional.
+
+use std::path::{Path, PathBuf};
+
+/// The `.zshenv` shim one zsh startup is pointed at. It hands the borrowed
+/// `ZDOTDIR` back before the user's own configuration runs, so the only thing
+/// that changes about the shell is the marks it emits.
+///
+/// The prompt-start mark lives in `PS1` (invisibly, via `%{ %}`) rather than
+/// being printed from the hook, because zle's own SIGWINCH redraw reprints
+/// `PS1`: a printed mark would survive only until the first resize repaint,
+/// and the second resize would find an unmarked prompt and truncate again.
+const ZSH_SHIM: &str = r#"# termiod routes one zsh startup through this directory (ZDOTDIR) so the
+# session's shell emits OSC 133 prompt marks -- the rows the host must know
+# to blank before it may reflow the screen on resize. The borrowed ZDOTDIR
+# is handed back immediately, before the user's own configuration runs, so
+# nothing else about the shell changes and a nested zsh is left alone.
+
+if [[ -n "${TERMIOD_ZSH_ZDOTDIR+set}" ]]; then
+    builtin export ZDOTDIR="$TERMIOD_ZSH_ZDOTDIR"
+    builtin unset TERMIOD_ZSH_ZDOTDIR
+else
+    builtin unset ZDOTDIR
+fi
+
+if [[ -f "${ZDOTDIR:-$HOME}/.zshenv" ]]; then
+    builtin source "${ZDOTDIR:-$HOME}/.zshenv"
+fi
+
+[[ -o interactive ]] || return 0
+
+# $? seen by the first precmd hook is the command's exit status; by the time
+# a later hook runs it is whatever the hooks before it returned. Capture it
+# in a hook registered before any theme's, for the close-out mark below.
+typeset -g _termiod_exit_status=0
+typeset -g _termiod_command_running=''
+_termiod_capture_status() { _termiod_exit_status=$?; }
+
+_termiod_preexec() {
+    builtin print -rn -- $'\e]133;C\a'
+    _termiod_command_running=1
+}
+
+# Close the previous command with its status, then make sure PS1 opens with
+# the prompt-start mark, wrapped in %{ %} so zsh's width math never sees it.
+_termiod_mark_prompt() {
+    if [[ -n "$_termiod_command_running" ]]; then
+        builtin print -rn -- $'\e]133;D;'"${_termiod_exit_status}"$'\a'
+        _termiod_command_running=''
+    fi
+    if [[ "$PS1" != *$'\e]133;A\a'* ]]; then
+        PS1="%{"$'\e]133;A\a'"%}${PS1}"
+    fi
+}
+
+# Themes rewrite PS1 from their own precmd hooks, and hooks run in
+# registration order -- a marker registered here, at .zshenv time, would run
+# before anything .zshrc registers and have its mark stripped every cycle.
+# So the first prompt re-registers the marker at the end of the list, where
+# it runs after every theme, and steps out of the way.
+_termiod_arm() {
+    add-zsh-hook -d precmd _termiod_arm
+    precmd_functions+=(_termiod_mark_prompt)
+    _termiod_mark_prompt
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _termiod_capture_status
+add-zsh-hook precmd _termiod_arm
+add-zsh-hook preexec _termiod_preexec
+"#;
+
+/// The `ZDOTDIR` to point a zsh session at, or `None` when `program` is not
+/// zsh or the shim could not be written. `None` never fails the spawn: a
+/// session without marks resizes the way every session did before this
+/// existed.
+pub fn zsh_shim_zdotdir(program: &str) -> Option<PathBuf> {
+    let name = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())?
+        .trim_start_matches('-');
+    if name != "zsh" {
+        return None;
+    }
+    let dir = match crate::paths::state_dir() {
+        Ok(state) => state.join("shell-integration").join("zsh"),
+        Err(error) => {
+            eprintln!("termiod: shell integration disabled, no state dir: {error}");
+            return None;
+        }
+    };
+    match install_shim(&dir) {
+        Ok(()) => Some(dir),
+        Err(error) => {
+            eprintln!(
+                "termiod: shell integration disabled, cannot write {}: {error}",
+                dir.display()
+            );
+            None
+        }
+    }
+}
+
+/// Write the shim if it is missing or stale. Byte-compared first so steady
+/// state is a read, not a write — sessions spawn far more often than this
+/// file changes, and the shim must always match the daemon that wrote it.
+fn install_shim(dir: &Path) -> std::io::Result<()> {
+    let path = dir.join(".zshenv");
+    if std::fs::read(&path).is_ok_and(|current| current == ZSH_SHIM.as_bytes()) {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(&path, ZSH_SHIM)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_zsh_is_instrumented() {
+        for program in ["/bin/bash", "bash", "fish", "/usr/bin/dash", "claude"] {
+            assert_eq!(zsh_shim_zdotdir(program), None, "{program} must not get the shim");
+        }
+    }
+
+    #[test]
+    fn shim_is_installed_and_kept_current() {
+        let dir = std::env::temp_dir().join(format!("termiod-shim-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        install_shim(&dir).expect("install");
+        let path = dir.join(".zshenv");
+        let written = std::fs::read_to_string(&path).expect("read shim");
+        assert_eq!(written, ZSH_SHIM);
+
+        // A stale shim (an older daemon's) is replaced, not trusted.
+        std::fs::write(&path, "stale").expect("stale write");
+        install_shim(&dir).expect("reinstall");
+        assert_eq!(std::fs::read_to_string(&path).expect("reread"), ZSH_SHIM);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/termiod/src/shell_integration.rs
+++ b/termiod/src/shell_integration.rs
@@ -27,11 +27,20 @@ use std::path::{Path, PathBuf};
 /// `PS1`: a printed mark would survive only until the first resize repaint,
 /// and the second resize would find an unmarked prompt and truncate again.
 ///
-/// The mark must stay a bare `133;A` — never `133;A;redraw=1`. An explicit
-/// `redraw=` is the one thing that flips the engine's own prompt-clear back
-/// on (the C API builds terminals with `shell_redraws_prompt = .false`, and
-/// only that parameter writes the flag), and the engine's clear runs *after*
-/// its reflow — the dde3d4d6b ordering `resize_for_shell` exists to avoid.
+/// The mark carries `redraw=0`, and that parameter is load-bearing. A bare
+/// `133;A` marks the row *and* leaves `shell_redraws_prompt` at its engine
+/// default — which is `.true` in the full libghostty core the Mac and iOS
+/// **surfaces** run. Those surfaces reflow locally on every resize, and with
+/// the flag on they clear the marked prompt themselves, in the engine's own
+/// clear-*after*-reflow order (the dde3d4d6b regression), leaving a blank
+/// prompt that the daemon's keyframe only sometimes repaints in time. The
+/// daemon is the one authority allowed to clear a prompt, in the correct
+/// order, through `resize_for_shell`; `redraw=0` turns the surfaces' local
+/// clear off (the engine's own words: it "will NOT clear any prompt lines on
+/// resize") while still marking the row, because the row's semantic content
+/// is set independently of the flag. The daemon's own sidecar VT is built
+/// through the C API, which already defaults the flag to `.false`, so
+/// `redraw=0` changes nothing there — its clear stays the manual one.
 const ZSH_SHIM: &str = r#"# termiod routes one zsh startup through this directory (ZDOTDIR) so the
 # session's shell emits OSC 133 prompt marks -- the rows the host must know
 # to blank before it may reflow the screen on resize. The borrowed ZDOTDIR
@@ -70,8 +79,8 @@ _termiod_mark_prompt() {
         builtin print -rn -- $'\e]133;D;'"${_termiod_exit_status}"$'\a'
         _termiod_command_running=''
     fi
-    if [[ "$PS1" != *$'\e]133;A\a'* ]]; then
-        PS1="%{"$'\e]133;A\a'"%}${PS1}"
+    if [[ "$PS1" != *$'\e]133;A;redraw=0\a'* ]]; then
+        PS1="%{"$'\e]133;A;redraw=0\a'"%}${PS1}"
     fi
 }
 

--- a/termiod/src/shell_integration.rs
+++ b/termiod/src/shell_integration.rs
@@ -26,6 +26,12 @@ use std::path::{Path, PathBuf};
 /// being printed from the hook, because zle's own SIGWINCH redraw reprints
 /// `PS1`: a printed mark would survive only until the first resize repaint,
 /// and the second resize would find an unmarked prompt and truncate again.
+///
+/// The mark must stay a bare `133;A` — never `133;A;redraw=1`. An explicit
+/// `redraw=` is the one thing that flips the engine's own prompt-clear back
+/// on (the C API builds terminals with `shell_redraws_prompt = .false`, and
+/// only that parameter writes the flag), and the engine's clear runs *after*
+/// its reflow — the dde3d4d6b ordering `resize_for_shell` exists to avoid.
 const ZSH_SHIM: &str = r#"# termiod routes one zsh startup through this directory (ZDOTDIR) so the
 # session's shell emits OSC 133 prompt marks -- the rows the host must know
 # to blank before it may reflow the screen on resize. The borrowed ZDOTDIR

--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 
 use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
 use libghostty_vt::render::{CellIterator, Dirty, RenderState, RowIterator};
-use libghostty_vt::screen::{CellContentTag, Screen};
+use libghostty_vt::screen::{CellContentTag, RowSemanticPrompt, Screen};
 use libghostty_vt::style::{RgbColor, StyleColor};
 use libghostty_vt::terminal::{Mode, Point, PointCoordinate};
 use libghostty_vt::{Error, Terminal, TerminalOptions};
@@ -213,9 +213,10 @@ impl VtTerminal {
     /// ⌘D duplicated-prompt report. Ghostty.app escapes this only because it
     /// injects shell integration and clears OSC 133-marked prompt rows before
     /// reflowing (and its engine's post-1.3.1 clear-after-reflow ordering,
-    /// dde3d4d6b, re-breaks the wrapped case even then). Sessions here carry
-    /// no integration, so the marks-free behaviour every shell is written
-    /// against — truncate, don't rewrap — is the correct one for the host.
+    /// dde3d4d6b, re-breaks the wrapped case even then). This is the
+    /// marks-free behaviour every shell is written against — truncate, don't
+    /// rewrap — and it stays the fallback whenever `resize_for_shell` finds no
+    /// marks under the cursor.
     ///
     /// The engine gates reflow on DECAWM (mode ?7), so wraparound is parked
     /// off across the resize and restored to whatever the program had chosen.
@@ -261,6 +262,70 @@ impl VtTerminal {
         // Pixel dimensions are not used by the daemon snapshot sidecar; fixed
         // cell metrics still give libghostty-vt consistent total dimensions.
         check(self.terminal.resize(cols, rows, 8, 16), "Terminal::resize")
+    }
+
+    /// Resize while a **shell** holds the terminal: reflow when the screen
+    /// carries OSC 133 prompt marks, truncate (`resize`) when it does not.
+    ///
+    /// This is Ghostty.app's escape from the duplicated-prompt trap, done in
+    /// the order its engine regression (dde3d4d6b) got wrong: blank the
+    /// current prompt *before* reflowing. zsh's SIGWINCH redisplay moves the
+    /// cursor up by the physical rows its prompt occupied at the width it was
+    /// drawn, then clears down and reprints. Blank rows do not rewrap, so
+    /// clearing the prompt's rows first keeps that arithmetic true across the
+    /// reflow — the redraw lands on clean cells — while everything above the
+    /// prompt rewraps to the new width instead of losing line tails.
+    ///
+    /// Only the prompt run the cursor sits in is cleared: the walk ascends
+    /// through continuation rows to the nearest primary prompt row and stops
+    /// there, so an earlier prompt stacked directly above (enter pressed at an
+    /// empty prompt) is history nobody will redraw and is left to reflow as
+    /// ordinary text. The cursor is saved and restored (DECSC/DECRC) around
+    /// the clear because the redisplay's row arithmetic starts from wherever
+    /// the cursor was — parking it at the prompt's first row would shift the
+    /// whole repaint up by the prompt's height.
+    pub fn resize_for_shell(&mut self, rows: u16, cols: u16) -> Result<()> {
+        match self.current_prompt_start()? {
+            Some(prompt_row) => {
+                let clear = format!("\x1b7\x1b[{};1H\x1b[J\x1b8", u32::from(prompt_row) + 1);
+                self.vt_write(clear.as_bytes());
+                self.resize_reflowing(rows, cols)
+            }
+            None => self.resize(rows, cols),
+        }
+    }
+
+    /// The first row of the prompt the cursor currently sits in, or `None`
+    /// when the cursor is not on an OSC 133-marked row — an unmarked shell, a
+    /// program that took the alternate screen, or a screen state the marks do
+    /// not describe. `None` is the signal to fall back to the truncating
+    /// resize, so every uncertain answer here must be `None`.
+    fn current_prompt_start(&self) -> Result<Option<u16>> {
+        let alternate =
+            check(self.terminal.active_screen(), "Terminal::active_screen")? == Screen::Alternate;
+        if alternate {
+            return Ok(None);
+        }
+        let mut y = check(self.terminal.cursor_y(), "Terminal::cursor_y")?;
+        loop {
+            match self.row_semantic_prompt(y)? {
+                RowSemanticPrompt::Prompt => return Ok(Some(y)),
+                RowSemanticPrompt::Continuation if y > 0 => y -= 1,
+                _ => return Ok(None),
+            }
+        }
+    }
+
+    fn row_semantic_prompt(&self, y: u16) -> Result<RowSemanticPrompt> {
+        let reference = check(
+            self.terminal.grid_ref(Point::Active(PointCoordinate {
+                x: 0,
+                y: u32::from(y),
+            })),
+            "Terminal::grid_ref(active)",
+        )?;
+        let row = check(reference.row(), "GridRef::row")?;
+        check(row.semantic_prompt(), "Row::semantic_prompt")
     }
 
     /// Serialise the current screen back into **VT sequences** — the repaint a

--- a/termiod/vt/tests/resize_reflow.rs
+++ b/termiod/vt/tests/resize_reflow.rs
@@ -181,6 +181,152 @@ fn widening_does_not_re_join_a_wrapped_line() {
     );
 }
 
+/// The prompt-start mark termiod's zsh integration carries at the head of
+/// `PS1` (invisible to zsh's width math via `%{ %}`), as the engine receives
+/// it: every prompt reprint re-marks its first row.
+const MARK_PROMPT_START: &[u8] = b"\x1b]133;A\x07";
+
+/// A marked shell gets Ghostty.app's resize: the prompt is blanked before the
+/// reflow, so zsh's old-width redraw lands on clean rows — one prompt, never
+/// two — while the content above rewraps to the new width.
+#[test]
+fn marked_prompt_resize_reflows_without_duplicating() {
+    let mut vt = VtTerminal::new(24, 63).expect("new");
+    vt.vt_write(b"image in clipboard, saved to /tmp/screenshot-2026.png ok\r\n");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(PROMPT.as_bytes());
+    vt.resize_for_shell(24, 47).expect("resize");
+    // zsh's redraw reprints PS1, which carries the mark — so the fresh prompt
+    // row is marked again and the *next* resize can also reflow.
+    vt.vt_write(ZSH_WINCH_REDRAW);
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(PROMPT.as_bytes());
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    let copies = rows
+        .iter()
+        .filter(|row| row.contains(">> termio git:("))
+        .count();
+    assert_eq!(copies, 1, "one prompt after a marked resize, rows: {rows:?}");
+}
+
+/// The user-visible half of the fix: text a narrow screen wrapped is re-joined
+/// when the window widens again, instead of staying broken (or, before this,
+/// being truncated outright on the way down).
+#[test]
+fn marked_widening_re_joins_a_wrapped_line() {
+    let mut vt = VtTerminal::new(6, 20).expect("new");
+    vt.vt_write(b"image in clipboard ok\r\n");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> ");
+    vt.resize_for_shell(6, 40).expect("resize");
+    vt.vt_write(b"\r\x1b[0m\x1b[27m\x1b[24m\x1b[J");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> ");
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    assert_eq!(
+        rows,
+        vec!["image in clipboard ok".to_string(), ">".to_string()],
+        "the wrapped line is re-joined at the new width"
+    );
+}
+
+/// Narrowing with marks keeps the tails: the long line rewraps onto two rows
+/// instead of losing everything past the new width — the `ls` truncation
+/// report this exists for.
+#[test]
+fn marked_narrowing_rewraps_instead_of_truncating() {
+    let mut vt = VtTerminal::new(24, 40).expect("new");
+    vt.vt_write(b"OakReader-pre-restore-2026-05-17T23-17\r\n");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> ");
+    vt.resize_for_shell(24, 30).expect("resize");
+    vt.vt_write(b"\r\x1b[0m\x1b[27m\x1b[24m\x1b[J");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> ");
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    assert_eq!(
+        rows,
+        vec![
+            "OakReader-pre-restore-2026-05-".to_string(),
+            "17T23-17".to_string(),
+            ">".to_string(),
+        ],
+        "the tail survives on a wrapped second row"
+    );
+}
+
+/// Without marks, `resize_for_shell` must be indistinguishable from the
+/// truncating `resize`: a shell nobody instrumented still redraws against the
+/// old wrap points, and reflowing under it recreates the duplicate.
+#[test]
+fn unmarked_resize_for_shell_still_truncates() {
+    let mut vt = VtTerminal::new(24, 63).expect("new");
+    vt.vt_write(PROMPT.as_bytes());
+    vt.resize_for_shell(24, 47).expect("resize");
+    vt.vt_write(ZSH_WINCH_REDRAW);
+    vt.vt_write(PROMPT.as_bytes());
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    assert_eq!(
+        rows,
+        vec![
+            ">> termio git:(docs/remote-access-after-shippin".to_string(),
+            "g) x".to_string(),
+        ],
+        "no marks, no reflow: same screen as the truncating resize"
+    );
+}
+
+/// An earlier prompt stacked directly above the current one (enter pressed at
+/// an empty prompt) is history nobody will redraw: the clear must stop at the
+/// current prompt's own first row and leave the one above as text.
+#[test]
+fn clearing_stops_at_the_current_prompt() {
+    let mut vt = VtTerminal::new(24, 63).expect("new");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> old\r\n");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> ");
+    vt.resize_for_shell(24, 47).expect("resize");
+    vt.vt_write(b"\r\x1b[0m\x1b[27m\x1b[24m\x1b[J");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(b"> ");
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    assert_eq!(
+        rows,
+        vec!["> old".to_string(), ">".to_string()],
+        "the earlier prompt's row survives the resize"
+    );
+}
+
+/// The ⌘D split storm again, marked this time: three consecutive narrowings,
+/// zsh redrawing after each. Once the prompt no longer fits the width it
+/// wraps, so the cursor sits on a *continuation* row and the clear has to
+/// ascend to the prompt's first row before it erases — the walk this test
+/// pins down. Every intermediate screen must hold exactly one prompt.
+#[test]
+fn marked_resize_survives_a_split_storm() {
+    let mut vt = VtTerminal::new(24, 95).expect("new");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(PROMPT.as_bytes());
+    for (cols, ups) in [(63u16, 0usize), (47, 0), (38, 1)] {
+        vt.resize_for_shell(24, cols).expect("resize");
+        vt.vt_write(b"\r");
+        // zsh moves up (prompt rows at the drawn width - 1); emulate it.
+        for _ in 0..ups {
+            vt.vt_write(b"\x1b[A");
+        }
+        vt.vt_write(b"\r\x1b[0m\x1b[27m\x1b[24m\x1b[J");
+        vt.vt_write(MARK_PROMPT_START);
+        vt.vt_write(PROMPT.as_bytes());
+        let rows = visible(&vt.format_vt().expect("fmt"));
+        let copies = rows
+            .iter()
+            .filter(|row| row.contains(">> termio git:("))
+            .count();
+        assert_eq!(copies, 1, "at {cols} cols expected one prompt, rows: {rows:?}");
+    }
+}
+
 /// The other half of the rule: with a job on screen rather than the shell, the
 /// same widening re-joins the line, which is what every terminal the program was
 /// written for does and what the user is comparing against.

--- a/termiod/vt/tests/resize_reflow.rs
+++ b/termiod/vt/tests/resize_reflow.rs
@@ -327,6 +327,41 @@ fn marked_resize_survives_a_split_storm() {
     }
 }
 
+/// The race the settle nudge exists for, at the VT layer: the shell's WINCH
+/// redraw and the sidecar's Resize share one FIFO, and when the redraw's
+/// bytes land first, `resize_for_shell` blanks the prompt the shell just
+/// painted — leaving a bare cursor, with nothing queued to paint it again
+/// (the "prompt disappeared" report). The daemon answers with a post-settle
+/// SIGWINCH; zsh redisplays, and the screen heals. This pins both halves:
+/// the blank screen the race produces, and the redraw that repairs it.
+#[test]
+fn redraw_winning_the_resize_race_blanks_until_the_nudged_redraw() {
+    let mut vt = VtTerminal::new(24, 63).expect("new");
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(PROMPT.as_bytes());
+    // The kernel's SIGWINCH beat the sidecar: zsh already redrew for the new
+    // width before the VT processed the resize.
+    vt.vt_write(ZSH_WINCH_REDRAW);
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(PROMPT.as_bytes());
+    vt.resize_for_shell(24, 47).expect("resize");
+    assert_eq!(
+        visible(&vt.format_vt().expect("fmt")),
+        Vec::<String>::new(),
+        "the late clear blanked the redrawn prompt"
+    );
+    // The settle nudge's SIGWINCH: zsh redisplays even at an unchanged size.
+    vt.vt_write(ZSH_WINCH_REDRAW);
+    vt.vt_write(MARK_PROMPT_START);
+    vt.vt_write(PROMPT.as_bytes());
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    let copies = rows
+        .iter()
+        .filter(|row| row.contains(">> termio git:("))
+        .count();
+    assert_eq!(copies, 1, "the nudged redraw restored one prompt, rows: {rows:?}");
+}
+
 /// The other half of the rule: with a job on screen rather than the shell, the
 /// same widening re-joins the line, which is what every terminal the program was
 /// written for does and what the user is comparing against.


### PR DESCRIPTION
Narrowing a Termio window truncated every line at the new width while the shell held the terminal, and widening could not bring the tails back — Ghostty reflows the same screen. The truncation was deliberate: zsh's SIGWINCH redisplay repaints against the old wrap points, and reflowing under it duplicates the prompt (the ⌘D split-storm report). Ghostty.app escapes the trap by injecting shell integration and blanking the OSC 133-marked prompt rows before it reflows. This PR gives the daemon both halves of that mechanism.

## What changed

- **`Pty::spawn` routes a zsh startup through a daemon-written `ZDOTDIR` shim** (`termiod/src/shell_integration.rs`). The shim hands the borrowed `ZDOTDIR` back before the user's configuration runs, then registers hooks that keep the OSC 133 prompt-start mark at the head of `PS1` (invisible via `%{ %}`) and close each command with its exit status. The mark rides `PS1` rather than a hook's `print` so zle's own resize redraw re-marks the fresh prompt row — without that, the second resize would find an unmarked prompt and truncate again. The marker hook re-registers itself at the end of `precmd_functions` on the first prompt, so themes that rewrite `PS1` from their own precmd cannot strip it. Written from scratch: Ghostty's script is GPLv3 via Kitty's, and this repository is MIT.
- **`VtTerminal::resize_for_shell`** blanks the current prompt run — ascending continuation rows to the primary prompt row and stopping there, so an earlier prompt stacked directly above survives — then reflows. Blanked rows do not rewrap, so zsh's old-width cursor arithmetic stays true and its redraw lands on clean cells: one prompt, never two, and the content above rewraps instead of losing line tails. The clear runs **before** the engine resize on purpose — the ordering Ghostty's `dde3d4d6b` regression got wrong. With no marks under the cursor (uninstrumented shell, alternate screen), it falls back to the truncating resize unchanged.
- The sidecar's shell branch calls `resize_for_shell`; the job branch still reflows unconditionally.

## Testing

- `termiod/vt/tests/resize_reflow.rs`: marked resizes reflow without duplicating the prompt (including the wrapped-prompt split storm, which exercises the continuation-row walk), narrowing keeps line tails, widening re-joins wrapped lines, unmarked screens truncate exactly as before, and the clear stops at the current prompt.
- `pty.rs`: end-to-end — a real zsh spawned by the daemon emits the prompt mark through the whole injection chain (skipped where zsh is absent).
- `cargo test` across termiod and termiod-vt: all green.

Manual verification still to do before undraft: dev-channel daemon, long `ls` output, drag-resize narrow and back in zsh (reflows) and in bash (truncates as before); confirm no prompt duplication with a ⌘D split storm and that powerlevel10k keeps the mark.

## Release Notes

- Resizing a session no longer cuts off long lines while the shell is at a prompt: the screen rewraps to the new width, in both directions. Sessions running zsh get this automatically; other shells keep the previous behavior.