### PR TITLE
Stabilize the inspector edge across split relayouts

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -667,6 +667,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // sidebar. It starts collapsed — the tree is summoned via the toolbar toggle.
         let inspector = FileBrowserHostingController(store: store, settings: settings)
         let inspectorItem = NSSplitViewItem(viewController: inspector)
+        // Hold firmer than the terminal (default 250): a sidebar toggle or window resize is
+        // absorbed by the terminal alone, Xcode-style, instead of being split proportionally
+        // between both flexible panes — which nudged the inspector's width (and relaid out its
+        // content) on every frame of the sidebar's slide. The inspector only yields once the
+        // terminal is squeezed to its own minimum.
+        inspectorItem.holdingPriority = .init(260)
         inspectorItem.minimumThickness = 260
         // Max width tracks the window: the inspector can grow to the golden ratio of the
         // content width (`updateInspectorMaxThickness`), never below the 420pt floor. A fixed

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -124,6 +124,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // max thickness (and the tracking-separator re-bind it forces) is recomputed once the drag
     // stops, not on every intermediate frame.
     private var inspectorResizeSettle: DispatchWorkItem?
+    // Catch-all for the tracking-separator re-bind: any content-split relayout (divider drag,
+    // sidebar toggle, fullscreen transition) can detach `.inspectorTrackingSeparator` from
+    // divider 1, leaving its hairline stranded beside the real divider. The explicit re-binds
+    // cover the known mutation sites; this observer covers the rest.
+    private var splitResizeObserver: NSObjectProtocol?
+    private var separatorReassertSettle: DispatchWorkItem?
+    // Divider 1's position at the last re-bind, so a settle that moved nothing (including the
+    // relayout a re-bind itself may cause) doesn't re-bind again.
+    private var lastReassertedInspectorMinX: CGFloat?
     // The floating panel shared by ⌘⇧O Open Quickly and ⌘⇧P Command Palette.
     // Presented as a child window (Xcode Open-Quickly style) because the
     // terminal surfaces are NSViews that draw above any SwiftUI overlay in the
@@ -288,6 +297,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 guard let store = self?.store, store.inspectorVisible != visible else { return }
                 store.inspectorVisible = visible
             }
+        }
+        // Re-bind the inspector's tracking separator after *any* split relayout settles — the
+        // explicit re-binds (detail open, max-thickness change, maximize restore) each cured one
+        // reported detachment path, and divider drags / sidebar toggles were still uncovered.
+        splitResizeObserver = NotificationCenter.default.addObserver(
+            forName: NSSplitView.didResizeSubviewsNotification,
+            object: splitViewController?.splitView, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.scheduleSeparatorReassert() }
         }
         // Re-resolve the window background whenever the OS flips light↔dark under `.system` mode
         // (see `appearanceObserver`). Pinned Light/Dark modes never see the effective appearance
@@ -1183,6 +1201,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 toolbar.removeItem(at: toggle - 1)
             }
         }
+    }
+
+    /// Coalesces the per-frame `didResizeSubviews` stream (a divider drag fires it continuously)
+    /// into one re-bind after the geometry settles, and only when divider 1 actually moved since
+    /// the last re-bind — which also keeps the relayout a re-bind itself may cause from cycling.
+    private func scheduleSeparatorReassert() {
+        separatorReassertSettle?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, let splitView = self.splitViewController?.splitView,
+                      splitView.arrangedSubviews.count > 2 else { return }
+                let inspectorMinX = splitView.arrangedSubviews[2].frame.minX
+                guard inspectorMinX != self.lastReassertedInspectorMinX else { return }
+                self.lastReassertedInspectorMinX = inspectorMinX
+                self.reassertInspectorSeparator()
+            }
+        }
+        separatorReassertSettle = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
     }
 
     /// Removes and re-inserts the inspector's tracking separator so it re-binds to divider 1 against

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -283,6 +283,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 // toolbar has nothing left to carry.
                 self?.store.sidebarVisible = !collapsed
                 self?.syncMaximizedChrome()
