### PR TITLE
Stop sidebar layout churn behind the beachball family

### DIFF
--- a/Shared/Sources/TermioShared/BrandIcons.swift
+++ b/Shared/Sources/TermioShared/BrandIcons.swift
@@ -538,7 +538,7 @@ public struct BrandLogoShape: Shape {
     }
 
     public func path(in rect: CGRect) -> Path {
-        scaledVectorPath(SVGPath(logo.pathData).cgPath, viewBox: logo.viewBox, in: rect)
+        scaledVectorPath(VectorGlyphCache.glyph(for: logo.pathData).glyph, viewBox: logo.viewBox, in: rect)
     }
 }
 
@@ -606,7 +606,7 @@ public struct OcticonShape: Shape {
     }
 
     public func path(in rect: CGRect) -> Path {
-        scaledVectorPath(SVGPath(icon.pathData).cgPath, viewBox: icon.viewBox, in: rect)
+        scaledVectorPath(VectorGlyphCache.glyph(for: icon.pathData).glyph, viewBox: icon.viewBox, in: rect)
     }
 }
 
@@ -657,8 +657,7 @@ public struct HugeIconShape: Shape {
         // width to a fixed fraction of the box — the terminal mark's own 18/24
         // fill — keeps the terminal identical while pulling wider marks in to
         // match it, so same-`size` HugeIcons line up.
-        let glyph = SVGPath(icon.pathData).cgPath
-        let ink = glyph.boundingBoxOfPath
+        let (glyph, ink) = VectorGlyphCache.glyph(for: icon.pathData)
         guard ink.width > 0, ink.height > 0 else { return Path(glyph) }
         let targetWidth = rect.width * (18.0 / 24.0)
         let scale = min(targetWidth / ink.width, rect.height / ink.height)
@@ -685,6 +684,27 @@ private func scaledVectorPath(_ glyph: CGPath, viewBox: CGFloat, in rect: CGRect
 }
 
 // MARK: - SVG path parser
+
+/// Parsed glyphs, keyed by their SVG path string. A `Shape`'s `path(in:)` runs
+/// on every layout pass, and parsing a real Hugeicons path measures ~171µs —
+/// free for one icon drawn once, real main-thread money for a sidebar of marks
+/// laid out 30 times a second (docs/design/20260819-workspace-switch-latency.md).
+/// The glyph and its ink box are immutable, so they are parsed once and reused;
+/// the icon set is a fixed catalog, so the cache needs no eviction.
+public enum VectorGlyphCache {
+    private static let lock = NSLock()
+    private static var parsed: [String: (glyph: CGPath, ink: CGRect)] = [:]
+
+    public static func glyph(for pathData: String) -> (glyph: CGPath, ink: CGRect) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let hit = parsed[pathData] { return hit }
+        let glyph = SVGPath(pathData).cgPath
+        let entry = (glyph: glyph, ink: glyph.boundingBoxOfPath)
+        parsed[pathData] = entry
+        return entry
+    }
+}
 
 /// A small parser for the subset of SVG path syntax used by the embedded
 /// brand marks — moveto/lineto/horizontal/vertical, cubic and quadratic

