### PR TITLE
Add the standard Hide items to the app menu

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -3019,6 +3019,27 @@ private func buildMainMenu() -> NSMenu {
         keyEquivalent: ","
     )
     appMenu.addItem(.separator())
+    // The standard Hide block every Mac app carries and termio didn't, which is
+    // why ⌘H did nothing (#612) — the Window menu's ⌘M had the same history.
+    // The surface's performKeyEquivalent passes unbound ⌘-chords through, so
+    // these fire from the menu with no extra key plumbing.
+    appMenu.addItem(
+        withTitle: localized("Hide Termio"),
+        action: #selector(NSApplication.hide(_:)),
+        keyEquivalent: "h"
+    )
+    let hideOthersItem = appMenu.addItem(
+        withTitle: localized("Hide Others"),
+        action: #selector(NSApplication.hideOtherApplications(_:)),
+        keyEquivalent: "h"
+    )
+    hideOthersItem.keyEquivalentModifierMask = [.command, .option]
+    appMenu.addItem(
+        withTitle: localized("Show All"),
+        action: #selector(NSApplication.unhideAllApplications(_:)),
+        keyEquivalent: ""
+    )
+    appMenu.addItem(.separator())
     appMenu.addItem(
         withTitle: localized("Quit Termio"),
         action: #selector(NSApplication.terminate(_:)),

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2904,12 +2904,32 @@
         }
       }
     },
+    "Hide Others": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏其他"
+          }
+        }
+      }
+    },
     "Hide Replace": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "隐藏替换"
+          }
+        }
+      }
+    },
+    "Hide Termio": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏 Termio"
           }
         }
       }
@@ -6074,6 +6094,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示"
+          }
+        }
+      }
+    },
+    "Show All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部显示"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -594,8 +594,12 @@
 	<string>Group with</string>
 	<key>Hide</key>
 	<string>Hide</string>
+	<key>Hide Others</key>
+	<string>Hide Others</string>
 	<key>Hide Replace</key>
 	<string>Hide Replace</string>
+	<key>Hide Termio</key>
+	<string>Hide Termio</string>
 	<key>Hide or show the inspector</key>
 	<string>Hide or show the inspector</string>
 	<key>Hide or show the navigator</key>
@@ -1230,6 +1234,8 @@
 	<string>Shortcuts must include ⌘ so they can’t shadow a key an agent or the shell needs. While recording, press ⌫ to remove a shortcut, or esc to cancel.</string>
 	<key>Show</key>
 	<string>Show</string>
+	<key>Show All</key>
+	<string>Show All</string>
 	<key>Show Original</key>
 	<string>Show Original</string>
 	<key>Show Project Files</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -594,8 +594,12 @@
 	<string>编组到</string>
 	<key>Hide</key>
 	<string>隐藏</string>
+	<key>Hide Others</key>
+	<string>隐藏其他</string>
 	<key>Hide Replace</key>
 	<string>隐藏替换</string>
+	<key>Hide Termio</key>
+	<string>隐藏 Termio</string>
 	<key>Hide or show the inspector</key>
 	<string>隐藏或显示检查器</string>
 	<key>Hide or show the navigator</key>
@@ -1230,6 +1234,8 @@
 	<string>快捷键必须包含 ⌘，以免遮蔽 Agent 或 shell 所需的按键。录制时按 ⌫ 可移除快捷键，按 esc 取消。</string>
 	<key>Show</key>
 	<string>显示</string>
+	<key>Show All</key>
+	<string>全部显示</string>
 	<key>Show Original</key>
 	<string>显示原身</string>
 	<key>Show Project Files</key>


### PR DESCRIPTION
Fixes #612.

⌘H did nothing because the hand-built app menu never carried the standard Hide block a nib supplies for free — the same gap the Window menu once had with ⌘M. The keypress had no menu equivalent to match, so it fell through to the terminal surface and died there.

Adds the standard trio between Settings… and Quit:

- **Hide Termio** (⌘H) → `NSApplication.hide(_:)`
- **Hide Others** (⌥⌘H) → `NSApplication.hideOtherApplications(_:)`
- **Show All** → `NSApplication.unhideAllApplications(_:)`

No key plumbing needed: the surface's `performKeyEquivalent` already passes unbound ⌘-chords through to the menu (Ghostty's own Hide works the same way, via its MainMenu.xib). Strings are localized (zh-Hans matches Apple's system menu wording) and the compiled `.lproj` output is regenerated with `scripts/compile-strings.sh`.

Verified with `swift build`.

Release Notes:
- Fixed ⌘H not hiding the app; the app menu now has the standard Hide Termio, Hide Others, and Show All items.