+                // The toolbar mutation above can detach the tracking separator, and the
+                // inspector holds its width through a sidebar toggle — divider 1 never moves,
+                // so the settle observer's moved-divider guard would skip this path. Re-bind
+                // explicitly once the mutation settles.
+                DispatchQueue.main.async { [weak self] in self?.reassertInspectorSeparator() }
             }
         }
         // Mirror the inspector's live collapse state onto the store, so panes it hosts
@@ -299,8 +304,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
         }
         // Re-bind the inspector's tracking separator after *any* split relayout settles — the
-        // explicit re-binds (detail open, max-thickness change, maximize restore) each cured one
-        // reported detachment path, and divider drags / sidebar toggles were still uncovered.
+        // explicit re-binds (detail open, max-thickness change, maximize restore, sidebar
+        // toggle) each cure one known mutation site; this catches divider drags and
+        // cap-preserving window resizes. Toolbar mutations that move no divider stay on the
+        // explicit list: the moved-divider guard in `scheduleSeparatorReassert` skips them.
         splitResizeObserver = NotificationCenter.default.addObserver(
             forName: NSSplitView.didResizeSubviewsNotification,
             object: splitViewController?.splitView, queue: .main
@@ -667,12 +674,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // sidebar. It starts collapsed — the tree is summoned via the toolbar toggle.
         let inspector = FileBrowserHostingController(store: store, settings: settings)
         let inspectorItem = NSSplitViewItem(viewController: inspector)
-        // Hold firmer than the terminal (default 250): a sidebar toggle or window resize is
-        // absorbed by the terminal alone, Xcode-style, instead of being split proportionally
-        // between both flexible panes — which nudged the inspector's width (and relaid out its
-        // content) on every frame of the sidebar's slide. The inspector only yields once the
-        // terminal is squeezed to its own minimum.
-        inspectorItem.holdingPriority = .init(260)
+        // Hold firmer than the terminal (250, the plain-item default): a sidebar toggle or
+        // window resize is absorbed by the terminal alone, Xcode-style, instead of being split
+        // proportionally between both flexible panes — which nudged the inspector's width (and
+        // relaid out its content) on every frame of the sidebar's slide. 261 is AppKit's own
+        // inspector-item default and clears the sidebar item's actual 260 (its header claims
+        // 250), so once the terminal is squeezed to its minimum the sidebar yields next, not a
+        // solver tie-break between the two.
+        inspectorItem.holdingPriority = .init(261)
         inspectorItem.minimumThickness = 260
         // Max width tracks the window: the inspector can grow to the golden ratio of the
         // content width (`updateInspectorMaxThickness`), never below the 420pt floor. A fixed


### PR DESCRIPTION
Two fixes for the terminal ‖ inspector boundary.

**Stray toolbar hairline.** `.inspectorTrackingSeparator` can detach from divider 1 on any split relayout, leaving its line stranded beside the real divider. The explicit re-binds only covered detail open, max-thickness changes, and maximize restore; divider drags, sidebar toggles, and cap-preserving window resizes were uncovered. A `didResizeSubviews` observer now coalesces the per-frame stream and re-binds once the geometry settles, skipping settles where divider 1 didn't move.

**Inspector width jitter.** All three split items held at the default priority (250), so a sidebar toggle's width change was split proportionally between the terminal and the inspector — the inspector's edge crept and its content relaid out on every animation frame. The inspector now holds firmer (260) than the terminal, so the terminal alone absorbs sidebar and window resizes, Xcode-style, until it reaches its own minimum.

Release Notes:
- Fixed a stray vertical hairline that could appear in the toolbar next to the inspector after dragging a divider or toggling the sidebar.
- Toggling the sidebar or resizing the window no longer nudges the inspector's width; the terminal absorbs the change.