### PR TITLE
Support the OpenCode 2 beta as its own agent

### DIFF
--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -448,6 +448,9 @@ enum HookDialect: Hashable {
     /// Shipped plugin templates. Each names a closed host API; manifests provide
     /// only the destination directory and event→state data.
     case openCodePlugin
+    /// OpenCode 2's rewritten plugin API: a default-exported `{ id, setup }`
+    /// object consuming `ctx.event.subscribe`, with payloads under `data`.
+    case openCode2Plugin
     case piPlugin
     case ampPlugin
     /// Cline: a directory of executables named after the lifecycle event
@@ -1169,6 +1172,8 @@ struct AgentManifest: Decodable {
             dialect = .kimiTOML
         case (.plugin, "opencode"):
             dialect = .openCodePlugin
+        case (.plugin, "opencode2"):
+            dialect = .openCode2Plugin
         case (.plugin, "pi"):
             dialect = .piPlugin
         case (.plugin, "amp"):
@@ -1205,7 +1210,7 @@ struct AgentManifest: Decodable {
                     throw ManifestError.invalid(
                         "\(id): hook conversation must name a stdin JSON field, not '\(raw)'")
                 }
-            case .openCodePlugin:
+            case .openCodePlugin, .openCode2Plugin:
                 let components = raw.split(separator: ".", omittingEmptySubsequences: false)
                 guard !components.isEmpty, components.allSatisfy(isIdentifier) else {
                     throw ManifestError.invalid(

--- a/Sources/termio/Resources/agents/opencode2.json
+++ b/Sources/termio/Resources/agents/opencode2.json
@@ -1,0 +1,10 @@
+{
+  "id": "opencode2",
+  "order": 31,
+  "name": "OpenCode 2",
+  "wire": "opencode2",
+  "command": "opencode2",
+  "icon": { "asset": "opencode-favicon" },
+  "install": "https://opencode.ai/v2/docs/",
+  "skills": { "dir": "~/.config/opencode/skills" }
+}

--- a/Sources/termio/Resources/agents/opencode2.json
+++ b/Sources/termio/Resources/agents/opencode2.json
@@ -6,5 +6,16 @@
   "command": "opencode2",
   "icon": { "asset": "opencode-favicon" },
   "install": "https://opencode.ai/v2/docs/",
-  "skills": { "dir": "~/.config/opencode/skills" }
+  "skills": { "dir": "~/.config/opencode/skills" },
+  "hooks": {
+    "type": "plugin",
+    "dir": "~/.config/opencode/plugins",
+    "dialect": "opencode2",
+    "conversation": "data.sessionID",
+    "events": [
+      { "on": "session.status", "state": "working", "matcher": "busy" },
+      { "on": "session.status", "state": "done", "matcher": "idle" },
+      { "on": "permission.asked", "state": "attention" }
+    ]
+  }
 }

--- a/Tests/Fixtures/agent-manifests/expected.json
+++ b/Tests/Fixtures/agent-manifests/expected.json
@@ -806,6 +806,60 @@
   },
   {
     "definition": {
+      "command": "opencode2",
+      "configHome": null,
+      "displayName": "OpenCode 2",
+      "emitsProgressStatus": false,
+      "hooks": {
+        "capturesTranscript": false,
+        "conversation": "data.sessionID",
+        "dialect": "openCode2Plugin",
+        "directory": "~/.config/opencode/plugins",
+        "events": [
+          {
+            "matcher": "busy",
+            "name": "session.status",
+            "state": "working"
+          },
+          {
+            "matcher": "idle",
+            "name": "session.status",
+            "state": "done"
+          },
+          {
+            "matcher": null,
+            "name": "permission.asked",
+            "state": "attention"
+          }
+        ],
+        "file": null,
+        "promptTitle": null,
+        "tool": null,
+        "type": "plugin"
+      },
+      "icon": "image",
+      "id": "opencode2",
+      "installURL": "https://opencode.ai/v2/docs/",
+      "order": 31,
+      "permissionBypassFlag": null,
+      "resume": {
+        "create": null,
+        "discover": null,
+        "resume": null,
+        "seed": null,
+        "store": null
+      },
+      "skillDir": "~/.config/opencode/skills",
+      "statusRules": null,
+      "tintHex": null,
+      "titleRules": null,
+      "wireName": "opencode2"
+    },
+    "file": "Sources/termio/Resources/agents/opencode2.json",
+    "result": "ok"
+  },
+  {
+    "definition": {
       "command": "pi",
       "configHome": null,
       "displayName": "Pi",

--- a/Tests/termioTests/AgentManifestFixtureTests.swift
+++ b/Tests/termioTests/AgentManifestFixtureTests.swift
@@ -187,6 +187,7 @@ final class AgentManifestFixtureTests: XCTestCase {
         case .copilotFlat: return "copilotFlat"
         case .kimiTOML: return "kimiTOML"
         case .openCodePlugin: return "openCodePlugin"
+        case .openCode2Plugin: return "openCode2Plugin"
         case .piPlugin: return "piPlugin"
         case .ampPlugin: return "ampPlugin"
         case .clineScripts: return "clineScripts"

--- a/Tests/termioTests/SessionSkillTests.swift
+++ b/Tests/termioTests/SessionSkillTests.swift
@@ -70,6 +70,7 @@ final class SessionSkillTests: XCTestCase {
             "cursor": "~/.cursor/skills",
             "grok": "~/.grok/skills",
             "opencode": "~/.config/opencode/skills",
+            "opencode2": "~/.config/opencode/skills",
             "pi": "~/.pi/agent/skills",
             "amp": "~/.config/agents/skills",
             "antigravity": "~/.gemini/antigravity/skills",

--- a/termiod/src/agent/manifest.rs
+++ b/termiod/src/agent/manifest.rs
@@ -989,6 +989,7 @@ pub const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("agents/hermes.json", include_str!("../../../Sources/termio/Resources/agents/hermes.json")),
     ("agents/kimi.json", include_str!("../../../Sources/termio/Resources/agents/kimi.json")),
     ("agents/opencode.json", include_str!("../../../Sources/termio/Resources/agents/opencode.json")),
+    ("agents/opencode2.json", include_str!("../../../Sources/termio/Resources/agents/opencode2.json")),
     ("agents/pi.json", include_str!("../../../Sources/termio/Resources/agents/pi.json")),
     ("agents/qwen.json", include_str!("../../../Sources/termio/Resources/agents/qwen.json")),
 ];

--- a/termiod/src/agent/manifest.rs
+++ b/termiod/src/agent/manifest.rs
@@ -219,6 +219,9 @@ pub enum HookDialect {
     /// Kimi's marker-delimited TOML array-of-tables block.
     KimiToml,
     OpenCodePlugin,
+    /// OpenCode 2's rewritten plugin API: a default-exported `{ id, setup }`
+    /// object consuming `ctx.event.subscribe`, with payloads under `data`.
+    OpenCode2Plugin,
     PiPlugin,
     AmpPlugin,
     /// Cline: a directory of executables named after the lifecycle event.
@@ -233,6 +236,7 @@ impl HookDialect {
             HookDialect::CopilotFlat => "copilotFlat",
             HookDialect::KimiToml => "kimiTOML",
             HookDialect::OpenCodePlugin => "openCodePlugin",
+            HookDialect::OpenCode2Plugin => "openCode2Plugin",
             HookDialect::PiPlugin => "piPlugin",
             HookDialect::AmpPlugin => "ampPlugin",
             HookDialect::ClineScripts => "clineScripts",
@@ -711,6 +715,7 @@ impl AgentManifest {
             (HookType::Json, Some("copilot")) => HookDialect::CopilotFlat,
             (HookType::Toml, None | Some("kimi")) => HookDialect::KimiToml,
             (HookType::Plugin, Some("opencode")) => HookDialect::OpenCodePlugin,
+            (HookType::Plugin, Some("opencode2")) => HookDialect::OpenCode2Plugin,
             (HookType::Plugin, Some("pi")) => HookDialect::PiPlugin,
             (HookType::Plugin, Some("amp")) => HookDialect::AmpPlugin,
             (HookType::Scripts, None | Some("cline")) => HookDialect::ClineScripts,
@@ -753,7 +758,7 @@ impl AgentManifest {
                         )));
                     }
                 }
-                HookDialect::OpenCodePlugin => {
+                HookDialect::OpenCodePlugin | HookDialect::OpenCode2Plugin => {
                     let components: Vec<&str> = raw.split('.').collect();
                     if components.is_empty() || !components.iter().all(|c| is_identifier(c)) {
                         return Err(invalid(format!(

--- a/termiod/src/agent/plugin.rs
+++ b/termiod/src/agent/plugin.rs
@@ -38,7 +38,7 @@ fn js(value: &str) -> String {
 /// keeps a rename from leaving the agent loading two copies.
 pub fn filenames(dialect: HookDialect) -> Option<(&'static str, &'static str)> {
     match dialect {
-        HookDialect::OpenCodePlugin | HookDialect::PiPlugin => {
+        HookDialect::OpenCodePlugin | HookDialect::OpenCode2Plugin | HookDialect::PiPlugin => {
             Some(("termio.js", "termio-status.js"))
         }
         HookDialect::AmpPlugin => Some(("termio.ts", "termio-status.ts")),
@@ -55,6 +55,7 @@ pub fn source(
 ) -> Option<String> {
     match dialect {
         HookDialect::OpenCodePlugin => Some(open_code_source(events, conversation, request)),
+        HookDialect::OpenCode2Plugin => Some(open_code_2_source(events, conversation, request)),
         HookDialect::PiPlugin => Some(pi_source(events, conversation, request)),
         HookDialect::AmpPlugin => Some(amp_source(events, request)),
         _ => None,
@@ -91,16 +92,16 @@ fn session_declaration() -> &'static str {
 /// `conversation`, when the manifest declared a locator, rides along — on both
 /// machines now. Bun's `$` escapes each interpolation into one argv token, so
 /// the id needs no quoting of its own.
-fn daemon_report_body(shell: &str, carries_conversation: bool) -> String {
-    let mut body = String::from("    if (!session) return;\n");
+fn daemon_report_body(shell: &str, carries_conversation: bool, indent: &str) -> String {
+    let mut body = format!("{indent}if (!session) return;\n");
     if carries_conversation {
         body.push_str(&format!(
-            "    if (conversation && roots.has(conversation)) {{\n      \
-             return {shell}`${{cli}} set-status ${{session}} ${{state}} --conversation ${{conversation}}`.quiet().nothrow();\n    }}\n"
+            "{indent}if (conversation && roots.has(conversation)) {{\n{indent}  \
+             return {shell}`${{cli}} set-status ${{session}} ${{state}} --conversation ${{conversation}}`.quiet().nothrow();\n{indent}}}\n"
         ));
     }
     body.push_str(&format!(
-        "    return {shell}`${{cli}} set-status ${{session}} ${{state}}`.quiet().nothrow();"
+        "{indent}return {shell}`${{cli}} set-status ${{session}} ${{state}}`.quiet().nothrow();"
     ));
     body
 }
@@ -166,7 +167,7 @@ fn open_code_source(
             .to_string()
     };
 
-    let report_body = daemon_report_body("$", conversation_expression.is_some());
+    let report_body = daemon_report_body("$", conversation_expression.is_some(), "    ");
     let report_parameters = if conversation_expression.is_none() {
         "(state)"
     } else {
@@ -189,6 +190,112 @@ fn open_code_source(
          }};",
         cli_declaration(request),
         session_declaration()
+    )
+}
+
+/// OpenCode 2 plugin: the same lifecycle report as [`open_code_source`], spoken
+/// through the rewritten v2 plugin API. Verified against the shipped
+/// `@opencode-ai/plugin@0.0.0-beta-19242` and its client: the plugin is a
+/// default-exported `{ id, setup }` object (v2's `Plugin.define` is the
+/// identity function, so the file imports nothing from the package); events
+/// arrive through `ctx.event.subscribe`, an AsyncIterable, instead of a
+/// returned `event` hook; payload fields moved from `event.properties` to
+/// `event.data`; `session.idle` folded into `session.status` as
+/// `{ status: { type: "idle" } }`; and the permission event is
+/// `permission.asked`. Bun's `$` is imported from `"bun"` — plugins run
+/// in-process under Bun — so the report command is byte-identical to v1's.
+///
+/// Two shapes are deliberate. Setup returns without subscribing when no
+/// `TERMIOD_SESSION_ID` is present, so an opencode2 started outside termio does
+/// not hold an idle event stream open for the process's lifetime. And the
+/// returned cleanup aborts the subscription, because v2 unloads a plugin by
+/// running its cleanup — an orphaned iterator would keep reporting into a
+/// session that replaced its plugins.
+///
+/// Top-level session tracking works as in v1 on the flat v2 payload:
+/// `session.created` carries `sessionID` and, for subagent children,
+/// `parentID`, so only top-level ids are forwarded as the conversation.
+fn open_code_2_source(
+    events: &[HookEvent],
+    conversation: Option<&str>,
+    request: &InstallRequest,
+) -> String {
+    let conversation_expression = conversation.map(|path| {
+        let mut expression = String::from("event");
+        for component in path.split('.') {
+            expression.push_str(&format!("?.{component}"));
+        }
+        expression
+    });
+
+    let branches = events
+        .iter()
+        .map(|event| {
+            let arguments = match &conversation_expression {
+                Some(expression) => format!("{}, {expression}", js(&event.state)),
+                None => js(&event.state),
+            };
+            match &event.matcher {
+                Some(matcher) => format!(
+                    "        if (event.type === {} && event.data?.status?.type === {}) {{ report({arguments}); continue; }}",
+                    js(&event.name),
+                    js(matcher)
+                ),
+                None => format!(
+                    "        if (event.type === {}) {{ report({arguments}); continue; }}",
+                    js(&event.name)
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let identity = if conversation_expression.is_none() {
+        String::new()
+    } else {
+        "\n    const roots = new Set();\n    const note = (data) => {\n      \
+         if (!data?.sessionID) return;\n      \
+         if (data.parentID) roots.delete(data.sessionID); else roots.add(data.sessionID);\n    };"
+            .to_string()
+    };
+    let identity_branches = if conversation_expression.is_none() {
+        String::new()
+    } else {
+        "        if (event.type === \"session.created\") { note(event.data); continue; }\n        \
+         if (event.type === \"session.deleted\") { roots.delete(event.data?.sessionID); continue; }\n"
+            .to_string()
+    };
+
+    let report_body = daemon_report_body("$", conversation_expression.is_some(), "      ");
+    let report_parameters = if conversation_expression.is_none() {
+        "(state)"
+    } else {
+        "(state, conversation)"
+    };
+
+    format!(
+        "// termio agent status — reports OpenCode session lifecycle to termio.\n\
+         // Socket marker: {SOCKET_MARKER}\n\
+         import {{ $ }} from \"bun\";\n\
+         export default {{\n  \
+         id: \"termio-status\",\n  \
+         async setup(ctx) {{\n    \
+         {}\n    \
+         const session = process.env.TERMIOD_SESSION_ID;\n    \
+         if (!session) return;{identity}\n    \
+         const report = {report_parameters} => {{\n\
+         {report_body}\n    \
+         }};\n    \
+         const abort = new AbortController();\n    \
+         (async () => {{\n      \
+         for await (const event of ctx.event.subscribe({{ signal: abort.signal }})) {{\n\
+         {identity_branches}{branches}\n      \
+         }}\n    \
+         }})().catch(() => {{}});\n    \
+         return () => abort.abort();\n  \
+         }},\n\
+         }};",
+        cli_declaration(request)
     )
 }
 
@@ -267,7 +374,7 @@ fn amp_source(events: &[HookEvent], request: &InstallRequest) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let report_body = daemon_report_body("amp.$", false);
+    let report_body = daemon_report_body("amp.$", false, "    ");
     format!(
         "// termio agent status — reports Amp turn lifecycle to termio.\n\
          // Socket marker: {SOCKET_MARKER}\n\
@@ -296,6 +403,17 @@ mod tests {
                   {"on":"session.status","state":"working","matcher":"busy"},
                   {"on":"session.idle","state":"done"},
                   {"on":"permission.updated","state":"attention"}]}}"#,
+        )
+    }
+
+    fn opencode2_spec() -> crate::agent::manifest::HookSpec {
+        spec_of(
+            r#"{"id":"opencode2","name":"OpenCode 2","hooks":{"type":"plugin",
+                "dir":"~/.config/opencode/plugins","dialect":"opencode2",
+                "conversation":"data.sessionID","events":[
+                  {"on":"session.status","state":"working","matcher":"busy"},
+                  {"on":"session.status","state":"done","matcher":"idle"},
+                  {"on":"permission.asked","state":"attention"}]}}"#,
         )
     }
 
@@ -335,6 +453,7 @@ mod tests {
     fn one_template_serves_both_machines() {
         for (dialect, spec) in [
             (HookDialect::OpenCodePlugin, opencode_spec()),
+            (HookDialect::OpenCode2Plugin, opencode2_spec()),
             (HookDialect::PiPlugin, pi_spec()),
             (HookDialect::AmpPlugin, amp_spec()),
         ] {
@@ -399,6 +518,51 @@ export const TermioStatus = async ({ $ }) => {
     }
 
     #[test]
+    fn the_opencode2_plugin_renders_exactly() {
+        assert_eq!(
+            rendered(
+                HookDialect::OpenCode2Plugin,
+                &opencode2_spec(),
+                &device_request("/opt/termiod")
+            ),
+            r#"// termio agent status — reports OpenCode session lifecycle to termio.
+// Socket marker: agent-status.sock
+import { $ } from "bun";
+export default {
+  id: "termio-status",
+  async setup(ctx) {
+    const cli = "\/opt\/termiod";
+    const session = process.env.TERMIOD_SESSION_ID;
+    if (!session) return;
+    const roots = new Set();
+    const note = (data) => {
+      if (!data?.sessionID) return;
+      if (data.parentID) roots.delete(data.sessionID); else roots.add(data.sessionID);
+    };
+    const report = (state, conversation) => {
+      if (!session) return;
+      if (conversation && roots.has(conversation)) {
+        return $`${cli} set-status ${session} ${state} --conversation ${conversation}`.quiet().nothrow();
+      }
+      return $`${cli} set-status ${session} ${state}`.quiet().nothrow();
+    };
+    const abort = new AbortController();
+    (async () => {
+      for await (const event of ctx.event.subscribe({ signal: abort.signal })) {
+        if (event.type === "session.created") { note(event.data); continue; }
+        if (event.type === "session.deleted") { roots.delete(event.data?.sessionID); continue; }
+        if (event.type === "session.status" && event.data?.status?.type === "busy") { report("working", event?.data?.sessionID); continue; }
+        if (event.type === "session.status" && event.data?.status?.type === "idle") { report("done", event?.data?.sessionID); continue; }
+        if (event.type === "permission.asked") { report("attention", event?.data?.sessionID); continue; }
+      }
+    })().catch(() => {});
+    return () => abort.abort();
+  },
+};"#
+        );
+    }
+
+    #[test]
     fn the_pi_plugin_renders_exactly() {
         assert_eq!(
             rendered(HookDialect::PiPlugin, &pi_spec(), &device_request("/opt/termiod")),
@@ -446,6 +610,7 @@ export default (amp) => {
     fn a_plugin_outside_a_session_reports_nothing() {
         for (dialect, spec) in [
             (HookDialect::OpenCodePlugin, opencode_spec()),
+            (HookDialect::OpenCode2Plugin, opencode2_spec()),
             (HookDialect::PiPlugin, pi_spec()),
             (HookDialect::AmpPlugin, amp_spec()),
         ] {
@@ -462,6 +627,7 @@ export default (amp) => {
     fn every_generated_plugin_is_recognizable_as_ours() {
         for (dialect, spec) in [
             (HookDialect::OpenCodePlugin, opencode_spec()),
+            (HookDialect::OpenCode2Plugin, opencode2_spec()),
             (HookDialect::PiPlugin, pi_spec()),
             (HookDialect::AmpPlugin, amp_spec()),
         ] {


### PR DESCRIPTION
OpenCode 2's beta installs side by side with v1 as its own binary, `opencode2`, so a hand-started session matched no manifest and rendered without the agent icon (#604). This adds a separate roster entry — `opencode2.json`, embedded in the daemon's bundled list as well — so the icon and identity resolve through the existing exact-match command index on both ends, with no matcher changes.

**Status hooks (second commit).** The v1 plugin dialect cannot serve v2 — the plugin API was rewritten — so this adds an `opencode2` dialect whose generated file speaks the v2 contract, verified against the shipped `@opencode-ai/plugin@0.0.0-beta-19242` and its client types rather than the docs:

- a plugin is a default-exported `{ id, setup }` object (`Plugin.define` is the identity function, so the file imports nothing from the package)
- events arrive through `ctx.event.subscribe`, an `AsyncIterable`, instead of a returned `event` hook; setup returns a cleanup that aborts the subscription, and skips subscribing entirely outside a termiod session
- payload fields moved from `event.properties` to `event.data`; `session.idle` folded into `session.status` as `{ status: { type: "idle" } }`; the permission event is `permission.asked`
- Bun's `$` is imported from `"bun"` instead of arriving as a plugin argument, so the `set-status` report is byte-identical to v1's
- the file installs into v2's global `~/.config/opencode/plugins/` — the v1 file stays in `plugin/`, matching the side-by-side install

Top-level session tracking (the subagent filter) ports to the flat v2 payload: `session.created` carries `sessionID`/`parentID` directly.

What the manifest still omits, and why:

- **Resume discovery** — v2 sessions live in a SQLite database (`opencode.db`), not the JSON files the `discover` config reads.
- **Permission bypass flag** — unverified for the v2 CLI.

The global skills directory (`~/.config/opencode/skills`) is unchanged in v2, so it carries over and is covered by the bundled-skills test.

Verified with `swift build`, the full Swift suite (993 tests, including the cross-parser manifest fixture against the regenerated golden record), and the full daemon suite (315 tests, including an exact-render golden for the new dialect). Worth one manual pass on a real `opencode2` install — none exists on this machine — to confirm the icon, the plugin loading, and that v2 skips the v1 file it also discovers.

Closes #604

Release Notes:
- Sessions running the OpenCode 2 beta (`opencode2`) now show the OpenCode icon, appear as their own agent, and report working / needs-you / done status through a plugin built for OpenCode 2's new plugin API.