### PR TITLE
Group directly-attached sessions by repo, and fix the phone's repaint after a shrink

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -957,10 +957,12 @@ public enum Termiod {
         /// which dot it becomes is the client's call.
         public let status: String
         public let agentID: String?
-        /// The workstream's project root, **on the device**. A client attached
-        /// straight to the host has no second source for it, so this is the only
-        /// thing that groups a flat session list into projects. `nil` for a
-        /// session with no workstream, and from a daemon too old to report one.
+        /// The workstream's project root, **on the device** — or, for a session
+        /// started without one, the root of the checkout its child is standing
+        /// in, as the daemon derived it. A client attached straight to the host
+        /// has no second source for it, so this is the only thing that groups a
+        /// flat session list into projects. `nil` for a session outside any
+        /// checkout, and from a daemon too old to report one.
         public let project: String?
         /// The title the agent reported, when it reported one.
         public let title: String?

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -259,7 +259,7 @@ final class TermiodSession: DeviceSession {
             // A screen parked before its attach landed has to say so: the device
             // counts every arrival as rendering.
             if !rendering { scheduleViewport() }
-            repaintPending = authoritativeGrid != viewportGrid
+            repaintPending = authoritativeGrid != surfaceGrid
             publishSharedGrid()
             if !pendingInput.isEmpty {
                 let buffered = pendingInput
@@ -382,7 +382,14 @@ final class TermiodSession: DeviceSession {
     private func applyAuthoritativeGrid(_ grid: TerminalGrid) {
         guard authoritativeGrid != grid else { return }
         authoritativeGrid = grid
-        repaintPending = grid != viewportGrid
+        // Armed against the grid the *surface* is laid out at, not this
+        // screen's viewport. The two part exactly when the PTY moves *to* this
+        // phone — typing here resizes the session to this viewport while the
+        // surface is still laid out at the old shared grid — and the child's
+        // redraw streams in before the layout pass catches up, parsed at the
+        // wrong grid. Keying on the viewport read that case as "nothing to
+        // repair", so the mangled screen stayed until the next reattach.
+        repaintPending = grid != surfaceGrid
         publishSharedGrid()
         guard grid != viewportGrid, viewportGrid.rows > 0 else { return }
         Log.device.info("""

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -1484,9 +1484,10 @@ pub struct SessionInfo {
     pub status: String,
     #[serde(default)]
     pub agent_id: Option<String>,
-    /// The workstream's project root. A client attached straight to this host
-    /// has no other source for it, and without it the roster is a flat list of
-    /// sessions with nothing to group them under.
+    /// The workstream's project root, or — for a session started without one —
+    /// the root of the checkout its child is standing in. A client attached
+    /// straight to this host has no other source for it, and without it the
+    /// roster is a flat list of sessions with nothing to group them under.
     #[serde(default)]
     pub project: Option<String>,
     #[serde(default)]

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -443,7 +443,19 @@ impl Session {
             alive: true,
             status: self.status.clone(),
             agent_id: self.workstream.as_ref().map(|w| w.agent_id.clone()),
-            project: self.workstream.as_ref().map(|w| w.project.clone()),
+            // A session created by a client names its project; one started by
+            // hand on this box carries none, so the checkout its child is
+            // standing in stands in — the repo root, not the raw cwd, because a
+            // cwd is wherever the user walked and filing by it would invent
+            // projects nobody opened (`TermiodRoster`, and the loose-terminal
+            // RFC). Cached by the foreground poll, so a roster request still
+            // costs no syscalls.
+            project: self
+                .workstream
+                .as_ref()
+                .map(|workstream| workstream.project.clone())
+                .filter(|project| !project.is_empty())
+                .or_else(|| self.foreground.current().repo_root.clone()),
             title: self.title.clone(),
             attached_clients: self.clients.len(),
             writer_client_id: self.writer.as_ref().map(ClientId::to_string),
@@ -4562,6 +4574,39 @@ mod tests {
         handle.send(SessionMsg::Kill {
             reason: EndReason::Killed,
         });
+    }
+
+    /// A session nobody named a project for — a shell started by hand on this
+    /// box — still groups under the checkout its child is standing in. The
+    /// repo root, found by walking up to `.git`, is what a directly attached
+    /// phone files the row under; without it every hand-started session lands
+    /// in the loose Terminals bucket.
+    #[tokio::test]
+    async fn a_hand_started_session_reports_the_checkout_it_stands_in() {
+        let cat = ["/bin/cat", "/usr/bin/cat"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+            .expect("no cat binary on this host");
+        let scratch = std::fs::canonicalize(std::env::temp_dir())
+            .expect("canonical temp dir")
+            .join(format!("termiod-project-root-{}", std::process::id()));
+        let checkout = scratch.join("checkout");
+        let nested = checkout.join("src");
+        std::fs::create_dir_all(&nested).expect("scratch tree");
+        std::fs::create_dir_all(checkout.join(".git")).expect("git dir");
+
+        let (handle, _events_rx, _on_exit) = start_session(
+            vec![cat.to_string()],
+            nested.to_str().expect("utf-8 path"),
+        );
+
+        let info = settled_info(&handle, |info| info.project.is_some()).await;
+        assert_eq!(info.project.as_deref(), checkout.to_str());
+
+        handle.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
+        std::fs::remove_dir_all(&scratch).expect("scratch cleanup");
     }
 
     /// A command started *inside* the session takes the tty's foreground away

--- a/termiod/src/session/foreground.rs
+++ b/termiod/src/session/foreground.rs
@@ -35,6 +35,12 @@ pub(crate) struct ForegroundSample {
     pub(super) argv: Option<Vec<String>>,
     pub(super) job: bool,
     pub(super) cwd: Option<String>,
+    /// The root of the git checkout `cwd` sits inside, or `None` outside one.
+    /// Derived here, on the blocking thread, so the roster can group a session
+    /// nobody named a project for — a shell started by hand on this box — under
+    /// the checkout it is actually standing in, without `info()` touching the
+    /// filesystem.
+    pub(super) repo_root: Option<String>,
 }
 
 /// The expensive half of a foreground sample, computed on a blocking thread and
@@ -48,6 +54,7 @@ pub(crate) struct ForegroundResolution {
     pid: Option<i32>,
     argv: Option<Vec<String>>,
     cwd: Option<String>,
+    repo_root: Option<String>,
     /// Only set when the session had not pinned its binary yet.
     executable: Option<ExecutableIdentity>,
 }
@@ -161,11 +168,14 @@ impl Foreground {
             // — and stop agreeing in a pipeline the moment it is not, which is
             // why the pid comes from the host rather than from that assumption.
             let pid = pgid.and_then(crate::proc::foreground_member);
+            let cwd = crate::proc::working_directory(child);
+            let repo_root = cwd.as_deref().and_then(repo_root);
             let _ = resolved.send(ForegroundResolution {
                 pgid,
                 pid,
                 argv: pid.and_then(crate::proc::process_arguments),
-                cwd: crate::proc::working_directory(child),
+                cwd,
+                repo_root,
                 executable: pin_executable
                     .then(|| crate::proc::executable_identity(child))
                     .flatten(),
@@ -196,6 +206,76 @@ impl Foreground {
             self.sample.cwd = resolution.cwd;
             changed = true;
         }
+        if self.sample.repo_root != resolution.repo_root {
+            self.sample.repo_root = resolution.repo_root;
+            changed = true;
+        }
         changed
+    }
+}
+
+/// The nearest ancestor of `cwd` holding a `.git` entry — a directory for a
+/// checkout, a file for a worktree. Walks *up* only, never down: descending
+/// from a home directory is what fires the macOS TCC prompts, and the upward
+/// walk is the repo-detection rule `20260713-loose-terminal-entity.md` set. A
+/// cwd outside any checkout answers `None`, which is what keeps a plain shell
+/// in `$HOME` a loose terminal.
+fn repo_root(cwd: &str) -> Option<String> {
+    let mut directory = std::path::Path::new(cwd);
+    loop {
+        if directory.join(".git").exists() {
+            return Some(directory.to_string_lossy().into_owned());
+        }
+        directory = directory.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::repo_root;
+
+    #[test]
+    fn repo_root_walks_up_to_the_checkout() {
+        let scratch =
+            std::env::temp_dir().join(format!("termiod-repo-root-{}", std::process::id()));
+        let checkout = scratch.join("checkout");
+        let nested = checkout.join("src").join("deep");
+        std::fs::create_dir_all(&nested).expect("scratch tree");
+        std::fs::create_dir_all(checkout.join(".git")).expect("git dir");
+
+        let root = repo_root(nested.to_str().expect("utf-8 path"));
+        assert_eq!(root.as_deref(), checkout.to_str());
+
+        std::fs::remove_dir_all(&scratch).expect("scratch cleanup");
+    }
+
+    #[test]
+    fn a_worktree_checkout_is_a_repo_too() {
+        // A linked worktree marks its root with a `.git` *file*, not a
+        // directory, and it is its own project root rather than the main
+        // checkout's.
+        let scratch =
+            std::env::temp_dir().join(format!("termiod-worktree-root-{}", std::process::id()));
+        let worktree = scratch.join("worktree");
+        std::fs::create_dir_all(&worktree).expect("scratch tree");
+        std::fs::write(worktree.join(".git"), "gitdir: elsewhere\n").expect("git file");
+
+        let root = repo_root(worktree.to_str().expect("utf-8 path"));
+        assert_eq!(root.as_deref(), worktree.to_str());
+
+        std::fs::remove_dir_all(&scratch).expect("scratch cleanup");
+    }
+
+    #[test]
+    fn a_directory_outside_any_checkout_is_loose() {
+        let scratch =
+            std::env::temp_dir().join(format!("termiod-loose-root-{}", std::process::id()));
+        std::fs::create_dir_all(&scratch).expect("scratch dir");
+
+        // temp_dir sits outside any checkout on every host this runs on, so
+        // the walk reaches the filesystem root and answers nothing.
+        assert_eq!(repo_root(scratch.to_str().expect("utf-8 path")), None);
+
+        std::fs::remove_dir_all(&scratch).expect("scratch cleanup");
     }
 }


### PR DESCRIPTION
A phone attached straight to a remote box saw its terminals but no project folders, and a full-screen agent redrew garbled after the PTY shrank to the phone's width. Both are on the direct-attach path (the phone talking to the box's termiod without a Mac in between).

## What changed

- **termiod derives a project for a hand-started session.** A session created through a client names its own project; one started by hand on the box (a plain ssh/bash shell) carried none, so a directly-attached phone filed every one under the loose "Terminals" bucket. termiod now reports the root of the git checkout the session's child is standing in — walking up to `.git` (a directory for a checkout, a file for a linked worktree), never down, so a plain shell in `$HOME` stays loose. The root is computed on the foreground poll's blocking thread and cached, so a roster request still touches no filesystem. No client change: `TermiodRoster.projects` already groups on this field.
- **iOS arms the repaint against the surface grid, not the viewport.** When the PTY moves to the phone, typing resizes the session to the phone's viewport while the surface is still laid out at the old shared grid, and the child's redraw streams in parsed at the wrong grid. Keying the repaint on the viewport read that as "nothing to repair", so the mangled screen stayed until the next reattach. It now keys on the grid the surface is actually laid out at.

## Tests

- `cargo test` — new: `repo_root_walks_up_to_the_checkout`, `a_worktree_checkout_is_a_repo_too`, `a_directory_outside_any_checkout_is_loose`, `a_hand_started_session_reports_the_checkout_it_stands_in`.
- `swift build` clean; iOS change is a two-line swap onto an existing property.

## Release Notes

- Sessions started by hand on a remote box now group under their git repository on a directly-attached iPhone, instead of all landing in Terminals.
- Fixed a garbled agent screen on iPhone after the terminal resized down to the phone.