--- a/Shared/Sources/TermioShared/SessionStatus.swift
+++ b/Shared/Sources/TermioShared/SessionStatus.swift
@@ -96,7 +96,13 @@ public struct WorkingIndicator: View {
             // comet is visually identical at 30Hz, and an uncapped timeline
             // ran this body at 120Hz per working row on ProMotion — enough to
             // saturate the main thread once a few sessions worked at once.
-            TimelineView(.animation(minimumInterval: 1.0 / 30)) { context in
+            //
+            // `.periodic`, not `.animation`: the animation clock wraps every
+            // tick in an animation transaction, and on macOS that makes the
+            // hosting view re-negotiate its size each tick (FB13810482) — the
+            // whole window's layout walked 30 times a second per working row.
+            // A periodic tick just redraws this Canvas.
+            TimelineView(.periodic(from: .now, by: 1.0 / 30)) { context in
                 let p = context.date.timeIntervalSinceReferenceDate
                     .truncatingRemainder(dividingBy: period) / period
                 grid(phase: p)

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -623,6 +623,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let sidebar = NSHostingController(rootView: SidebarView()
             .environmentObject(store)
             .environmentObject(settings))
+        // Same reason as the detail pane below: the default `.preferredContentSize`
+        // publishes the tree's ideal size on every view update, so a 30Hz working
+        // indicator re-negotiated the split layout 30 times a second. The split
+        // item's min/max thickness governs the column; the content never should.
+        sidebar.sizingOptions = []
         let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebar)
         // The sidebar's toolbar region must hold the traffic lights, the navigator toggle, and
         // (while open) the sort pull-down + new-terminal button; below ~240 the trailing `+`

--- a/Sources/termio/App/BrandIcons.swift
+++ b/Sources/termio/App/BrandIcons.swift
@@ -189,7 +189,7 @@ struct BrandLogoShape: Shape {
     let logo: BrandLogo
 
     func path(in rect: CGRect) -> Path {
-        scaledVectorPath(SVGPath(logo.pathData).cgPath, viewBox: logo.viewBox, in: rect)
+        scaledVectorPath(VectorGlyphCache.glyph(for: logo.pathData).glyph, viewBox: logo.viewBox, in: rect)
     }
 }
 
@@ -293,7 +293,7 @@ private struct CodiconShape: Shape {
     let viewBox: CGFloat
 
     func path(in rect: CGRect) -> Path {
-        scaledVectorPath(SVGPath(pathData).cgPath, viewBox: viewBox, in: rect)
+        scaledVectorPath(VectorGlyphCache.glyph(for: pathData).glyph, viewBox: viewBox, in: rect)
     }
 }
 
@@ -344,7 +344,7 @@ private struct ForgeMarkShape: Shape {
     let forge: GitService.Forge
 
     func path(in rect: CGRect) -> Path {
-        scaledVectorPath(SVGPath(forge.pathData).cgPath, viewBox: 24, in: rect)
+        scaledVectorPath(VectorGlyphCache.glyph(for: forge.pathData).glyph, viewBox: 24, in: rect)
     }
 }
 

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -664,12 +664,19 @@ private struct SessionRowDragAndDrop: ViewModifier {
             //
             // The height comes off the row itself because the zones are fractions of it;
             // rows grow with the interface row padding, so a fixed band would drift.
-            .background(
-                GeometryReader { proxy in
-                    Color.clear.onAppear { rowHeight = proxy.size.height }
-                        .onChange(of: proxy.size.height) { _, new in rowHeight = new }
-                }
-            )
+            //
+            // `onGeometryChange`, not a `GeometryReader` background: the reader wrote
+            // `rowHeight` from `onAppear`/`onChange` *inside* the layout pass, and a
+            // column of rows mounting at once turned that into reentrant NSTableView
+            // layout — AppKit warns, and a cold switch into a large workspace spent
+            // seconds re-laying the List (docs/bug/main-thread-beachball-sidebar-layout.md).
+            // `onGeometryChange` delivers the same height with the write deferred out
+            // of the update.
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                rowHeight = newHeight
+            }
             .onDrop(of: [.text], delegate: SessionRowDropDelegate(
                 session: session.id, height: rowHeight, store: store))
     }


### PR DESCRIPTION
Fixes the beachball family diagnosed in `docs/bug/main-thread-beachball-sidebar-layout.md`: workspace switches stalling the main thread for seconds (8.7s cold into a 37-session workspace, with AppKit's reentrant-NSTableView warning), and typing in agent TUIs freezing past spindump's 0.5s slow-HID threshold (13 OS-recorded events on 2026-09-04 alone).

Four changes, one per commit:

- **`WorkingIndicator` ticks on `.periodic`, not `.animation`.** The animation clock wraps each tick in an animation transaction, and on macOS that re-negotiates hosting-view size per tick (FB13810482) — the window's full layout tree walked 30×/s per working row. The comet is visually unchanged.
- **The sidebar hosting controller gets `sizingOptions = []`.** The default publishes the tree's ideal size on every view update; the split item's thickness bounds govern the column. Mirrors the detail pane's existing fix in the same function.
- **`VectorGlyphCache` parses each SVG path once.** Every `path(in:)` re-ran the parser (~171µs per real Hugeicons path, measured in `docs/design/20260819-workspace-switch-latency.md`) on every layout pass; the glyph and ink box are immutable.
- **Row height measurement moves to `onGeometryChange`.** The `GeometryReader` background wrote state from inside the layout pass; N rows mounting at once made that reentrant table layout — the super-linear cold-switch cost.

Verified: `swift build` and `swift test` green. The stall numbers are instrumented (`workspace column elapsed_ms`, spindump slow-HID lines), so before/after on a real workspace switch is one `log show` away; the cold-switch measurement should be re-taken on this branch per the bug doc's §4.

Release Notes:

- Fixed multi-second beachballs when switching to a workspace with many sessions.
- Fixed intermittent input freezes while agents are working: the sidebar's working indicator no longer drives whole-window layout on every tick, and icon rendering no longer re-parses vector paths on every pass.
