### PR TITLE
Remove a worktree whose folder was deleted externally

### DIFF
--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -203,6 +203,19 @@ struct Worktree: Identifiable, Hashable, Codable {
     /// `applyDiscoveredWorktrees` reuses the existing entry by path rather than
     /// rebuilding it, so the flag rides along. A freshly discovered worktree is unpinned.
     var pinned = false
+    /// Whether git still holds a registration for this worktree but the checkout
+    /// itself is not usable — its folder deleted out from under git, most often.
+    ///
+    /// The row is kept in that state on purpose: it is the only way to reach the
+    /// removal that lets the registration go and tidies the branch. But there is
+    /// nothing to work *in*, so nothing offers to start a session there — a
+    /// folder that is not there would be handed to the daemon as a working
+    /// directory, and the session would open somewhere nobody asked for.
+    ///
+    /// Derived from git on every reconcile rather than persisted: it describes
+    /// the checkout right now, and a folder that came back between launches must
+    /// not read as missing until the first pass says so.
+    var missing = false
 }
 
 extension Worktree {

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -162,27 +162,50 @@ enum WorktreeService {
         return !FileManager.default.fileExists(atPath: mountPoint)
     }
 
-    /// The linked worktree paths for `repoRoot`, primary checkout excluded and paths
-    /// standardized. `nil` when `git worktree list` fails (not a work tree, or a git
-    /// error) — the caller treats `nil` as "leave the current list alone" and `[]` as
-    /// "git genuinely reports no linked worktrees" (safe to prune).
+    /// What a reconcile pass needs to merge git's worktrees into a project's,
+    /// with every path it will compare already resolved.
     ///
-    /// A `prunable` worktree — its directory deleted out from under git — is skipped,
-    /// as is any path that no longer exists on disk. Without this, a stale worktree
-    /// would show in the sidebar and a session started there would launch with a
-    /// missing cwd, so the shell silently falls back to `/` (the bug this guards
-    /// against).
-    static func linkedWorktrees(in repoRoot: String) async -> [String]? {
+    /// The resolving is the point. Matching a stored row against git's spelling
+    /// takes `canonicalPath`, which stats and reads links, and the merge itself
+    /// runs on the main actor — so a hung SMB mount or a stalled `/Volumes`
+    /// device would beachball the app on a pass that fires whenever an agent
+    /// touches git state. Those spellings are worked out here, off-main, and the
+    /// merge only looks them up.
+    struct Reconcile: Sendable {
+        /// Linked worktrees git reports and this machine can see, in git's order.
+        let discovered: [String]
+        /// Canonical spelling for every path the merge compares, by the spelling
+        /// it was asked about.
+        let canonical: [String: String]
+    }
+
+    /// The linked worktrees of `repoRoot`, primary checkout excluded, together
+    /// with canonical spellings for them and for `known` — the paths the caller
+    /// already holds. `nil` when `git worktree list` fails (not a work tree, or a
+    /// git error): the caller treats `nil` as "leave the current list alone" and
+    /// an empty `discovered` as "git genuinely reports no linked worktrees".
+    ///
+    /// A `prunable` worktree — its directory deleted out from under git — is
+    /// skipped, as is any path that no longer exists on disk. Without this, a
+    /// stale worktree would show in the sidebar and a session started there would
+    /// launch with a missing cwd, so the shell silently falls back to `/` (the
+    /// bug this guards against).
+    static func reconcile(in repoRoot: String, against known: [String]) async -> Reconcile? {
         await offMain {
             guard let all = records(in: repoRoot) else { return nil }
-            return all.dropFirst()                                      // primary checkout
+            let discovered = all.dropFirst()                            // primary checkout
                 .filter { !$0.bare && !$0.prunable }
-                .compactMap { record in
+                .compactMap { record -> String? in
                     var isDirectory: ObjCBool = false
                     guard FileManager.default.fileExists(atPath: record.path, isDirectory: &isDirectory),
                           isDirectory.boolValue else { return nil }
                     return URL(fileURLWithPath: record.path).standardizedFileURL.path
                 }
+            var canonical: [String: String] = [:]
+            for path in discovered + known where canonical[path] == nil {
+                canonical[path] = canonicalPath(path)
+            }
+            return Reconcile(discovered: discovered, canonical: canonical)
         }
     }
 

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -211,7 +211,8 @@ enum WorktreeService {
 
     /// The repo's worktree records, primary checkout first, in git's order. `nil`
     /// when `git worktree list` fails. Blocks on the git spawn — callers already on
-    /// a git-spawning path use it directly; use `linkedWorktrees` off-main.
+    /// a git-spawning path use it directly; `reconcile(in:against:)` is the
+    /// off-main entry point.
     static func records(in repoRoot: String) -> [Record]? {
         guard let out = run(["worktree", "list", "--porcelain"], in: repoRoot) else { return nil }
         return records(from: out)

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -7,40 +7,78 @@ import Foundation
 /// Git is the source of truth; `TermioStore` reconciles `Project.worktrees` against this
 /// (the one piece of git state termio used to mirror instead of read). Runs off-main.
 enum WorktreeService {
+    /// One record of `git worktree list --porcelain` — everything a caller decides
+    /// on: `prunable` means git itself judges the checkout gone (folder deleted, or
+    /// its `.git` gitfile damaged), and `locked` means git refuses to let go of it
+    /// (the convention for worktrees on removable media).
+    struct Record: Sendable {
+        /// The path as git printed it — its realpath spelling, which need not match
+        /// how the same folder is spelled elsewhere; callers canonicalize both
+        /// sides before comparing.
+        let path: String
+        /// The checked-out branch's short name; `nil` on a detached HEAD or a bare
+        /// entry.
+        let branch: String?
+        let bare: Bool
+        let locked: Bool
+        let prunable: Bool
+    }
+
     /// The linked worktree paths for `repoRoot`, primary checkout excluded and paths
     /// standardized. `nil` when `git worktree list` fails (not a work tree, or a git
     /// error) — the caller treats `nil` as "leave the current list alone" and `[]` as
     /// "git genuinely reports no linked worktrees" (safe to prune).
+    ///
+    /// A `prunable` worktree — its directory deleted out from under git — is skipped,
+    /// as is any path that no longer exists on disk. Without this, a stale worktree
+    /// would show in the sidebar and a session started there would launch with a
+    /// missing cwd, so the shell silently falls back to `/` (the bug this guards
+    /// against).
     static func linkedWorktrees(in repoRoot: String) async -> [String]? {
         await offMain {
-            guard let out = run(["worktree", "list", "--porcelain"], in: repoRoot) else { return nil }
-            return parse(out)
+            guard let all = records(in: repoRoot) else { return nil }
+            return all.dropFirst()                                      // primary checkout
+                .filter { !$0.bare && !$0.prunable }
+                .compactMap { record in
+                    var isDirectory: ObjCBool = false
+                    guard FileManager.default.fileExists(atPath: record.path, isDirectory: &isDirectory),
+                          isDirectory.boolValue else { return nil }
+                    return URL(fileURLWithPath: record.path).standardizedFileURL.path
+                }
         }
     }
 
-    /// Parses `git worktree list --porcelain`: blank-line-separated records, each opening
-    /// with `worktree <path>`. The first record is the primary checkout (dropped); `bare`
-    /// entries are skipped; what remains are the linked worktrees, in git's order.
-    ///
-    /// A `prunable` worktree — its directory deleted out from under git — is skipped, as is
-    /// any path that no longer exists on disk. Without this, a stale worktree would show in
-    /// the sidebar and a session started there would launch with a missing cwd, so the shell
-    /// silently falls back to `/` (the bug this guards against).
-    private static func parse(_ text: String) -> [String] {
-        var result: [String] = []
-        for (index, record) in text.components(separatedBy: "\n\n").enumerated() {
+    /// The repo's worktree records, primary checkout first, in git's order. `nil`
+    /// when `git worktree list` fails. Blocks on the git spawn — callers already on
+    /// a git-spawning path use it directly; use `linkedWorktrees` off-main.
+    static func records(in repoRoot: String) -> [Record]? {
+        guard let out = run(["worktree", "list", "--porcelain"], in: repoRoot) else { return nil }
+        return records(from: out)
+    }
+
+    /// Parses `git worktree list --porcelain`: blank-line-separated records, each
+    /// opening with `worktree <path>`. `locked` and `prunable` may carry a reason
+    /// after a space; `branch` is a full ref (`refs/heads/<name>`), reduced here to
+    /// the short name every caller wants.
+    static func records(from listing: String) -> [Record] {
+        listing.components(separatedBy: "\n\n").compactMap { record in
             let lines = record.split(separator: "\n", omittingEmptySubsequences: true)
-            guard let worktreeLine = lines.first(where: { $0.hasPrefix("worktree ") }) else { continue }
-            if index == 0 { continue }                                  // primary checkout
-            if lines.contains(where: { $0 == "bare" }) { continue }
-            if lines.contains(where: { $0.hasPrefix("prunable") }) { continue }
-            let path = String(worktreeLine.dropFirst("worktree ".count))
-            var isDirectory: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
-                  isDirectory.boolValue else { continue }
-            result.append(URL(fileURLWithPath: path).standardizedFileURL.path)
+            guard let worktreeLine = lines.first(where: { $0.hasPrefix("worktree ") }) else { return nil }
+            let branch = lines.first(where: { $0.hasPrefix("branch ") })
+                .map { String($0.dropFirst("branch ".count)) }
+                .map { reference in
+                    reference.hasPrefix("refs/heads/")
+                        ? String(reference.dropFirst("refs/heads/".count))
+                        : reference
+                }
+            return Record(
+                path: String(worktreeLine.dropFirst("worktree ".count)),
+                branch: branch,
+                bare: lines.contains { $0 == "bare" },
+                locked: lines.contains { $0 == "locked" || $0.hasPrefix("locked ") },
+                prunable: lines.contains { $0 == "prunable" || $0.hasPrefix("prunable ") }
+            )
         }
-        return result
     }
 
     // MARK: Process

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -27,9 +27,20 @@ enum WorktreeService {
     /// What a disk read can say about a checkout git can no longer inspect — the
     /// only evidence left once a worktree's `.git` gitfile is gone or git never
     /// knew the path at all.
+    ///
+    /// The three "nothing to protect" shapes are kept apart because each needs a
+    /// different move: a path that is gone needs nothing done to it, an empty
+    /// folder has to be cleared before git will deregister the worktree, and
+    /// something that is not a folder at all can only be reported — removing it
+    /// would delete a file this action was never pointed at.
     enum FolderEvidence: Equatable {
-        /// Nothing at the path, or a directory with nothing in it worth keeping.
-        case nothingToProtect
+        /// Nothing is at the path.
+        case gone
+        /// A directory with nothing in it worth keeping.
+        case emptyFolder
+        /// Something is at the path that is not a directory — a plain file, or a
+        /// symlink — so no checkout is there, and it is not ours to remove.
+        case occupied
         /// Entries are present, and nothing can tell whether they are work.
         case mayHoldWork
         /// The path could not be read, so nothing at all is known about it.
@@ -54,18 +65,19 @@ enum WorktreeService {
             attributes = try manager.attributesOfItem(atPath: path)
         } catch let error as NSError
             where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
-            return .nothingToProtect
+            return .gone
         } catch let error as NSError
             where error.domain == NSPOSIXErrorDomain && error.code == Int(ENOENT) {
-            return .nothingToProtect
+            return .gone
         } catch {
             // Something is there, and this could not find out what.
             return .unreadable
         }
-        // A path that is not a directory holds no checkout — deleted and replaced
-        // by a plain file, or a dangling symlink. Nothing here ever removes it.
+        // A path that is not a directory holds no checkout — replaced by a plain
+        // file, or a symlink, which this deliberately does not follow: whatever
+        // is on the other side was never part of the checkout.
         guard attributes[.type] as? FileAttributeType == .typeDirectory else {
-            return .nothingToProtect
+            return .occupied
         }
         let entries: [String]
         do {
@@ -73,7 +85,7 @@ enum WorktreeService {
         } catch {
             return .unreadable
         }
-        return entries.contains { $0 != ".DS_Store" } ? .mayHoldWork : .nothingToProtect
+        return entries.contains { $0 != ".DS_Store" } ? .mayHoldWork : .emptyFolder
     }
 
     /// The linked worktree paths for `repoRoot`, primary checkout excluded and paths

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -199,6 +199,16 @@ enum WorktreeService {
     struct Reconcile: Sendable {
         /// Linked worktrees git reports and this machine can see, in git's order.
         let discovered: [String]
+        /// Worktrees git still has a registration for but that cannot be used —
+        /// the folder gone, or git itself calling the record `prunable`.
+        ///
+        /// They are deliberately kept out of `discovered`: a row for a folder
+        /// that is not there is a row a session can be started in, and the shell
+        /// then opens somewhere nobody asked for. But a row that already exists
+        /// for one has to *stay*, because it is the only way to reach the removal
+        /// that lets go of the registration and tidies the branch. Dropping it
+        /// left both in the repository for good.
+        let stale: [String]
         /// Canonical spelling for every path the merge compares, by the spelling
         /// it was asked about.
         let canonical: [String: String]
@@ -218,46 +228,21 @@ enum WorktreeService {
     static func reconcile(in repoRoot: String, against known: [String]) async -> Reconcile? {
         await offMain {
             guard let all = records(in: repoRoot) else { return nil }
-            sweepVanishedWorktrees(all, in: repoRoot)
-            let discovered = all.dropFirst()                            // primary checkout
-                .filter { !$0.bare && !$0.prunable }
-                .compactMap { record -> String? in
-                    var isDirectory: ObjCBool = false
-                    guard FileManager.default.fileExists(atPath: record.path, isDirectory: &isDirectory),
-                          isDirectory.boolValue else { return nil }
-                    return URL(fileURLWithPath: record.path).standardizedFileURL.path
-                }
+            var discovered: [String] = []
+            var stale: [String] = []
+            for record in all.dropFirst() where !record.bare {   // primary checkout
+                let path = URL(fileURLWithPath: record.path).standardizedFileURL.path
+                var isDirectory: ObjCBool = false
+                let usable = !record.prunable
+                    && FileManager.default.fileExists(atPath: record.path, isDirectory: &isDirectory)
+                    && isDirectory.boolValue
+                if usable { discovered.append(path) } else { stale.append(path) }
+            }
             var canonical: [String: String] = [:]
-            for path in discovered + known where canonical[path] == nil {
+            for path in discovered + stale + known where canonical[path] == nil {
                 canonical[path] = canonicalPath(path)
             }
-            return Reconcile(discovered: discovered, canonical: canonical)
-        }
-    }
-
-    /// Deregister the worktrees whose folders are simply gone.
-    ///
-    /// These rows leave the sidebar on the next pass — `discovered` filters
-    /// `prunable` out — so without this nothing could ever reach them again:
-    /// the registration and its branch stayed in the repo for good, and a later
-    /// `git worktree add` at the same path was refused as already registered.
-    /// A successful removal used to sweep them as a side effect, by running
-    /// `git worktree prune` across the whole repo. That was the wrong tool —
-    /// it also deregistered worktrees holding work nobody had inspected — but
-    /// dropping it left the job undone.
-    ///
-    /// So each one is removed by name, and only where there is nothing to lose:
-    /// `.gone` is the path not being there at all, which is the one shape
-    /// `git worktree remove` settles without touching a file. A folder that
-    /// still holds anything, one this cannot read, one on a volume that is not
-    /// mounted, and one git is holding with `lock` are all left exactly as they
-    /// are for the user's own Remove to decide on. Branches are left alone too:
-    /// deleting a ref is not something a pass nobody asked for should do, and
-    /// the sweep this replaces never did either.
-    private static func sweepVanishedWorktrees(_ records: [Record], in repoRoot: String) {
-        for record in records.dropFirst() where record.prunable && !record.locked {
-            guard folderEvidence(at: record.path) == .gone else { continue }
-            _ = run(["worktree", "remove", record.path], in: repoRoot)
+            return Reconcile(discovered: discovered, stale: stale, canonical: canonical)
         }
     }
 

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -47,6 +47,37 @@ enum WorktreeService {
         case unreadable
     }
 
+    /// One spelling for a worktree path however it reaches us: git prints
+    /// realpaths, while a stored `Worktree.path` keeps whatever spelling created
+    /// it, so a symlinked ancestor (`/tmp`, `/var`, a linked home) makes the two
+    /// disagree.
+    ///
+    /// The resolution has to survive the path being *gone*, which is the whole
+    /// case this exists for. `resolvingSymlinksInPath` returns a path that does
+    /// not exist unchanged, so canonicalizing the leaf directly stopped working
+    /// at exactly the moment a worktree's folder was deleted: the stored row and
+    /// git's record no longer matched, the record read as absent, and a removal
+    /// dropped the row while git kept the registration for good. So the deepest
+    /// *existing* ancestor is resolved — that part is real, and both spellings
+    /// share it — and the missing components are appended back to it.
+    static func canonicalPath(_ path: String) -> String {
+        var missing: [String] = []
+        var probe = URL(fileURLWithPath: path).standardized
+        while !FileManager.default.fileExists(atPath: probe.path) {
+            let parent = probe.deletingLastPathComponent().standardized
+            // The root resolves to itself; without this a path on no existing
+            // volume at all would walk forever.
+            guard parent.path != probe.path else { return probe.path }
+            missing.append(probe.lastPathComponent)
+            probe = parent
+        }
+        var resolved = probe.resolvingSymlinksInPath()
+        for component in missing.reversed() {
+            resolved.appendPathComponent(component)
+        }
+        return resolved.path
+    }
+
     /// What is at `path`, for the callers that have no git left to ask.
     ///
     /// Fails closed, and that is the whole point of the return type: a read that
@@ -64,11 +95,14 @@ enum WorktreeService {
         do {
             attributes = try manager.attributesOfItem(atPath: path)
         } catch let error as NSError
-            where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
-            return .gone
-        } catch let error as NSError
-            where error.domain == NSPOSIXErrorDomain && error.code == Int(ENOENT) {
-            return .gone
+            where (error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError)
+            || (error.domain == NSPOSIXErrorDomain && error.code == Int(ENOENT)) {
+            // Absent is only "deleted" when the volume it would be on is here to
+            // say so. An unplugged drive answers `ENOENT` for everything on it,
+            // which would read as "nothing to protect" for a checkout sitting
+            // safely on the drive — the one shape this probe must not fail open
+            // on.
+            return volumeIsMissing(for: path) ? .unreadable : .gone
         } catch {
             // Something is there, and this could not find out what.
             return .unreadable
@@ -86,6 +120,27 @@ enum WorktreeService {
             return .unreadable
         }
         return entries.contains { $0 != ".DS_Store" } ? .mayHoldWork : .emptyFolder
+    }
+
+    /// Whether `path` names a volume that is not mounted right now.
+    ///
+    /// macOS mounts what a person plugs in or connects to under `/Volumes`, so a
+    /// path there whose volume directory is absent is an ejected drive or a
+    /// dropped share, not a deleted checkout. That is the case worth telling
+    /// apart: everything on such a volume answers "no such file", and letting go
+    /// of a worktree on that evidence deregisters a checkout that is still on
+    /// the drive, uncommitted work and all.
+    ///
+    /// It reads only the mount point, so a volume left mounted with the checkout
+    /// genuinely deleted still answers `.gone`, and a share mounted somewhere
+    /// other than `/Volumes` is not covered — `git worktree lock` is git's own
+    /// answer for those, and the removal honors it.
+    private static func volumeIsMissing(for path: String) -> Bool {
+        let components = URL(fileURLWithPath: path).standardized.pathComponents
+        // ["/", "Volumes", "<name>", …]
+        guard components.count > 2, components[1] == "Volumes" else { return false }
+        let mountPoint = "/\(components[1])/\(components[2])"
+        return !FileManager.default.fileExists(atPath: mountPoint)
     }
 
     /// The linked worktree paths for `repoRoot`, primary checkout excluded and paths

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -141,25 +141,50 @@ enum WorktreeService {
         return entries.contains { $0 != ".DS_Store" } ? .mayHoldWork : .emptyFolder
     }
 
-    /// Whether `path` names a volume that is not mounted right now.
+    /// Whether `path` is absent because what would hold it is not mounted.
     ///
-    /// macOS mounts what a person plugs in or connects to under `/Volumes`, so a
-    /// path there whose volume directory is absent is an ejected drive or a
-    /// dropped share, not a deleted checkout. That is the case worth telling
-    /// apart: everything on such a volume answers "no such file", and letting go
-    /// of a worktree on that evidence deregisters a checkout that is still on
+    /// That is the case worth telling apart from a deleted checkout: everything
+    /// on an ejected drive or a dropped share answers "no such file", and letting
+    /// go of a worktree on that evidence deregisters a checkout still sitting on
     /// the drive, uncommitted work and all.
     ///
-    /// It reads only the mount point, so a volume left mounted with the checkout
-    /// genuinely deleted still answers `.gone`, and a share mounted somewhere
-    /// other than `/Volumes` is not covered — `git worktree lock` is git's own
-    /// answer for those, and the removal honors it.
+    /// It asks where the path *stops* existing. A mount that is gone leaves its
+    /// mount point gone with it, so the deepest directory still there is the one
+    /// that was holding it — and two kinds of directory hold mounts: `/Volumes`,
+    /// which is where macOS puts what a person plugs in or connects to, and an
+    /// autofs trigger such as `/net`, which mounts on demand and reports its own
+    /// filesystem type. Neither test fires for a checkout deleted from a volume
+    /// that is still mounted: there the deepest existing directory is inside that
+    /// volume, not the container holding it.
+    ///
+    /// A share the user mounts somewhere of their own — `~/mnt/work` — cannot be
+    /// told from a deleted directory once it is unmounted, because nothing on
+    /// disk records that a mount belonged there. `git worktree lock` is git's own
+    /// answer for that, and the removal honors it.
     private static func volumeIsMissing(for path: String) -> Bool {
-        let components = URL(fileURLWithPath: path).standardized.pathComponents
-        // ["/", "Volumes", "<name>", …]
-        guard components.count > 2, components[1] == "Volumes" else { return false }
-        let mountPoint = "/\(components[1])/\(components[2])"
-        return !FileManager.default.fileExists(atPath: mountPoint)
+        guard let ancestor = deepestExistingAncestor(of: path) else { return false }
+        return ancestor == "/Volumes" || filesystemType(at: ancestor) == "autofs"
+    }
+
+    /// The deepest directory on `path` that exists, or `nil` when `path` itself
+    /// does — the caller only asks about paths that are absent.
+    private static func deepestExistingAncestor(of path: String) -> String? {
+        var probe = URL(fileURLWithPath: path).standardized
+        while !FileManager.default.fileExists(atPath: probe.path) {
+            let parent = probe.deletingLastPathComponent().standardized
+            guard parent.path != probe.path else { return nil }
+            probe = parent
+        }
+        return probe.path
+    }
+
+    /// The filesystem mounted at `path`, as the kernel names it.
+    private static func filesystemType(at path: String) -> String? {
+        var info = statfs()
+        guard statfs(path, &info) == 0 else { return nil }
+        return withUnsafeBytes(of: info.f_fstypename) { raw in
+            raw.bindMemory(to: CChar.self).baseAddress.map { String(cString: $0) }
+        }
     }
 
     /// What a reconcile pass needs to merge git's worktrees into a project's,
@@ -193,6 +218,7 @@ enum WorktreeService {
     static func reconcile(in repoRoot: String, against known: [String]) async -> Reconcile? {
         await offMain {
             guard let all = records(in: repoRoot) else { return nil }
+            sweepVanishedWorktrees(all, in: repoRoot)
             let discovered = all.dropFirst()                            // primary checkout
                 .filter { !$0.bare && !$0.prunable }
                 .compactMap { record -> String? in
@@ -206,6 +232,32 @@ enum WorktreeService {
                 canonical[path] = canonicalPath(path)
             }
             return Reconcile(discovered: discovered, canonical: canonical)
+        }
+    }
+
+    /// Deregister the worktrees whose folders are simply gone.
+    ///
+    /// These rows leave the sidebar on the next pass — `discovered` filters
+    /// `prunable` out — so without this nothing could ever reach them again:
+    /// the registration and its branch stayed in the repo for good, and a later
+    /// `git worktree add` at the same path was refused as already registered.
+    /// A successful removal used to sweep them as a side effect, by running
+    /// `git worktree prune` across the whole repo. That was the wrong tool —
+    /// it also deregistered worktrees holding work nobody had inspected — but
+    /// dropping it left the job undone.
+    ///
+    /// So each one is removed by name, and only where there is nothing to lose:
+    /// `.gone` is the path not being there at all, which is the one shape
+    /// `git worktree remove` settles without touching a file. A folder that
+    /// still holds anything, one this cannot read, one on a volume that is not
+    /// mounted, and one git is holding with `lock` are all left exactly as they
+    /// are for the user's own Remove to decide on. Branches are left alone too:
+    /// deleting a ref is not something a pass nobody asked for should do, and
+    /// the sweep this replaces never did either.
+    private static func sweepVanishedWorktrees(_ records: [Record], in repoRoot: String) {
+        for record in records.dropFirst() where record.prunable && !record.locked {
+            guard folderEvidence(at: record.path) == .gone else { continue }
+            _ = run(["worktree", "remove", record.path], in: repoRoot)
         }
     }
 

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -63,11 +63,30 @@ enum WorktreeService {
     static func canonicalPath(_ path: String) -> String {
         var missing: [String] = []
         var probe = URL(fileURLWithPath: path).standardized
+        var hops = 0
         while !FileManager.default.fileExists(atPath: probe.path) {
+            // A symlink whose target is gone still says where it pointed, and
+            // that is the spelling git recorded. `resolvingSymlinksInPath` gives
+            // up on one, which left a worktree under a symlinked ancestor
+            // unmatchable once that target went — the row and its sessions
+            // dropped while git kept the registration for good. The hop count is
+            // for a link that points at itself.
+            if hops < 32,
+               let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: probe.path) {
+                hops += 1
+                probe = (destination.hasPrefix("/")
+                    ? URL(fileURLWithPath: destination)
+                    : probe.deletingLastPathComponent().appendingPathComponent(destination))
+                    .standardized
+                continue
+            }
             let parent = probe.deletingLastPathComponent().standardized
             // The root resolves to itself; without this a path on no existing
-            // volume at all would walk forever.
-            guard parent.path != probe.path else { return probe.path }
+            // volume at all would walk forever. Breaking rather than returning
+            // keeps the components gathered so far, which a bare return dropped
+            // — collapsing every path to `/`, where any row would match any
+            // record.
+            guard parent.path != probe.path else { break }
             missing.append(probe.lastPathComponent)
             probe = parent
         }

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -24,6 +24,58 @@ enum WorktreeService {
         let prunable: Bool
     }
 
+    /// What a disk read can say about a checkout git can no longer inspect — the
+    /// only evidence left once a worktree's `.git` gitfile is gone or git never
+    /// knew the path at all.
+    enum FolderEvidence: Equatable {
+        /// Nothing at the path, or a directory with nothing in it worth keeping.
+        case nothingToProtect
+        /// Entries are present, and nothing can tell whether they are work.
+        case mayHoldWork
+        /// The path could not be read, so nothing at all is known about it.
+        case unreadable
+    }
+
+    /// What is at `path`, for the callers that have no git left to ask.
+    ///
+    /// Fails closed, and that is the whole point of the return type: a read that
+    /// throws answers `.unreadable`, never `.nothingToProtect`. A folder behind a
+    /// permission or TCC denial is one nothing has looked inside, and reading that
+    /// as "empty, safe to let go of" is how an unreadable checkout full of
+    /// uncommitted work gets deregistered.
+    ///
+    /// `.DS_Store` is Finder's, not the user's: a folder emptied in the Finder
+    /// keeps one, and counting it as work would dead-end a removal on a worktree
+    /// with nothing in it.
+    static func folderEvidence(at path: String) -> FolderEvidence {
+        let manager = FileManager.default
+        let attributes: [FileAttributeKey: Any]
+        do {
+            attributes = try manager.attributesOfItem(atPath: path)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+            return .nothingToProtect
+        } catch let error as NSError
+            where error.domain == NSPOSIXErrorDomain && error.code == Int(ENOENT) {
+            return .nothingToProtect
+        } catch {
+            // Something is there, and this could not find out what.
+            return .unreadable
+        }
+        // A path that is not a directory holds no checkout — deleted and replaced
+        // by a plain file, or a dangling symlink. Nothing here ever removes it.
+        guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+            return .nothingToProtect
+        }
+        let entries: [String]
+        do {
+            entries = try manager.contentsOfDirectory(atPath: path)
+        } catch {
+            return .unreadable
+        }
+        return entries.contains { $0 != ".DS_Store" } ? .mayHoldWork : .nothingToProtect
+    }
+
     /// The linked worktree paths for `repoRoot`, primary checkout excluded and paths
     /// standardized. `nil` when `git worktree list` fails (not a work tree, or a git
     /// error) — the caller treats `nil` as "leave the current list alone" and `[]` as

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -199,7 +199,7 @@ enum WorktreeService {
     struct Reconcile: Sendable {
         /// Linked worktrees git reports and this machine can see, in git's order.
         let discovered: [String]
-        /// Worktrees git still has a registration for but that cannot be used —
+        /// Worktrees git still has a registration for but that cannot be offered —
         /// the folder gone, or git itself calling the record `prunable`.
         ///
         /// They are deliberately kept out of `discovered`: a row for a folder
@@ -209,6 +209,12 @@ enum WorktreeService {
         /// that lets go of the registration and tidies the branch. Dropping it
         /// left both in the repository for good.
         let stale: [String]
+        /// Of the stale ones, those with nowhere to work at all: the path gone, or
+        /// something that is not a directory sitting at it. A row for one of these
+        /// offers no way to start a session, because there is nowhere to start it
+        /// — while a stale row whose folder is still full keeps every verb, since
+        /// opening a terminal in it is how the user reaches their own files.
+        let absent: [String]
         /// Canonical spelling for every path the merge compares, by the spelling
         /// it was asked about.
         let canonical: [String: String]
@@ -220,29 +226,50 @@ enum WorktreeService {
     /// git error): the caller treats `nil` as "leave the current list alone" and
     /// an empty `discovered` as "git genuinely reports no linked worktrees".
     ///
-    /// A `prunable` worktree — its directory deleted out from under git — is
-    /// skipped, as is any path that no longer exists on disk. Without this, a
-    /// stale worktree would show in the sidebar and a session started there would
-    /// launch with a missing cwd, so the shell silently falls back to `/` (the
-    /// bug this guards against).
+    /// A worktree git calls `prunable`, and any whose path is not a directory,
+    /// is reported `stale` rather than offered: no row is created for one, because
+    /// a row for a checkout that cannot be opened is a row a session starts in,
+    /// and the shell then lands somewhere nobody asked for. A row that already
+    /// exists keeps its place, so the removal stays reachable.
+    ///
+    /// `absent` is the narrower question of whether there is anywhere to work at
+    /// all, which is a different thing from git having lost track: a worktree
+    /// whose `.git` gitfile was deleted is `prunable` with every one of the user's
+    /// files still in place, and a terminal opened there is exactly what they need
+    /// to get those files out.
     static func reconcile(in repoRoot: String, against known: [String]) async -> Reconcile? {
         await offMain {
             guard let all = records(in: repoRoot) else { return nil }
             var discovered: [String] = []
             var stale: [String] = []
+            var absent: [String] = []
             for record in all.dropFirst() where !record.bare {   // primary checkout
                 let path = URL(fileURLWithPath: record.path).standardizedFileURL.path
                 var isDirectory: ObjCBool = false
-                let usable = !record.prunable
-                    && FileManager.default.fileExists(atPath: record.path, isDirectory: &isDirectory)
+                let openable = FileManager.default
+                    .fileExists(atPath: record.path, isDirectory: &isDirectory)
                     && isDirectory.boolValue
-                if usable { discovered.append(path) } else { stale.append(path) }
+                if !record.prunable && openable {
+                    discovered.append(path)
+                    continue
+                }
+                stale.append(path)
+                // Only where there is no folder to work in. A directory that is
+                // still there — even one git has lost its way to — can be opened,
+                // and telling the user otherwise left them with a row they could
+                // neither use nor remove and advice that would have deleted their
+                // files.
+                switch folderEvidence(at: record.path) {
+                case .gone, .occupied: absent.append(path)
+                case .emptyFolder, .mayHoldWork, .unreadable: break
+                }
             }
             var canonical: [String: String] = [:]
             for path in discovered + stale + known where canonical[path] == nil {
                 canonical[path] = canonicalPath(path)
             }
-            return Reconcile(discovered: discovered, stale: stale, canonical: canonical)
+            return Reconcile(
+                discovered: discovered, stale: stale, absent: absent, canonical: canonical)
         }
     }
 

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6718,16 +6718,6 @@
         }
       }
     },
-    "The folder was removed, but git couldn’t prune its stale worktree metadata.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文件夹已移除，但 git 无法清理其残留的 worktree 元数据。"
-          }
-        }
-      }
-    },
     "The ignore rule couldn’t be added.": {
       "localizations": {
         "zh-Hans": {
@@ -7739,16 +7729,6 @@
         }
       }
     },
-    "Worktree removed": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Worktree 已移除"
-          }
-        }
-      }
-    },
     "Yesterday": {
       "localizations": {
         "zh-Hans": {
@@ -8101,6 +8081,36 @@
           "stringUnit": {
             "state": "translated",
             "value": "“%@”未安装，正在显示系统默认字体。"
+          }
+        }
+      }
+    },
+    "Worktree is locked": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 已锁定"
+          }
+        }
+      }
+    },
+    "Unlock “%@” (git worktree unlock) before removing it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请先解锁“%@”（git worktree unlock）再移除。"
+          }
+        }
+      }
+    },
+    "git still lists “%@”, so it was not removed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "git 仍列出“%@”，因此未移除。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -8154,6 +8154,16 @@
           }
         }
       }
+    },
+    "termio couldn’t remove the empty folder at “%@”, so the worktree was not removed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "termio 无法删除“%@”处的空文件夹，因此未移除 worktree。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -8164,6 +8164,16 @@
           }
         }
       }
+    },
+    "git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "git 已不再跟踪“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -8125,12 +8125,22 @@
         }
       }
     },
-    "git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.": {
+    "git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "git 已无法读取“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。"
+            "value": "git 已不再跟踪“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。"
+          }
+        }
+      }
+    },
+    "termio couldn’t read “%@”, so it was not removed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "termio 无法读取“%@”，因此未移除。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -8114,6 +8114,26 @@
           }
         }
       }
+    },
+    "git couldn’t read this project’s worktrees, so “%@” was not removed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "git 无法读取此项目的 worktree，因此未移除“%@”。"
+          }
+        }
+      }
+    },
+    "git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "git 已无法读取“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -8125,22 +8125,32 @@
         }
       }
     },
-    "git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "git 已不再跟踪“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。"
-          }
-        }
-      }
-    },
     "termio couldn’t read “%@”, so it was not removed.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "termio 无法读取“%@”，因此未移除。"
+          }
+        }
+      }
+    },
+    "git can no longer inspect “%@”, and its folder still holds files. Delete the folder to remove the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "git 已无法检查“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。"
+          }
+        }
+      }
+    },
+    "Something other than a folder is at “%@”. Move or delete it, then remove the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@”所在位置现在不是文件夹。请先移走或删除它，再移除 worktree。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1606,6 +1606,8 @@
 	<string>git couldn’t read this project’s worktrees, so “%@” was not removed.</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git couldn’t remove “%@”.</string>
+	<key>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</string>
 	<key>git still lists “%@”, so it was not removed.</key>
 	<string>git still lists “%@”, so it was not removed.</string>
 	<key>issue.state.open</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1594,8 +1594,6 @@
 	<string>e.g. JetBrains Mono</string>
 	<key>first %1$lld of %2$lld files</key>
 	<string>first %1$lld of %2$lld files</string>
-	<key>git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
-	<string>git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git couldn’t check “%@” for changes, so it was not removed.</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>
@@ -1604,6 +1602,8 @@
 	<string>git couldn’t read this project’s worktrees, so “%@” was not removed.</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git couldn’t remove “%@”.</string>
+	<key>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</string>
 	<key>git still lists “%@”, so it was not removed.</key>
 	<string>git still lists “%@”, so it was not removed.</string>
 	<key>issue.state.open</key>
@@ -1626,6 +1626,8 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 	<string>termio can teach the agents you run (Claude Code, Codex, …) a `termio sessions` command so they can see, drive, and read each other's sessions in a project.
 
 Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks. You can turn it off anytime in Settings ▸ Agents.</string>
+	<key>termio couldn’t read “%@”, so it was not removed.</key>
+	<string>termio couldn’t read “%@”, so it was not removed.</string>
 	<key>termiod on %@ never opened its listener.
 %@</key>
 	<string>termiod on %@ never opened its listener.

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1594,10 +1594,14 @@
 	<string>e.g. JetBrains Mono</string>
 	<key>first %1$lld of %2$lld files</key>
 	<string>first %1$lld of %2$lld files</string>
+	<key>git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git couldn’t check “%@” for changes, so it was not removed.</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>
 	<string>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</string>
+	<key>git couldn’t read this project’s worktrees, so “%@” was not removed.</key>
+	<string>git couldn’t read this project’s worktrees, so “%@” was not removed.</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git couldn’t remove “%@”.</string>
 	<key>git still lists “%@”, so it was not removed.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1630,6 +1630,8 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks. You can turn it off anytime in Settings ▸ Agents.</string>
 	<key>termio couldn’t read “%@”, so it was not removed.</key>
 	<string>termio couldn’t read “%@”, so it was not removed.</string>
+	<key>termio couldn’t remove the empty folder at “%@”, so the worktree was not removed.</key>
+	<string>termio couldn’t remove the empty folder at “%@”, so the worktree was not removed.</string>
 	<key>termiod on %@ never opened its listener.
 %@</key>
 	<string>termiod on %@ never opened its listener.

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1358,8 +1358,6 @@
 	<string>The device couldn’t read this comparison.</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
 	<string>The devices in your ~/.ssh/config, and the keys that reach them</string>
-	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
-	<string>The folder was removed, but git couldn’t prune its stale worktree metadata.</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>The ignore rule couldn’t be added.</string>
 	<key>The install page — the same one whichever machine you are installing on.</key>
@@ -1494,6 +1492,8 @@
 	<string>Underline</string>
 	<key>Ungroup</key>
 	<string>Ungroup</string>
+	<key>Unlock “%@” (git worktree unlock) before removing it.</key>
+	<string>Unlock “%@” (git worktree unlock) before removing it.</string>
 	<key>Unpin</key>
 	<string>Unpin</string>
 	<key>Unsaved changes — press ⌘S to save to %@</key>
@@ -1562,8 +1562,8 @@
 	<string>Workspaces</string>
 	<key>Worktree has changes</key>
 	<string>Worktree has changes</string>
-	<key>Worktree removed</key>
-	<string>Worktree removed</string>
+	<key>Worktree is locked</key>
+	<string>Worktree is locked</string>
 	<key>Yesterday</key>
 	<string>Yesterday</string>
 	<key>You can restore it from the Trash.</key>
@@ -1600,6 +1600,8 @@
 	<string>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git couldn’t remove “%@”.</string>
+	<key>git still lists “%@”, so it was not removed.</key>
+	<string>git still lists “%@”, so it was not removed.</string>
 	<key>issue.state.open</key>
 	<string>Open</string>
 	<key>macOS hasn’t been asked to allow Termio’s notifications yet.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1270,6 +1270,8 @@
 	<string>Somebody else wrote this file after you opened it. Overwriting replaces their version.</string>
 	<key>Something else already owns %@.</key>
 	<string>Something else already owns %@.</string>
+	<key>Something other than a folder is at “%@”. Move or delete it, then remove the worktree.</key>
+	<string>Something other than a folder is at “%@”. Move or delete it, then remove the worktree.</string>
 	<key>Something went wrong loading this repository. Try again in a moment.</key>
 	<string>Something went wrong loading this repository. Try again in a moment.</string>
 	<key>Sort</key>
@@ -1594,6 +1596,8 @@
 	<string>e.g. JetBrains Mono</string>
 	<key>first %1$lld of %2$lld files</key>
 	<string>first %1$lld of %2$lld files</string>
+	<key>git can no longer inspect “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git can no longer inspect “%@”, and its folder still holds files. Delete the folder to remove the worktree.</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git couldn’t check “%@” for changes, so it was not removed.</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>
@@ -1602,8 +1606,6 @@
 	<string>git couldn’t read this project’s worktrees, so “%@” was not removed.</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git couldn’t remove “%@”.</string>
-	<key>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
-	<string>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</string>
 	<key>git still lists “%@”, so it was not removed.</key>
 	<string>git still lists “%@”, so it was not removed.</string>
 	<key>issue.state.open</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1630,6 +1630,8 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 启用后会在你的 ~/.claude/CLAUDE.md 中添加一段简短说明并安装状态 hooks。你可以随时在“设置 ▸ Agents”中将其关闭。</string>
 	<key>termio couldn’t read “%@”, so it was not removed.</key>
 	<string>termio 无法读取“%@”，因此未移除。</string>
+	<key>termio couldn’t remove the empty folder at “%@”, so the worktree was not removed.</key>
+	<string>termio 无法删除“%@”处的空文件夹，因此未移除 worktree。</string>
 	<key>termiod on %@ never opened its listener.
 %@</key>
 	<string>%1$@ 上的 termiod 始终没有打开监听器。

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1270,6 +1270,8 @@
 	<string>在你打开之后，有人写入了这个文件。覆盖会替换掉对方的版本。</string>
 	<key>Something else already owns %@.</key>
 	<string>%@ 已被其他程序占用。</string>
+	<key>Something other than a folder is at “%@”. Move or delete it, then remove the worktree.</key>
+	<string>“%@”所在位置现在不是文件夹。请先移走或删除它，再移除 worktree。</string>
 	<key>Something went wrong loading this repository. Try again in a moment.</key>
 	<string>载入该仓库时出错。请稍后重试。</string>
 	<key>Sort</key>
@@ -1594,6 +1596,8 @@
 	<string>例如 JetBrains Mono</string>
 	<key>first %1$lld of %2$lld files</key>
 	<string>%2$lld 个文件中的前 %1$lld 个</string>
+	<key>git can no longer inspect “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git 已无法检查“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git 无法检查“%@”是否有更改，因此未将其移除。</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>
@@ -1602,8 +1606,6 @@
 	<string>git 无法读取此项目的 worktree，因此未移除“%@”。</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git 无法移除“%@”。</string>
-	<key>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
-	<string>git 已不再跟踪“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。</string>
 	<key>git still lists “%@”, so it was not removed.</key>
 	<string>git 仍列出“%@”，因此未移除。</string>
 	<key>issue.state.open</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1594,10 +1594,14 @@
 	<string>例如 JetBrains Mono</string>
 	<key>first %1$lld of %2$lld files</key>
 	<string>%2$lld 个文件中的前 %1$lld 个</string>
+	<key>git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git 已无法读取“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git 无法检查“%@”是否有更改，因此未将其移除。</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>
 	<string>git 无法为“%@”创建 worktree。请确认它是包含至少一个提交的 git 仓库。</string>
+	<key>git couldn’t read this project’s worktrees, so “%@” was not removed.</key>
+	<string>git 无法读取此项目的 worktree，因此未移除“%@”。</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git 无法移除“%@”。</string>
 	<key>git still lists “%@”, so it was not removed.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1358,8 +1358,6 @@
 	<string>该设备无法读取这个对比。</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
 	<string>~/.ssh/config 里的设备，以及连上它们的密钥</string>
-	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
-	<string>文件夹已移除，但 git 无法清理其残留的 worktree 元数据。</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>无法添加忽略规则。</string>
 	<key>The install page — the same one whichever machine you are installing on.</key>
@@ -1494,6 +1492,8 @@
 	<string>下划线</string>
 	<key>Ungroup</key>
 	<string>取消编组</string>
+	<key>Unlock “%@” (git worktree unlock) before removing it.</key>
+	<string>请先解锁“%@”（git worktree unlock）再移除。</string>
 	<key>Unpin</key>
 	<string>取消固定</string>
 	<key>Unsaved changes — press ⌘S to save to %@</key>
@@ -1562,8 +1562,8 @@
 	<string>工作区</string>
 	<key>Worktree has changes</key>
 	<string>Worktree 存在更改</string>
-	<key>Worktree removed</key>
-	<string>Worktree 已移除</string>
+	<key>Worktree is locked</key>
+	<string>Worktree 已锁定</string>
 	<key>Yesterday</key>
 	<string>昨天</string>
 	<key>You can restore it from the Trash.</key>
@@ -1600,6 +1600,8 @@
 	<string>git 无法为“%@”创建 worktree。请确认它是包含至少一个提交的 git 仓库。</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git 无法移除“%@”。</string>
+	<key>git still lists “%@”, so it was not removed.</key>
+	<string>git 仍列出“%@”，因此未移除。</string>
 	<key>issue.state.open</key>
 	<string>开放</string>
 	<key>macOS hasn’t been asked to allow Termio’s notifications yet.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1594,8 +1594,6 @@
 	<string>例如 JetBrains Mono</string>
 	<key>first %1$lld of %2$lld files</key>
 	<string>%2$lld 个文件中的前 %1$lld 个</string>
-	<key>git can no longer read “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
-	<string>git 已无法读取“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git 无法检查“%@”是否有更改，因此未将其移除。</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>
@@ -1604,6 +1602,8 @@
 	<string>git 无法读取此项目的 worktree，因此未移除“%@”。</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git 无法移除“%@”。</string>
+	<key>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git 已不再跟踪“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。</string>
 	<key>git still lists “%@”, so it was not removed.</key>
 	<string>git 仍列出“%@”，因此未移除。</string>
 	<key>issue.state.open</key>
@@ -1626,6 +1626,8 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 	<string>termio 可以教你运行的 Agent（Claude Code、Codex 等）使用 `termio sessions` 命令，让它们在项目中查看、驱动并读取彼此的会话。
 
 启用后会在你的 ~/.claude/CLAUDE.md 中添加一段简短说明并安装状态 hooks。你可以随时在“设置 ▸ Agents”中将其关闭。</string>
+	<key>termio couldn’t read “%@”, so it was not removed.</key>
+	<string>termio 无法读取“%@”，因此未移除。</string>
 	<key>termiod on %@ never opened its listener.
 %@</key>
 	<string>%1$@ 上的 termiod 始终没有打开监听器。

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1606,6 +1606,8 @@
 	<string>git 无法读取此项目的 worktree，因此未移除“%@”。</string>
 	<key>git couldn’t remove “%@”.</key>
 	<string>git 无法移除“%@”。</string>
+	<key>git no longer tracks “%@”, and its folder still holds files. Delete the folder to remove the worktree.</key>
+	<string>git 已不再跟踪“%@”，且其文件夹中仍有文件。请删除该文件夹后再移除 worktree。</string>
 	<key>git still lists “%@”, so it was not removed.</key>
 	<string>git 仍列出“%@”，因此未移除。</string>
 	<key>issue.state.open</key>

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -796,6 +796,15 @@ private struct ProjectHeader: View {
         store.addSession(to: project.id, agent: preset, worktreePath: worktree?.path)
     }
 
+    /// Whether this row has somewhere to start a session. A worktree git still
+    /// registers but whose checkout is gone has not: the path would reach the
+    /// daemon as a working directory that does not exist, and the session would
+    /// open somewhere nobody asked for. The row itself stays, because removing it
+    /// is what the user still needs to reach.
+    private var canStartSession: Bool {
+        worktree?.missing != true
+    }
+
     /// What the hover cluster and the agents submenu offer — the same presets
     /// wherever the project lives, since the far daemon launches agents too.
     private var headerPresets: [AgentPreset] {
@@ -822,12 +831,14 @@ private struct ProjectHeader: View {
         // verb names it outright instead of offering a device submenu whose rows
         // would all be wrong but one.
         if store.isOnAnotherDevice(project) { return remoteMenuItems }
-        var items: [SidebarMenuItem] = [
-            newTerminalMenuItem(store: store, project: project) { addSession(.terminal) },
-            .submenu(localized("New Agent Session"), enabledAgentPresets(settings)
-                .filter { $0 != .terminal }
-                .map { preset in .agent(preset) { addSession(preset) } }),
-        ]
+        var items: [SidebarMenuItem] = canStartSession
+            ? [
+                newTerminalMenuItem(store: store, project: project) { addSession(.terminal) },
+                .submenu(localized("New Agent Session"), enabledAgentPresets(settings)
+                    .filter { $0 != .terminal }
+                    .map { preset in .agent(preset) { addSession(preset) } }),
+            ]
+            : []
         if let worktree {
             if let cloneTo = cloneToDeviceMenuItem(
                 store: store, folder: worktree.path, project: project.id) {
@@ -987,7 +998,7 @@ private struct ProjectHeader: View {
         // lifecycle actions live in the right-click menu rather than inline.
         .overlay(alignment: .trailing) {
             HStack(spacing: 3) {
-                ForEach(headerPresets) { preset in
+                ForEach(canStartSession ? headerPresets : []) { preset in
                     AgentQuickAddButton(preset: preset, chrome: chrome) {
                         addSession(preset)
                     }

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -840,12 +840,18 @@ private struct ProjectHeader: View {
             ]
             : []
         if let worktree {
+            // A separator only ever divides, so nothing adds one while the list is
+            // still empty: a row with no session verbs would otherwise open its
+            // menu on a rule with nothing above it.
+            func divide() {
+                if !items.isEmpty { items.append(.separator) }
+            }
             if let cloneTo = cloneToDeviceMenuItem(
                 store: store, folder: worktree.path, project: project.id) {
-                items.append(.separator)
+                divide()
                 items.append(cloneTo)
             }
-            items.append(.separator)
+            divide()
             items.append(.action(worktree.pinned ? localized("Unpin") : localized("Pin")) {
                 store.toggleWorktreePinned(worktree.id)
             })

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -431,18 +431,29 @@ extension TermioStore {
         func remove(_ target: String, _ operation: (UnsafePointer<CChar>) -> Int32) -> Int32 {
             target.withCString { pointer in operation(pointer) == 0 ? 0 : errno }
         }
-        // `rmdir` first, and `.DS_Store` only once it is the one thing in the
-        // way. Unlinking up front threw away the user's Finder state for the
-        // folder even when a file had appeared beside it and the removal was
-        // then correctly refused — a side effect of an operation that reports
-        // it did nothing.
+        // `rmdir` first, and `.DS_Store` only once it is provably the one thing
+        // in the way. Unlinking on `ENOTEMPTY` alone was not that: a file that
+        // appeared beside it since the decision left the folder correctly
+        // refused, with the user's Finder state for it deleted anyway — a side
+        // effect of an operation that reports it did nothing.
         var failure = remove(path, rmdir)
-        if failure == ENOTEMPTY {
+        if failure == ENOTEMPTY, holdsOnlyFinderState(at: path) {
             _ = remove((path as NSString).appendingPathComponent(".DS_Store"), unlink)
             failure = remove(path, rmdir)
         }
         // Already gone is the state this wanted; anything else is a real refusal.
         return failure == 0 || failure == ENOENT
+    }
+
+    /// Whether `.DS_Store` is the only thing left in a folder — the one entry
+    /// that is Finder's rather than the user's, and so the only one this may
+    /// clear to let a `rmdir` through. A folder it cannot read holds something
+    /// as far as this is concerned.
+    private func holdsOnlyFinderState(at path: String) -> Bool {
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: path) else {
+            return false
+        }
+        return entries == [".DS_Store"]
     }
 
     /// See `WorktreeService.canonicalPath`: git's spelling of a path and the one

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -180,7 +180,11 @@ extension TermioStore {
     private struct StaleRegistration {
         /// git's own spelling of the path, which is what git must be handed.
         let path: String
-        let clearFolderFirst: Bool
+        /// An empty directory is at the path, so clearing it is authorized if
+        /// git refuses to deregister the worktree while it is there. The
+        /// authorization is the point: nothing may delete a folder the decision
+        /// did not find empty.
+        let mayClearFolder: Bool
     }
 
     /// Removes a clean linked checkout, then drops its container and matching flat
@@ -219,25 +223,13 @@ extension TermioStore {
                 // can differ through a symlinked ancestor, and git refuses an
                 // argument it cannot realpath — "is not a working tree" for a
                 // removal that succeeds when handed its own spelling.
-                if registration.clearFolderFirst {
-                    // Reported on its own, before anything is dropped: git will
-                    // refuse to deregister a worktree whose path still exists,
-                    // so "git still lists it" below would blame git for a folder
-                    // that could not be cleared.
-                    guard clearEmptyFolder(at: worktree.path) else {
-                        presentWorktreeFailure(
-                            title: localized("Couldn’t remove worktree"),
-                            message: localized("termio couldn’t remove the empty folder at “\(displayName)”, so the worktree was not removed.")
-                        )
-                        return
-                    }
-                }
-                // With the path cleared, git's own *targeted* remove applies: it
-                // deregisters this worktree and nothing else. `git worktree
-                // prune` is never run — it is repo-wide, so it would take every
-                // other worktree whose folder is missing with it, including ones
+                //
+                // git's own *targeted* remove does the deregistering: it takes
+                // this worktree and nothing else. `git worktree prune` is never
+                // run here — it is repo-wide, so it would take every other
+                // worktree whose folder is missing with it, including ones
                 // holding work this action was never pointed at.
-                guard runGit(["worktree", "remove", registration.path], in: repository) != nil else {
+                guard deregister(registration, at: worktree.path, in: repository) else {
                     presentWorktreeFailure(
                         title: localized("Couldn’t remove worktree"),
                         message: localized("git still lists “\(displayName)”, so it was not removed.")
@@ -316,8 +308,13 @@ extension TermioStore {
             }
             return decisionWithoutRegistration(for: path, named: displayName)
         }
+        // Resolved once, not once per registration: every call walks ancestors
+        // with `fileExists` and `destinationOfSymbolicLink`, on the main actor
+        // while the click waits, and a repo with many worktrees on a slow mount
+        // paid that twice over for each of them.
+        let wanted = canonicalWorktreePath(path)
         guard let record = registrations
-            .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(path) })
+            .first(where: { canonicalWorktreePath($0.path) == wanted })
         else {
             return decisionWithoutRegistration(for: path, named: displayName)
         }
@@ -360,12 +357,12 @@ extension TermioStore {
         case .gone:
             return .letGo(
                 branch: record.branch,
-                registration: StaleRegistration(path: record.path, clearFolderFirst: false)
+                registration: StaleRegistration(path: record.path, mayClearFolder: false)
             )
         case .emptyFolder:
             return .letGo(
                 branch: record.branch,
-                registration: StaleRegistration(path: record.path, clearFolderFirst: true)
+                registration: StaleRegistration(path: record.path, mayClearFolder: true)
             )
         case .occupied:
             // git refuses to deregister a worktree whose path exists without a
@@ -432,6 +429,31 @@ extension TermioStore {
                 message: localized("termio couldn’t read “\(displayName)”, so it was not removed.")
             )
         }
+    }
+
+    /// Drop git's registration for a checkout that is no longer there, and
+    /// answer whether it is gone.
+    ///
+    /// The empty folder is cleared only when git has *refused* over it, and is
+    /// put back when git then refuses anyway — so a removal that reports nothing
+    /// happened really did leave the path as it found it. Deleting first and
+    /// reporting afterwards is the shape that kept coming back: git refuses while
+    /// the path exists, so the clearing is needed, but doing it up front meant
+    /// any later refusal — a concurrent git holding `.git/worktrees`, a
+    /// read-only repo — told the user nothing had happened while their folder was
+    /// already deleted. The order here cannot say that: either the path is gone
+    /// and the registration with it, or both are as they were.
+    private func deregister(
+        _ registration: StaleRegistration, at path: String, in repository: String
+    ) -> Bool {
+        if runGit(["worktree", "remove", registration.path], in: repository) != nil { return true }
+        // A remove that refuses while the path still exists touches nothing, so
+        // there is nothing to undo before trying the one thing that can help.
+        guard registration.mayClearFolder, clearEmptyFolder(at: path) else { return false }
+        if runGit(["worktree", "remove", registration.path], in: repository) != nil { return true }
+        try? FileManager.default.createDirectory(
+            atPath: path, withIntermediateDirectories: false)
+        return false
     }
 
     /// Remove the empty folder a checkout left behind, so git's targeted remove

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -161,31 +161,44 @@ extension TermioStore {
               let worktree = projects[projectIndex].worktrees.first(where: { $0.id == worktreeID })
         else { return }
 
-        guard let status = runGit(["status", "--porcelain"], in: worktree.path) else {
-            presentWorktreeFailure(
-                title: localized("Couldn’t inspect worktree"),
-                message: localized("git couldn’t check “\((worktree.path as NSString).lastPathComponent)” for changes, so it was not removed.")
-            )
-            return
-        }
-        guard status.isEmpty else {
-            presentWorktreeFailure(
-                title: localized("Worktree has changes"),
-                message: localized("Commit or discard the changes in “\((worktree.path as NSString).lastPathComponent)” before removing it.")
-            )
-            return
-        }
-        // The branch termio created for this worktree, captured before removal so it can
-        // be tidied afterward. A user who switched branches inside the worktree leaves a
-        // different name here — that is theirs to keep, and the safe delete below won't
-        // touch it if it carries unmerged commits.
-        let branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], in: worktree.path)
-        guard runGit(["worktree", "remove", worktree.path], in: projects[projectIndex].path) != nil else {
-            presentWorktreeFailure(
-                title: localized("Couldn’t remove worktree"),
-                message: localized("git couldn’t remove “\((worktree.path as NSString).lastPathComponent)”.")
-            )
-            return
+        // A worktree whose folder was deleted by another tool can't be inspected —
+        // `git status` has no directory to run in, and `git worktree remove` refuses a
+        // missing path — so the dirty check would dead-end this action forever (a live
+        // session is what keeps a git-absent worktree in the sidebar, see
+        // `applyDiscoveredWorktrees`, and this action is the only way to let go of it).
+        // There is no work left on disk to protect: skip straight to pruning the stale
+        // registration, recovering the branch from the parent repo's metadata since the
+        // checkout can no longer answer for itself.
+        let branch: String?
+        if FileManager.default.fileExists(atPath: worktree.path) {
+            guard let status = runGit(["status", "--porcelain"], in: worktree.path) else {
+                presentWorktreeFailure(
+                    title: localized("Couldn’t inspect worktree"),
+                    message: localized("git couldn’t check “\((worktree.path as NSString).lastPathComponent)” for changes, so it was not removed.")
+                )
+                return
+            }
+            guard status.isEmpty else {
+                presentWorktreeFailure(
+                    title: localized("Worktree has changes"),
+                    message: localized("Commit or discard the changes in “\((worktree.path as NSString).lastPathComponent)” before removing it.")
+                )
+                return
+            }
+            // The branch termio created for this worktree, captured before removal so it can
+            // be tidied afterward. A user who switched branches inside the worktree leaves a
+            // different name here — that is theirs to keep, and the safe delete below won't
+            // touch it if it carries unmerged commits.
+            branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], in: worktree.path)
+            guard runGit(["worktree", "remove", worktree.path], in: projects[projectIndex].path) != nil else {
+                presentWorktreeFailure(
+                    title: localized("Couldn’t remove worktree"),
+                    message: localized("git couldn’t remove “\((worktree.path as NSString).lastPathComponent)”.")
+                )
+                return
+            }
+        } else {
+            branch = registeredBranch(ofWorktreeAt: worktree.path, in: projects[projectIndex].path)
         }
 
         let pruneSucceeded = runGit(["worktree", "prune"], in: projects[projectIndex].path) != nil
@@ -208,6 +221,29 @@ extension TermioStore {
                 message: localized("The folder was removed, but git couldn’t prune its stale worktree metadata.")
             )
         }
+    }
+
+    /// The branch checked out in the worktree registered at `path`, read from the parent
+    /// repo's own records (`git worktree list --porcelain`) — the only source that still
+    /// answers once the checkout's folder is gone. Records are blank-line separated; the
+    /// one opening with `worktree <path>` carries a `branch refs/heads/<name>` line,
+    /// absent on a detached HEAD (which has no branch to tidy anyway).
+    private func registeredBranch(ofWorktreeAt path: String, in repository: String) -> String? {
+        guard let listing = runGit(["worktree", "list", "--porcelain"], in: repository) else { return nil }
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
+        for record in listing.components(separatedBy: "\n\n") {
+            let lines = record.split(separator: "\n", omittingEmptySubsequences: true)
+            guard let worktreeLine = lines.first(where: { $0.hasPrefix("worktree ") }),
+                  URL(fileURLWithPath: String(worktreeLine.dropFirst("worktree ".count)))
+                      .standardizedFileURL.path == standardized
+            else { continue }
+            guard let branchLine = lines.first(where: { $0.hasPrefix("branch ") }) else { return nil }
+            let reference = String(branchLine.dropFirst("branch ".count))
+            return reference.hasPrefix("refs/heads/")
+                ? String(reference.dropFirst("refs/heads/".count))
+                : reference
+        }
+        return nil
     }
 
     /// Copies the git-ignored files a repo lists in `.worktreeinclude` into a freshly

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -205,7 +205,17 @@ extension TermioStore {
             // it cannot realpath — "is not a working tree" for a removal that
             // succeeds when handed its own spelling.
             if emptyFolder {
-                clearEmptyFolder(at: worktree.path)
+                // Reported on its own, before anything is dropped: git will
+                // refuse to deregister a worktree whose path still exists, so
+                // "git still lists it" below would blame git for a folder that
+                // could not be cleared.
+                guard clearEmptyFolder(at: worktree.path) else {
+                    presentWorktreeFailure(
+                        title: localized("Couldn’t remove worktree"),
+                        message: localized("termio couldn’t remove the empty folder at “\(displayName)”, so the worktree was not removed.")
+                    )
+                    return
+                }
             }
             if let registration {
                 // With the path cleared, git's own *targeted* remove applies: it
@@ -360,17 +370,22 @@ extension TermioStore {
     /// symlink this would reach into a directory the decision never inspected.
     /// `folderEvidence` classifies that path `.occupied` instead, and this is
     /// not called for it.
-    private func clearEmptyFolder(at path: String) {
+    /// Answers whether the path is clear afterwards, so a folder that would not
+    /// go is reported as itself rather than as git refusing the worktree.
+    @discardableResult
+    private func clearEmptyFolder(at path: String) -> Bool {
         let dsStore = (path as NSString).appendingPathComponent(".DS_Store")
         _ = dsStore.withCString { unlink($0) }
-        _ = path.withCString { rmdir($0) }
+        if path.withCString({ rmdir($0) }) == 0 { return true }
+        // Already gone is the state this wanted; anything else is a real refusal.
+        return errno == ENOENT
     }
 
-    /// One spelling for a worktree path however it reaches us: git prints realpaths
-    /// while `Worktree.path` keeps whatever spelling created it, so a symlinked
-    /// ancestor (a linked home directory, `/tmp`) would otherwise defeat the match.
+    /// See `WorktreeService.canonicalPath`: git's spelling of a path and the one
+    /// a sidebar row carries have to be compared in one form, including after
+    /// the folder is gone.
     private func canonicalWorktreePath(_ path: String) -> String {
-        URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+        WorktreeService.canonicalPath(path)
     }
 
     /// Copies the git-ignored files a repo lists in `.worktreeinclude` into a freshly

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -301,18 +301,40 @@ extension TermioStore {
                 message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
             )
         }
-        // git holding no registration ends it here: there is nothing to
-        // deregister, no branch of its recording to tidy, and nothing this
-        // action would touch on disk — the sidebar row is the whole of what is
-        // being removed. So the folder's contents are not consulted and cannot
-        // refuse: whatever is in it stays exactly where it is, and telling a
-        // user to delete a folder full of real work in order to clear a stale
-        // row would be asking for the one thing the removal was never going to
-        // do anyway.
+        // git holds no registration: there is nothing to deregister and no
+        // branch of its recording to tidy. But the row is not free to drop on
+        // that alone. Dropping it closes every session in the worktree, and a
+        // reconcile re-adds any row a live session still points at
+        // (`applyDiscoveredWorktrees`), so a removal that spared the sessions
+        // would simply undo itself — leaving refusal as the only way not to
+        // destroy them.
+        //
+        // So the disk decides here as well, and only the shapes with nothing
+        // left on them let go. A folder still holding files is a checkout whose
+        // parent repo was re-cloned or whose admin directory was lost, running
+        // agents and uncommitted work and all; before this it was silently
+        // closed and dropped on one click.
         guard let record = registrations
             .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(path) })
         else {
-            return .letGo(branch: nil, registration: nil)
+            switch WorktreeService.folderEvidence(at: path) {
+            case .gone, .emptyFolder, .occupied:
+                // Nothing to protect, and nothing for git to let go of: the
+                // sidebar row is the whole of what is being removed. The folder
+                // is left alone — with no registration, nothing needs the path
+                // cleared.
+                return .letGo(branch: nil, registration: nil)
+            case .mayHoldWork:
+                return .refuse(
+                    title: localized("Couldn’t inspect worktree"),
+                    message: localized("git no longer tracks “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
+                )
+            case .unreadable:
+                return .refuse(
+                    title: localized("Couldn’t inspect worktree"),
+                    message: localized("termio couldn’t read “\(displayName)”, so it was not removed.")
+                )
+            }
         }
 
         // Locked first, because it is not a shape of brokenness: git marks a
@@ -402,11 +424,25 @@ extension TermioStore {
     /// Answers whether the path is clear afterwards, so a folder that would not
     /// go is reported as itself rather than as git refusing the worktree.
     private func clearEmptyFolder(at path: String) -> Bool {
-        let dsStore = (path as NSString).appendingPathComponent(".DS_Store")
-        _ = dsStore.withCString { unlink($0) }
-        if path.withCString({ rmdir($0) }) == 0 { return true }
+        // `errno` is captured inside the closure: reading it after
+        // `withCString` returns reads it after that call's own cleanup, which is
+        // not guaranteed to leave it alone, and a folder that was already gone
+        // would then be reported as a folder that refused to go.
+        func remove(_ target: String, _ operation: (UnsafePointer<CChar>) -> Int32) -> Int32 {
+            target.withCString { pointer in operation(pointer) == 0 ? 0 : errno }
+        }
+        // `rmdir` first, and `.DS_Store` only once it is the one thing in the
+        // way. Unlinking up front threw away the user's Finder state for the
+        // folder even when a file had appeared beside it and the removal was
+        // then correctly refused — a side effect of an operation that reports
+        // it did nothing.
+        var failure = remove(path, rmdir)
+        if failure == ENOTEMPTY {
+            _ = remove((path as NSString).appendingPathComponent(".DS_Store"), unlink)
+            failure = remove(path, rmdir)
+        }
         // Already gone is the state this wanted; anything else is a real refusal.
-        return errno == ENOENT
+        return failure == 0 || failure == ENOENT
     }
 
     /// See `WorktreeService.canonicalPath`: git's spelling of a path and the one

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -153,6 +153,22 @@ extension TermioStore {
         return candidate
     }
 
+    /// What `removeWorktree` is allowed to do to a worktree, decided by
+    /// `removalDecision` before anything is touched. The cases carry the branch to
+    /// tidy afterward, read from the parent repo rather than from a checkout that
+    /// may no longer be able to answer.
+    private enum WorktreeRemoval {
+        /// git can still inspect the checkout, and it came back clean: git removes
+        /// the folder and the registration itself.
+        case removeCheckout(branch: String?)
+        /// Nothing on disk is left to protect. `registered` says whether git still
+        /// lists the worktree and there is a registration to drop, or whether only
+        /// the sidebar row remains.
+        case letGo(branch: String?, registered: Bool)
+        /// Leave everything as it is, and say why.
+        case refuse(title: String, message: String)
+    }
+
     /// Removes a clean linked checkout, then drops its container and matching flat
     /// sessions from the parent project. Dirty work always stays on disk and in the
     /// sidebar so an accidental cleanup cannot discard agent changes.
@@ -164,103 +180,44 @@ extension TermioStore {
         let repository = projects[projectIndex].path
         let displayName = (worktree.path as NSString).lastPathComponent
 
-        // One `git worktree list --porcelain` read answers everything the removal
-        // decides on: whether git still knows this checkout, whether git itself
-        // judges it gone (`prunable`), whether git is holding on to it (`locked`),
-        // and which branch to tidy afterward. The branch comes from the repo's
-        // records for every arm: the checkout can't be asked once its folder is
-        // damaged, and a detached HEAD simply carries no branch line, so no
-        // sentinel string is needed.
-        //
-        // A read that fails is not an answer. Treating it as "git doesn't know
-        // this worktree" would skip both the dirty check and the deregistration
-        // while still closing the sessions and dropping the row, so a repo git
-        // could not read for a moment would cost the user the row and the work
-        // behind it.
-        guard let registrations = WorktreeService.records(in: repository) else {
-            presentWorktreeFailure(
-                title: localized("Couldn’t inspect worktree"),
-                message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
-            )
+        let branch: String?
+        switch removalDecision(for: worktree.path, in: repository, named: displayName) {
+        case let .refuse(title, message):
+            presentWorktreeFailure(title: title, message: message)
             return
-        }
-        let record = registrations
-            .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) })
-        let branch = record?.branch
 
-        if let record {
-            // Locked comes first because it is not a shape of brokenness: git
-            // marks a locked worktree `locked` and never `prunable`, even with
-            // its folder deleted, which is exactly how a checkout on removable
-            // media survives being unplugged. Checking it inside the prunable
-            // arm would never fire.
-            guard !record.locked else {
+        case let .removeCheckout(checkedOutBranch):
+            guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
                 presentWorktreeFailure(
-                    title: localized("Worktree is locked"),
-                    message: localized("Unlock “\(displayName)” (git worktree unlock) before removing it.")
+                    title: localized("Couldn’t remove worktree"),
+                    message: localized("git couldn’t remove “\(displayName)”.")
                 )
                 return
             }
-            if record.prunable {
-                // `prunable` says git lost its way to the checkout, not that the
-                // work is gone: a worktree whose `.git` gitfile was deleted is
-                // marked prunable with every file still on disk. Nothing can
-                // inspect those files for changes — that is what being prunable
-                // costs — so a folder that still holds anything is left alone
-                // rather than deregistered out from under work nobody can see.
-                guard !folderHoldsFiles(at: worktree.path) else {
-                    presentWorktreeFailure(
-                        title: localized("Couldn’t inspect worktree"),
-                        message: localized("git can no longer read “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
-                    )
-                    return
-                }
-                // A targeted remove deregisters just this worktree when its folder
-                // is gone. The damaged-folder shapes fail its validation, and for
-                // those pruning is the only tool git offers — repo-wide, so it is
-                // the fallback rather than the first resort.
-                if runGit(["worktree", "remove", worktree.path], in: repository) == nil {
-                    runGit(["worktree", "prune"], in: repository)
-                }
-                // A prune that silently skipped this worktree must not be reported
-                // as a removal, or the row would reappear on the next discovery
-                // pass. Only git still naming the worktree proves that: a read
-                // that fails here says nothing about a removal that already ran,
-                // and refusing on it would strand a row git has let go of.
-                if let remaining = WorktreeService.records(in: repository),
-                   remaining.contains(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) }) {
+            branch = checkedOutBranch
+
+        case let .letGo(registeredBranch, registered):
+            if registered {
+                // An empty folder is cleared so git's own *targeted* remove
+                // applies: with the path gone it deregisters this worktree and
+                // nothing else. `git worktree prune` is never run — it is
+                // repo-wide, so it would take every other worktree whose folder
+                // is missing with it, including ones holding work this action
+                // was never pointed at and nothing has inspected.
+                clearEmptyFolder(at: worktree.path)
+                guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
                     presentWorktreeFailure(
                         title: localized("Couldn’t remove worktree"),
                         message: localized("git still lists “\(displayName)”, so it was not removed.")
                     )
                     return
                 }
-            } else {
-                guard let status = runGit(["status", "--porcelain"], in: worktree.path) else {
-                    presentWorktreeFailure(
-                        title: localized("Couldn’t inspect worktree"),
-                        message: localized("git couldn’t check “\(displayName)” for changes, so it was not removed.")
-                    )
-                    return
-                }
-                guard status.isEmpty else {
-                    presentWorktreeFailure(
-                        title: localized("Worktree has changes"),
-                        message: localized("Commit or discard the changes in “\(displayName)” before removing it.")
-                    )
-                    return
-                }
-                guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
-                    presentWorktreeFailure(
-                        title: localized("Couldn’t remove worktree"),
-                        message: localized("git couldn’t remove “\(displayName)”.")
-                    )
-                    return
-                }
             }
+            branch = registeredBranch
         }
-        // A worktree git lists nowhere has nothing left to deregister; the
-        // sidebar row and its sessions are all that remain of it.
+
+        // Past the gate: everything below drops state, and only a decision above
+        // reaches it.
 
         // Best-effort tidy of the auto-created branch. `-d` (not `-D`) refuses to drop a
         // branch with unmerged commits, so real work is never lost — the branch simply
@@ -277,27 +234,114 @@ extension TermioStore {
         }
     }
 
+    /// What a removal is permitted to do — the one gate every path through
+    /// `removeWorktree` passes.
+    ///
+    /// Three rounds of review found the same bug three times: a guard added to
+    /// whichever arm was reported, and the path beside it left open. So the
+    /// authorization is a value now, produced here and nowhere else. Nothing
+    /// below this function deregisters a worktree, closes a session or drops a
+    /// row except by holding one, which is what makes "every exit is checked"
+    /// something the type system carries rather than something each arm has to
+    /// remember.
+    ///
+    /// Two rules decide every case. A read that fails refuses — an answer nobody
+    /// got is not an answer that the checkout is empty. And no path proceeds on a
+    /// checkout that might still hold work: git's own dirty check settles that
+    /// where git can still inspect the folder, and where it cannot, the disk is
+    /// the only witness left ([`WorktreeService.folderEvidence`]).
+    ///
+    /// Reads only; it touches nothing.
+    private func removalDecision(
+        for path: String,
+        in repository: String,
+        named displayName: String
+    ) -> WorktreeRemoval {
+        // One `git worktree list --porcelain` read answers what git knows: whether
+        // it still tracks this checkout, whether it judges the checkout gone
+        // (`prunable`), whether it is holding on to it (`locked`), and which branch
+        // to tidy afterward — the checkout cannot be asked once its folder is
+        // damaged, and a detached HEAD carries no branch line, so no sentinel
+        // string is needed.
+        guard let registrations = WorktreeService.records(in: repository) else {
+            return .refuse(
+                title: localized("Couldn’t inspect worktree"),
+                message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
+            )
+        }
+        let record = registrations
+            .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(path) })
+
+        // Locked first, because it is not a shape of brokenness: git marks a
+        // locked worktree `locked` and never `prunable`, even with its folder
+        // deleted, which is how a checkout on removable media survives being
+        // unplugged. Asked after `prunable`, this could never fire.
+        if let record, record.locked {
+            return .refuse(
+                title: localized("Worktree is locked"),
+                message: localized("Unlock “\(displayName)” (git worktree unlock) before removing it.")
+            )
+        }
+
+        // A checkout git can still inspect answers for itself, and its answer is
+        // the only thing that authorizes deleting files.
+        if let record, !record.prunable {
+            guard let status = runGit(["status", "--porcelain"], in: path) else {
+                return .refuse(
+                    title: localized("Couldn’t inspect worktree"),
+                    message: localized("git couldn’t check “\(displayName)” for changes, so it was not removed.")
+                )
+            }
+            guard status.isEmpty else {
+                return .refuse(
+                    title: localized("Worktree has changes"),
+                    message: localized("Commit or discard the changes in “\(displayName)” before removing it.")
+                )
+            }
+            return .removeCheckout(branch: record.branch)
+        }
+
+        // Everything else reaches the same gate: a `prunable` record, where git
+        // lost its way to the checkout, and no record at all, where git never
+        // knew it or the user already pruned it. Both leave the disk as the only
+        // witness, and both used to have their own way through — the second with
+        // no check whatsoever, closing a live session and dropping the row on one
+        // click of a menu item that asks nothing first.
+        switch WorktreeService.folderEvidence(at: path) {
+        case .nothingToProtect:
+            return .letGo(branch: record?.branch, registered: record != nil)
+        case .mayHoldWork:
+            return .refuse(
+                title: localized("Couldn’t inspect worktree"),
+                message: localized("git no longer tracks “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
+            )
+        case .unreadable:
+            return .refuse(
+                title: localized("Couldn’t inspect worktree"),
+                message: localized("termio couldn’t read “\(displayName)”, so it was not removed.")
+            )
+        }
+    }
+
+    /// Remove the empty folder a checkout left behind, so git's targeted remove
+    /// applies to it.
+    ///
+    /// Only ever an empty directory — `rmdir` refuses a directory holding
+    /// anything, and the `.DS_Store` unlinked first is the one entry
+    /// `folderEvidence` discounted. Nothing recursive, so a folder that gained a
+    /// file between the decision and here survives, and the removal that follows
+    /// fails loudly instead of taking it.
+    private func clearEmptyFolder(at path: String) {
+        let dsStore = (path as NSString).appendingPathComponent(".DS_Store")
+        _ = dsStore.withCString { unlink($0) }
+        _ = path.withCString { rmdir($0) }
+    }
+
     /// One spelling for a worktree path however it reaches us: git prints realpaths
     /// while `Worktree.path` keeps whatever spelling created it, so a symlinked
     /// ancestor (a linked home directory, `/tmp`) would otherwise defeat the match.
     private func canonicalWorktreePath(_ path: String) -> String {
         URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
-    }
-
-    /// Whether anything is left in a checkout git can no longer inspect — the only
-    /// question a disk read can still answer once the `.git` gitfile is gone.
-    ///
-    /// A path that isn't a directory holds no checkout (deleted, or replaced by a
-    /// plain file the removal never touches), and `.DS_Store` is Finder's, not the
-    /// user's: a folder emptied in the Finder keeps one, and counting it would
-    /// dead-end the removal on a worktree with nothing in it.
-    private func folderHoldsFiles(at path: String) -> Bool {
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
-              isDirectory.boolValue,
-              let entries = try? FileManager.default.contentsOfDirectory(atPath: path)
-        else { return false }
-        return entries.contains { $0 != ".DS_Store" }
     }
 
     /// Copies the git-ignored files a repo lists in `.worktreeinclude` into a freshly

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -161,14 +161,26 @@ extension TermioStore {
         /// git can still inspect the checkout, and it came back clean: git removes
         /// the folder and the registration itself.
         case removeCheckout(branch: String?, registration: String)
-        /// Nothing on disk is left to protect. `registration` is git's own
-        /// spelling of the path when it still lists the worktree, and `nil` when
-        /// it does not and only the sidebar row remains. `emptyFolder` says an
-        /// empty directory is still at the path and has to be cleared before git
-        /// will deregister the worktree.
-        case letGo(branch: String?, registration: String?, emptyFolder: Bool)
+        /// Nothing on disk is left to protect. `registration` is what git still
+        /// holds, or `nil` when git holds nothing and the sidebar row is all
+        /// there is to remove.
+        case letGo(branch: String?, registration: StaleRegistration?)
         /// Leave everything as it is, and say why.
         case refuse(title: String, message: String)
+    }
+
+    /// A registration git still holds for a checkout that is no longer there.
+    ///
+    /// The two travel together because the clearing exists only to serve the
+    /// deregistration: git refuses to let go of a worktree whose path still
+    /// exists, so an empty folder has to go first. Kept apart, the clearing ran
+    /// on its own and deleted a directory git did not track — and refused the
+    /// whole removal when `rmdir` failed, stranding the sidebar row this action
+    /// exists to clear.
+    private struct StaleRegistration {
+        /// git's own spelling of the path, which is what git must be handed.
+        let path: String
+        let clearFolderFirst: Bool
     }
 
     /// Removes a clean linked checkout, then drops its container and matching flat
@@ -198,32 +210,34 @@ extension TermioStore {
             }
             branch = checkedOutBranch
 
-        case let .letGo(registeredBranch, registration, emptyFolder):
-            // Filesystem work goes to the path the evidence was gathered at;
-            // git is addressed by the spelling git itself printed. The two can
-            // differ through a symlinked ancestor, and git refuses an argument
-            // it cannot realpath — "is not a working tree" for a removal that
-            // succeeds when handed its own spelling.
-            if emptyFolder {
-                // Reported on its own, before anything is dropped: git will
-                // refuse to deregister a worktree whose path still exists, so
-                // "git still lists it" below would blame git for a folder that
-                // could not be cleared.
-                guard clearEmptyFolder(at: worktree.path) else {
-                    presentWorktreeFailure(
-                        title: localized("Couldn’t remove worktree"),
-                        message: localized("termio couldn’t remove the empty folder at “\(displayName)”, so the worktree was not removed.")
-                    )
-                    return
-                }
-            }
+        case let .letGo(registeredBranch, registration):
+            // Nothing happens on disk or in git without a registration to drop:
+            // with none, the sidebar row is the whole of what is being removed.
             if let registration {
+                // Filesystem work goes to the path the evidence was gathered at;
+                // git is addressed by the spelling git itself printed. The two
+                // can differ through a symlinked ancestor, and git refuses an
+                // argument it cannot realpath — "is not a working tree" for a
+                // removal that succeeds when handed its own spelling.
+                if registration.clearFolderFirst {
+                    // Reported on its own, before anything is dropped: git will
+                    // refuse to deregister a worktree whose path still exists,
+                    // so "git still lists it" below would blame git for a folder
+                    // that could not be cleared.
+                    guard clearEmptyFolder(at: worktree.path) else {
+                        presentWorktreeFailure(
+                            title: localized("Couldn’t remove worktree"),
+                            message: localized("termio couldn’t remove the empty folder at “\(displayName)”, so the worktree was not removed.")
+                        )
+                        return
+                    }
+                }
                 // With the path cleared, git's own *targeted* remove applies: it
                 // deregisters this worktree and nothing else. `git worktree
                 // prune` is never run — it is repo-wide, so it would take every
                 // other worktree whose folder is missing with it, including ones
                 // holding work this action was never pointed at.
-                guard runGit(["worktree", "remove", registration], in: repository) != nil else {
+                guard runGit(["worktree", "remove", registration.path], in: repository) != nil else {
                     presentWorktreeFailure(
                         title: localized("Couldn’t remove worktree"),
                         message: localized("git still lists “\(displayName)”, so it was not removed.")
@@ -287,14 +301,25 @@ extension TermioStore {
                 message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
             )
         }
-        let record = registrations
+        // git holding no registration ends it here: there is nothing to
+        // deregister, no branch of its recording to tidy, and nothing this
+        // action would touch on disk — the sidebar row is the whole of what is
+        // being removed. So the folder's contents are not consulted and cannot
+        // refuse: whatever is in it stays exactly where it is, and telling a
+        // user to delete a folder full of real work in order to clear a stale
+        // row would be asking for the one thing the removal was never going to
+        // do anyway.
+        guard let record = registrations
             .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(path) })
+        else {
+            return .letGo(branch: nil, registration: nil)
+        }
 
         // Locked first, because it is not a shape of brokenness: git marks a
         // locked worktree `locked` and never `prunable`, even with its folder
         // deleted, which is how a checkout on removable media survives being
         // unplugged. Asked after `prunable`, this could never fire.
-        if let record, record.locked {
+        if record.locked {
             return .refuse(
                 title: localized("Worktree is locked"),
                 message: localized("Unlock “\(displayName)” (git worktree unlock) before removing it.")
@@ -303,7 +328,7 @@ extension TermioStore {
 
         // A checkout git can still inspect answers for itself, and its answer is
         // the only thing that authorizes deleting files.
-        if let record, !record.prunable {
+        if !record.prunable {
             guard let status = runGit(["status", "--porcelain"], in: path) else {
                 return .refuse(
                     title: localized("Couldn’t inspect worktree"),
@@ -319,17 +344,22 @@ extension TermioStore {
             return .removeCheckout(branch: record.branch, registration: record.path)
         }
 
-        // Everything else reaches the same gate: a `prunable` record, where git
-        // lost its way to the checkout, and no record at all, where git never
-        // knew it or the user already pruned it. Both leave the disk as the only
-        // witness, and both used to have their own way through — the second with
-        // no check whatsoever, closing a live session and dropping the row on one
-        // click of a menu item that asks nothing first.
+        // What is left is a `prunable` record: git still holds a registration
+        // but has lost its way to the checkout, so it can no longer be asked
+        // about the folder and the disk is the only witness. Only here does the
+        // removal have both something to drop in git and something it might
+        // disturb on disk, which is what these refusals protect.
         switch WorktreeService.folderEvidence(at: path) {
         case .gone:
-            return .letGo(branch: record?.branch, registration: record?.path, emptyFolder: false)
+            return .letGo(
+                branch: record.branch,
+                registration: StaleRegistration(path: record.path, clearFolderFirst: false)
+            )
         case .emptyFolder:
-            return .letGo(branch: record?.branch, registration: record?.path, emptyFolder: true)
+            return .letGo(
+                branch: record.branch,
+                registration: StaleRegistration(path: record.path, clearFolderFirst: true)
+            )
         case .occupied:
             // git refuses to deregister a worktree whose path exists without a
             // `.git` in it — `--force` included — and what is sitting there is
@@ -340,10 +370,9 @@ extension TermioStore {
                 message: localized("Something other than a folder is at “\(displayName)”. Move or delete it, then remove the worktree.")
             )
         case .mayHoldWork:
-            // "Can no longer inspect", not "no longer tracks": this arm is also
-            // reached with a `prunable` record, where `git worktree list` does
-            // still name the worktree and a user who checked would find the
-            // opposite of what the alert said.
+            // "Can no longer inspect", not "no longer tracks": git does still
+            // name this worktree — it is `prunable`, not absent — and a user who
+            // checked would find the opposite of what the alert said.
             return .refuse(
                 title: localized("Couldn’t inspect worktree"),
                 message: localized("git can no longer inspect “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
@@ -372,7 +401,6 @@ extension TermioStore {
     /// not called for it.
     /// Answers whether the path is clear afterwards, so a folder that would not
     /// go is reported as itself rather than as git refusing the worktree.
-    @discardableResult
     private func clearEmptyFolder(at path: String) -> Bool {
         let dsStore = (path as NSString).appendingPathComponent(".DS_Store")
         _ = dsStore.withCString { unlink($0) }

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -166,21 +166,34 @@ extension TermioStore {
 
         // One `git worktree list --porcelain` read answers everything the removal
         // decides on: whether git still knows this checkout, whether git itself
-        // judges it gone (`prunable` covers the folder-deleted shape *and* the
-        // damaged ones — an emptied folder, a deleted `.git` gitfile, a path
-        // replaced by a plain file — none of which `git status` can inspect), and
-        // which branch to tidy afterward. The branch comes from the repo's records
-        // for both arms: the checkout can't be asked once its folder is damaged,
-        // and a detached HEAD simply carries no branch line, so no sentinel string
-        // is needed. Raw disk checks are deliberately not consulted — git's own
-        // verdict is what decides, including its escape hatch: a worktree on
-        // removable media is protected by `git worktree lock`, which is honored
-        // below.
-        let record = WorktreeService.records(in: repository)?
+        // judges it gone (`prunable`), whether git is holding on to it (`locked`),
+        // and which branch to tidy afterward. The branch comes from the repo's
+        // records for every arm: the checkout can't be asked once its folder is
+        // damaged, and a detached HEAD simply carries no branch line, so no
+        // sentinel string is needed.
+        //
+        // A read that fails is not an answer. Treating it as "git doesn't know
+        // this worktree" would skip both the dirty check and the deregistration
+        // while still closing the sessions and dropping the row, so a repo git
+        // could not read for a moment would cost the user the row and the work
+        // behind it.
+        guard let registrations = WorktreeService.records(in: repository) else {
+            presentWorktreeFailure(
+                title: localized("Couldn’t inspect worktree"),
+                message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
+            )
+            return
+        }
+        let record = registrations
             .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) })
         let branch = record?.branch
 
-        if let record, record.prunable {
+        if let record {
+            // Locked comes first because it is not a shape of brokenness: git
+            // marks a locked worktree `locked` and never `prunable`, even with
+            // its folder deleted, which is exactly how a checkout on removable
+            // media survives being unplugged. Checking it inside the prunable
+            // arm would never fire.
             guard !record.locked else {
                 presentWorktreeFailure(
                     title: localized("Worktree is locked"),
@@ -188,51 +201,65 @@ extension TermioStore {
                 )
                 return
             }
-            // A targeted remove deregisters just this worktree when its folder is
-            // gone. The damaged-folder shapes fail its validation, and for those
-            // pruning is the only tool git offers — repo-wide, so it is the
-            // fallback rather than the first resort.
-            if runGit(["worktree", "remove", worktree.path], in: repository) == nil {
-                runGit(["worktree", "prune"], in: repository)
-            }
-            // Success is the registration actually being gone — a prune that
-            // silently skipped this worktree must not be reported as a removal,
-            // or the row would reappear on the next discovery pass.
-            let gone = WorktreeService.records(in: repository)
-                .map { records in
-                    !records.contains { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) }
-                } ?? false
-            guard gone else {
-                presentWorktreeFailure(
-                    title: localized("Couldn’t remove worktree"),
-                    message: localized("git still lists “\(displayName)”, so it was not removed.")
-                )
-                return
-            }
-        } else if record != nil {
-            guard let status = runGit(["status", "--porcelain"], in: worktree.path) else {
-                presentWorktreeFailure(
-                    title: localized("Couldn’t inspect worktree"),
-                    message: localized("git couldn’t check “\(displayName)” for changes, so it was not removed.")
-                )
-                return
-            }
-            guard status.isEmpty else {
-                presentWorktreeFailure(
-                    title: localized("Worktree has changes"),
-                    message: localized("Commit or discard the changes in “\(displayName)” before removing it.")
-                )
-                return
-            }
-            guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
-                presentWorktreeFailure(
-                    title: localized("Couldn’t remove worktree"),
-                    message: localized("git couldn’t remove “\(displayName)”.")
-                )
-                return
+            if record.prunable {
+                // `prunable` says git lost its way to the checkout, not that the
+                // work is gone: a worktree whose `.git` gitfile was deleted is
+                // marked prunable with every file still on disk. Nothing can
+                // inspect those files for changes — that is what being prunable
+                // costs — so a folder that still holds anything is left alone
+                // rather than deregistered out from under work nobody can see.
+                guard !folderHoldsFiles(at: worktree.path) else {
+                    presentWorktreeFailure(
+                        title: localized("Couldn’t inspect worktree"),
+                        message: localized("git can no longer read “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
+                    )
+                    return
+                }
+                // A targeted remove deregisters just this worktree when its folder
+                // is gone. The damaged-folder shapes fail its validation, and for
+                // those pruning is the only tool git offers — repo-wide, so it is
+                // the fallback rather than the first resort.
+                if runGit(["worktree", "remove", worktree.path], in: repository) == nil {
+                    runGit(["worktree", "prune"], in: repository)
+                }
+                // A prune that silently skipped this worktree must not be reported
+                // as a removal, or the row would reappear on the next discovery
+                // pass. Only git still naming the worktree proves that: a read
+                // that fails here says nothing about a removal that already ran,
+                // and refusing on it would strand a row git has let go of.
+                if let remaining = WorktreeService.records(in: repository),
+                   remaining.contains(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) }) {
+                    presentWorktreeFailure(
+                        title: localized("Couldn’t remove worktree"),
+                        message: localized("git still lists “\(displayName)”, so it was not removed.")
+                    )
+                    return
+                }
+            } else {
+                guard let status = runGit(["status", "--porcelain"], in: worktree.path) else {
+                    presentWorktreeFailure(
+                        title: localized("Couldn’t inspect worktree"),
+                        message: localized("git couldn’t check “\(displayName)” for changes, so it was not removed.")
+                    )
+                    return
+                }
+                guard status.isEmpty else {
+                    presentWorktreeFailure(
+                        title: localized("Worktree has changes"),
+                        message: localized("Commit or discard the changes in “\(displayName)” before removing it.")
+                    )
+                    return
+                }
+                guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
+                    presentWorktreeFailure(
+                        title: localized("Couldn’t remove worktree"),
+                        message: localized("git couldn’t remove “\(displayName)”.")
+                    )
+                    return
+                }
             }
         }
-        // A worktree git no longer lists at all has nothing left to remove; the
+        // A worktree git lists nowhere has nothing left to deregister; the
         // sidebar row and its sessions are all that remain of it.
 
         // Best-effort tidy of the auto-created branch. `-d` (not `-D`) refuses to drop a
@@ -255,6 +282,22 @@ extension TermioStore {
     /// ancestor (a linked home directory, `/tmp`) would otherwise defeat the match.
     private func canonicalWorktreePath(_ path: String) -> String {
         URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    /// Whether anything is left in a checkout git can no longer inspect — the only
+    /// question a disk read can still answer once the `.git` gitfile is gone.
+    ///
+    /// A path that isn't a directory holds no checkout (deleted, or replaced by a
+    /// plain file the removal never touches), and `.DS_Store` is Finder's, not the
+    /// user's: a folder emptied in the Finder keeps one, and counting it would
+    /// dead-end the removal on a worktree with nothing in it.
+    private func folderHoldsFiles(at path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              let entries = try? FileManager.default.contentsOfDirectory(atPath: path)
+        else { return false }
+        return entries.contains { $0 != ".DS_Store" }
     }
 
     /// Copies the git-ignored files a repo lists in `.worktreeinclude` into a freshly

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -257,8 +257,14 @@ extension TermioStore {
         if let branch {
             runGit(["branch", "-d", branch], in: repository)
         }
+        // Matched the way the record was matched. An exact string agrees only
+        // after a reconcile has moved every session onto the row's spelling, and
+        // one that never ran — git erroring on the project, or a session started
+        // since the last pass — would leave those sessions behind, naming a row
+        // that no longer exists: out of the sidebar, still in the saved roster.
+        let key = canonicalWorktreePath(worktree.path)
         let sessionIDs = projects[projectIndex].sessions
-            .filter { $0.worktreePath == worktree.path }
+            .filter { $0.worktreePath.map(canonicalWorktreePath) == key }
             .map(\.id)
         for sessionID in sessionIDs { closeSession(sessionID) }
         if let updatedProjectIndex = projects.firstIndex(where: { $0.id == projectID }) {
@@ -296,45 +302,24 @@ extension TermioStore {
         // damaged, and a detached HEAD carries no branch line, so no sentinel
         // string is needed.
         guard let registrations = WorktreeService.records(in: repository) else {
-            return .refuse(
-                title: localized("Couldn’t inspect worktree"),
-                message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
-            )
+            // A repository whose own folder is gone answers this way and always
+            // will — deleted, or on a share that is not mounted. Refusing on it
+            // would make every row under that project permanently unremovable,
+            // which is the dead end this action exists to undo. A repository
+            // that *is* there and still could not answer is a git failure that
+            // may pass, so that one refuses.
+            guard WorktreeService.folderEvidence(at: repository) == .gone else {
+                return .refuse(
+                    title: localized("Couldn’t inspect worktree"),
+                    message: localized("git couldn’t read this project’s worktrees, so “\(displayName)” was not removed.")
+                )
+            }
+            return decisionWithoutRegistration(for: path, named: displayName)
         }
-        // git holds no registration: there is nothing to deregister and no
-        // branch of its recording to tidy. But the row is not free to drop on
-        // that alone. Dropping it closes every session in the worktree, and a
-        // reconcile re-adds any row a live session still points at
-        // (`applyDiscoveredWorktrees`), so a removal that spared the sessions
-        // would simply undo itself — leaving refusal as the only way not to
-        // destroy them.
-        //
-        // So the disk decides here as well, and only the shapes with nothing
-        // left on them let go. A folder still holding files is a checkout whose
-        // parent repo was re-cloned or whose admin directory was lost, running
-        // agents and uncommitted work and all; before this it was silently
-        // closed and dropped on one click.
         guard let record = registrations
             .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(path) })
         else {
-            switch WorktreeService.folderEvidence(at: path) {
-            case .gone, .emptyFolder, .occupied:
-                // Nothing to protect, and nothing for git to let go of: the
-                // sidebar row is the whole of what is being removed. The folder
-                // is left alone — with no registration, nothing needs the path
-                // cleared.
-                return .letGo(branch: nil, registration: nil)
-            case .mayHoldWork:
-                return .refuse(
-                    title: localized("Couldn’t inspect worktree"),
-                    message: localized("git no longer tracks “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
-                )
-            case .unreadable:
-                return .refuse(
-                    title: localized("Couldn’t inspect worktree"),
-                    message: localized("termio couldn’t read “\(displayName)”, so it was not removed.")
-                )
-            }
+            return decisionWithoutRegistration(for: path, named: displayName)
         }
 
         // Locked first, because it is not a shape of brokenness: git marks a
@@ -398,6 +383,48 @@ extension TermioStore {
             return .refuse(
                 title: localized("Couldn’t inspect worktree"),
                 message: localized("git can no longer inspect “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
+            )
+        case .unreadable:
+            return .refuse(
+                title: localized("Couldn’t inspect worktree"),
+                message: localized("termio couldn’t read “\(displayName)”, so it was not removed.")
+            )
+        }
+    }
+
+    /// What a removal may do when git holds no registration for the path —
+    /// because it never had one, because the user pruned it, or because the
+    /// parent repository itself is gone.
+    ///
+    /// There is nothing to deregister and no branch of git's recording to tidy,
+    /// but the row is not free to drop on that alone: dropping it closes every
+    /// session in the worktree, and a reconcile re-adds any row a live session
+    /// still points at (`applyDiscoveredWorktrees`), so a removal that spared
+    /// the sessions would undo itself. Refusing is the only way not to destroy
+    /// them, so the disk decides, and only what is provably empty lets go.
+    private func decisionWithoutRegistration(
+        for path: String, named displayName: String
+    ) -> WorktreeRemoval {
+        switch WorktreeService.folderEvidence(at: path) {
+        case .gone, .emptyFolder:
+            // Nothing to protect, and nothing for git to let go of: the sidebar
+            // row is the whole of what is being removed. The folder is left
+            // alone — with no registration, nothing needs the path cleared.
+            return .letGo(branch: nil, registration: nil)
+        case .occupied:
+            // Refused for the same reason the registered arm refuses it, and it
+            // is not only about git: `.occupied` is a symlink as well as a plain
+            // file, and a link is exactly the shape that still holds a checkout
+            // — one pointing at work on another volume. Nothing here follows it
+            // to find out, so nothing here may close the sessions in it either.
+            return .refuse(
+                title: localized("Couldn’t remove worktree"),
+                message: localized("Something other than a folder is at “\(displayName)”. Move or delete it, then remove the worktree.")
+            )
+        case .mayHoldWork:
+            return .refuse(
+                title: localized("Couldn’t inspect worktree"),
+                message: localized("git no longer tracks “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
             )
         case .unreadable:
             return .refuse(

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -229,10 +229,21 @@ extension TermioStore {
                 // run here — it is repo-wide, so it would take every other
                 // worktree whose folder is missing with it, including ones
                 // holding work this action was never pointed at.
-                guard deregister(registration, at: worktree.path, in: repository) else {
+                switch deregister(registration, at: worktree.path, in: repository) {
+                case .done:
+                    break
+                case .gitRefused:
                     presentWorktreeFailure(
                         title: localized("Couldn’t remove worktree"),
                         message: localized("git still lists “\(displayName)”, so it was not removed.")
+                    )
+                    return
+                // Named for what actually refused. Reported as git's doing, this
+                // pointed at the one thing that had not gone wrong.
+                case .folderRefused:
+                    presentWorktreeFailure(
+                        title: localized("Couldn’t remove worktree"),
+                        message: localized("termio couldn’t remove the empty folder at “\(displayName)”, so the worktree was not removed.")
                     )
                     return
                 }
@@ -313,8 +324,17 @@ extension TermioStore {
         // while the click waits, and a repo with many worktrees on a slow mount
         // paid that twice over for each of them.
         let wanted = canonicalWorktreePath(path)
-        guard let record = registrations
-            .first(where: { canonicalWorktreePath($0.path) == wanted })
+        let spellings = registrations.map { (canonicalWorktreePath($0.path), $0) }
+        // Exactly, then ignoring case. The filesystem under these paths is
+        // case-insensitive by default and so is git's own `fspathcmp` on macOS, so
+        // a row spelled `Repo-wt` against git's `repo-wt` matched no record — and
+        // the removal then refused with "git no longer tracks it", which was the
+        // opposite of the truth and a dead end of exactly the kind this action
+        // exists to clear. The exact match is tried first so a genuinely
+        // case-sensitive volume, where those are two different checkouts, still
+        // gets the one it named.
+        guard let record = spellings.first(where: { $0.0 == wanted })?.1
+            ?? spellings.first(where: { $0.0.compare(wanted, options: .caseInsensitive) == .orderedSame })?.1
         else {
             return decisionWithoutRegistration(for: path, named: displayName)
         }
@@ -435,8 +455,10 @@ extension TermioStore {
     /// answer whether it is gone.
     ///
     /// The empty folder is cleared only when git has *refused* over it, and is
-    /// put back when git then refuses anyway — so a removal that reports nothing
-    /// happened really did leave the path as it found it. Deleting first and
+    /// put back, with the permissions it had, when git then refuses anyway — so a
+    /// removal that reports nothing happened leaves the path as it found it. The
+    /// one thing not put back is the `.DS_Store`: it is Finder's own, which is
+    /// why clearing it was allowed at all, and Finder writes it again. Deleting first and
     /// reporting afterwards is the shape that kept coming back: git refuses while
     /// the path exists, so the clearing is needed, but doing it up front meant
     /// any later refusal — a concurrent git holding `.git/worktrees`, a
@@ -445,15 +467,27 @@ extension TermioStore {
     /// and the registration with it, or both are as they were.
     private func deregister(
         _ registration: StaleRegistration, at path: String, in repository: String
-    ) -> Bool {
-        if runGit(["worktree", "remove", registration.path], in: repository) != nil { return true }
+    ) -> DeregisterOutcome {
+        if runGit(["worktree", "remove", registration.path], in: repository) != nil { return .done }
         // A remove that refuses while the path still exists touches nothing, so
         // there is nothing to undo before trying the one thing that can help.
-        guard registration.mayClearFolder, clearEmptyFolder(at: path) else { return false }
-        if runGit(["worktree", "remove", registration.path], in: repository) != nil { return true }
+        guard registration.mayClearFolder else { return .gitRefused }
+        // Kept so the folder can go back the way it was found, if it has to.
+        let mode = try? FileManager.default.attributesOfItem(atPath: path)[.posixPermissions]
+        guard clearEmptyFolder(at: path) else { return .folderRefused }
+        if runGit(["worktree", "remove", registration.path], in: repository) != nil { return .done }
         try? FileManager.default.createDirectory(
-            atPath: path, withIntermediateDirectories: false)
-        return false
+            atPath: path, withIntermediateDirectories: false,
+            attributes: mode.map { [.posixPermissions: $0] })
+        return .gitRefused
+    }
+
+    /// What came of trying to drop git's registration — named so the refusal the
+    /// user reads is the one that actually happened.
+    private enum DeregisterOutcome {
+        case done
+        case gitRefused
+        case folderRefused
     }
 
     /// Remove the empty folder a checkout left behind, so git's targeted remove

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -324,7 +324,6 @@ extension TermioStore {
         // while the click waits, and a repo with many worktrees on a slow mount
         // paid that twice over for each of them.
         let wanted = canonicalWorktreePath(path)
-        let spellings = registrations.map { (canonicalWorktreePath($0.path), $0) }
         // Exactly, then ignoring case. The filesystem under these paths is
         // case-insensitive by default and so is git's own `fspathcmp` on macOS, so
         // a row spelled `Repo-wt` against git's `repo-wt` matched no record — and
@@ -333,8 +332,16 @@ extension TermioStore {
         // exists to clear. The exact match is tried first so a genuinely
         // case-sensitive volume, where those are two different checkouts, still
         // gets the one it named.
-        guard let record = spellings.first(where: { $0.0 == wanted })?.1
-            ?? spellings.first(where: { $0.0.compare(wanted, options: .caseInsensitive) == .orderedSame })?.1
+        //
+        // Lazily, because resolving a path stats it and follows its links: doing
+        // that to every registration up front meant one worktree on a hung mount
+        // blocked the click that removed an unrelated, healthy one.
+        guard let record = registrations.lazy
+            .first(where: { canonicalWorktreePath($0.path) == wanted })
+            ?? registrations.lazy.first(where: {
+                canonicalWorktreePath($0.path).compare(wanted, options: .caseInsensitive)
+                    == .orderedSame
+            })
         else {
             return decisionWithoutRegistration(for: path, named: displayName)
         }

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -161,52 +161,85 @@ extension TermioStore {
               let worktree = projects[projectIndex].worktrees.first(where: { $0.id == worktreeID })
         else { return }
 
-        // A worktree whose folder was deleted by another tool can't be inspected —
-        // `git status` has no directory to run in, and `git worktree remove` refuses a
-        // missing path — so the dirty check would dead-end this action forever (a live
-        // session is what keeps a git-absent worktree in the sidebar, see
-        // `applyDiscoveredWorktrees`, and this action is the only way to let go of it).
-        // There is no work left on disk to protect: skip straight to pruning the stale
-        // registration, recovering the branch from the parent repo's metadata since the
-        // checkout can no longer answer for itself.
-        let branch: String?
-        if FileManager.default.fileExists(atPath: worktree.path) {
+        let repository = projects[projectIndex].path
+        let displayName = (worktree.path as NSString).lastPathComponent
+
+        // One `git worktree list --porcelain` read answers everything the removal
+        // decides on: whether git still knows this checkout, whether git itself
+        // judges it gone (`prunable` covers the folder-deleted shape *and* the
+        // damaged ones — an emptied folder, a deleted `.git` gitfile, a path
+        // replaced by a plain file — none of which `git status` can inspect), and
+        // which branch to tidy afterward. The branch comes from the repo's records
+        // for both arms: the checkout can't be asked once its folder is damaged,
+        // and a detached HEAD simply carries no branch line, so no sentinel string
+        // is needed. Raw disk checks are deliberately not consulted — git's own
+        // verdict is what decides, including its escape hatch: a worktree on
+        // removable media is protected by `git worktree lock`, which is honored
+        // below.
+        let record = WorktreeService.records(in: repository)?
+            .first(where: { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) })
+        let branch = record?.branch
+
+        if let record, record.prunable {
+            guard !record.locked else {
+                presentWorktreeFailure(
+                    title: localized("Worktree is locked"),
+                    message: localized("Unlock “\(displayName)” (git worktree unlock) before removing it.")
+                )
+                return
+            }
+            // A targeted remove deregisters just this worktree when its folder is
+            // gone. The damaged-folder shapes fail its validation, and for those
+            // pruning is the only tool git offers — repo-wide, so it is the
+            // fallback rather than the first resort.
+            if runGit(["worktree", "remove", worktree.path], in: repository) == nil {
+                runGit(["worktree", "prune"], in: repository)
+            }
+            // Success is the registration actually being gone — a prune that
+            // silently skipped this worktree must not be reported as a removal,
+            // or the row would reappear on the next discovery pass.
+            let gone = WorktreeService.records(in: repository)
+                .map { records in
+                    !records.contains { canonicalWorktreePath($0.path) == canonicalWorktreePath(worktree.path) }
+                } ?? false
+            guard gone else {
+                presentWorktreeFailure(
+                    title: localized("Couldn’t remove worktree"),
+                    message: localized("git still lists “\(displayName)”, so it was not removed.")
+                )
+                return
+            }
+        } else if record != nil {
             guard let status = runGit(["status", "--porcelain"], in: worktree.path) else {
                 presentWorktreeFailure(
                     title: localized("Couldn’t inspect worktree"),
-                    message: localized("git couldn’t check “\((worktree.path as NSString).lastPathComponent)” for changes, so it was not removed.")
+                    message: localized("git couldn’t check “\(displayName)” for changes, so it was not removed.")
                 )
                 return
             }
             guard status.isEmpty else {
                 presentWorktreeFailure(
                     title: localized("Worktree has changes"),
-                    message: localized("Commit or discard the changes in “\((worktree.path as NSString).lastPathComponent)” before removing it.")
+                    message: localized("Commit or discard the changes in “\(displayName)” before removing it.")
                 )
                 return
             }
-            // The branch termio created for this worktree, captured before removal so it can
-            // be tidied afterward. A user who switched branches inside the worktree leaves a
-            // different name here — that is theirs to keep, and the safe delete below won't
-            // touch it if it carries unmerged commits.
-            branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], in: worktree.path)
-            guard runGit(["worktree", "remove", worktree.path], in: projects[projectIndex].path) != nil else {
+            guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
                 presentWorktreeFailure(
                     title: localized("Couldn’t remove worktree"),
-                    message: localized("git couldn’t remove “\((worktree.path as NSString).lastPathComponent)”.")
+                    message: localized("git couldn’t remove “\(displayName)”.")
                 )
                 return
             }
-        } else {
-            branch = registeredBranch(ofWorktreeAt: worktree.path, in: projects[projectIndex].path)
         }
+        // A worktree git no longer lists at all has nothing left to remove; the
+        // sidebar row and its sessions are all that remain of it.
 
-        let pruneSucceeded = runGit(["worktree", "prune"], in: projects[projectIndex].path) != nil
         // Best-effort tidy of the auto-created branch. `-d` (not `-D`) refuses to drop a
         // branch with unmerged commits, so real work is never lost — the branch simply
-        // stays. Skips a detached HEAD ("HEAD") and any failure is silent.
-        if let branch, branch != "HEAD" {
-            runGit(["branch", "-d", branch], in: projects[projectIndex].path)
+        // stays. Any failure is silent.
+        if let branch {
+            runGit(["branch", "-d", branch], in: repository)
         }
         let sessionIDs = projects[projectIndex].sessions
             .filter { $0.worktreePath == worktree.path }
@@ -215,35 +248,13 @@ extension TermioStore {
         if let updatedProjectIndex = projects.firstIndex(where: { $0.id == projectID }) {
             projects[updatedProjectIndex].worktrees.removeAll { $0.id == worktreeID }
         }
-        if !pruneSucceeded {
-            presentWorktreeFailure(
-                title: localized("Worktree removed"),
-                message: localized("The folder was removed, but git couldn’t prune its stale worktree metadata.")
-            )
-        }
     }
 
-    /// The branch checked out in the worktree registered at `path`, read from the parent
-    /// repo's own records (`git worktree list --porcelain`) — the only source that still
-    /// answers once the checkout's folder is gone. Records are blank-line separated; the
-    /// one opening with `worktree <path>` carries a `branch refs/heads/<name>` line,
-    /// absent on a detached HEAD (which has no branch to tidy anyway).
-    private func registeredBranch(ofWorktreeAt path: String, in repository: String) -> String? {
-        guard let listing = runGit(["worktree", "list", "--porcelain"], in: repository) else { return nil }
-        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
-        for record in listing.components(separatedBy: "\n\n") {
-            let lines = record.split(separator: "\n", omittingEmptySubsequences: true)
-            guard let worktreeLine = lines.first(where: { $0.hasPrefix("worktree ") }),
-                  URL(fileURLWithPath: String(worktreeLine.dropFirst("worktree ".count)))
-                      .standardizedFileURL.path == standardized
-            else { continue }
-            guard let branchLine = lines.first(where: { $0.hasPrefix("branch ") }) else { return nil }
-            let reference = String(branchLine.dropFirst("branch ".count))
-            return reference.hasPrefix("refs/heads/")
-                ? String(reference.dropFirst("refs/heads/".count))
-                : reference
-        }
-        return nil
+    /// One spelling for a worktree path however it reaches us: git prints realpaths
+    /// while `Worktree.path` keeps whatever spelling created it, so a symlinked
+    /// ancestor (a linked home directory, `/tmp`) would otherwise defeat the match.
+    private func canonicalWorktreePath(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
     }
 
     /// Copies the git-ignored files a repo lists in `.worktreeinclude` into a freshly

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -160,11 +160,13 @@ extension TermioStore {
     private enum WorktreeRemoval {
         /// git can still inspect the checkout, and it came back clean: git removes
         /// the folder and the registration itself.
-        case removeCheckout(branch: String?)
-        /// Nothing on disk is left to protect. `registered` says whether git still
-        /// lists the worktree and there is a registration to drop, or whether only
-        /// the sidebar row remains.
-        case letGo(branch: String?, registered: Bool)
+        case removeCheckout(branch: String?, registration: String)
+        /// Nothing on disk is left to protect. `registration` is git's own
+        /// spelling of the path when it still lists the worktree, and `nil` when
+        /// it does not and only the sidebar row remains. `emptyFolder` says an
+        /// empty directory is still at the path and has to be cleared before git
+        /// will deregister the worktree.
+        case letGo(branch: String?, registration: String?, emptyFolder: Bool)
         /// Leave everything as it is, and say why.
         case refuse(title: String, message: String)
     }
@@ -186,8 +188,8 @@ extension TermioStore {
             presentWorktreeFailure(title: title, message: message)
             return
 
-        case let .removeCheckout(checkedOutBranch):
-            guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
+        case let .removeCheckout(checkedOutBranch, registration):
+            guard runGit(["worktree", "remove", registration], in: repository) != nil else {
                 presentWorktreeFailure(
                     title: localized("Couldn’t remove worktree"),
                     message: localized("git couldn’t remove “\(displayName)”.")
@@ -196,16 +198,22 @@ extension TermioStore {
             }
             branch = checkedOutBranch
 
-        case let .letGo(registeredBranch, registered):
-            if registered {
-                // An empty folder is cleared so git's own *targeted* remove
-                // applies: with the path gone it deregisters this worktree and
-                // nothing else. `git worktree prune` is never run — it is
-                // repo-wide, so it would take every other worktree whose folder
-                // is missing with it, including ones holding work this action
-                // was never pointed at and nothing has inspected.
+        case let .letGo(registeredBranch, registration, emptyFolder):
+            // Filesystem work goes to the path the evidence was gathered at;
+            // git is addressed by the spelling git itself printed. The two can
+            // differ through a symlinked ancestor, and git refuses an argument
+            // it cannot realpath — "is not a working tree" for a removal that
+            // succeeds when handed its own spelling.
+            if emptyFolder {
                 clearEmptyFolder(at: worktree.path)
-                guard runGit(["worktree", "remove", worktree.path], in: repository) != nil else {
+            }
+            if let registration {
+                // With the path cleared, git's own *targeted* remove applies: it
+                // deregisters this worktree and nothing else. `git worktree
+                // prune` is never run — it is repo-wide, so it would take every
+                // other worktree whose folder is missing with it, including ones
+                // holding work this action was never pointed at.
+                guard runGit(["worktree", "remove", registration], in: repository) != nil else {
                     presentWorktreeFailure(
                         title: localized("Couldn’t remove worktree"),
                         message: localized("git still lists “\(displayName)”, so it was not removed.")
@@ -298,7 +306,7 @@ extension TermioStore {
                     message: localized("Commit or discard the changes in “\(displayName)” before removing it.")
                 )
             }
-            return .removeCheckout(branch: record.branch)
+            return .removeCheckout(branch: record.branch, registration: record.path)
         }
 
         // Everything else reaches the same gate: a `prunable` record, where git
@@ -308,12 +316,27 @@ extension TermioStore {
         // no check whatsoever, closing a live session and dropping the row on one
         // click of a menu item that asks nothing first.
         switch WorktreeService.folderEvidence(at: path) {
-        case .nothingToProtect:
-            return .letGo(branch: record?.branch, registered: record != nil)
+        case .gone:
+            return .letGo(branch: record?.branch, registration: record?.path, emptyFolder: false)
+        case .emptyFolder:
+            return .letGo(branch: record?.branch, registration: record?.path, emptyFolder: true)
+        case .occupied:
+            // git refuses to deregister a worktree whose path exists without a
+            // `.git` in it — `--force` included — and what is sitting there is
+            // not this action's to delete. Naming the remedy is the whole
+            // difference between this and the dead end the PR set out to fix.
+            return .refuse(
+                title: localized("Couldn’t remove worktree"),
+                message: localized("Something other than a folder is at “\(displayName)”. Move or delete it, then remove the worktree.")
+            )
         case .mayHoldWork:
+            // "Can no longer inspect", not "no longer tracks": this arm is also
+            // reached with a `prunable` record, where `git worktree list` does
+            // still name the worktree and a user who checked would find the
+            // opposite of what the alert said.
             return .refuse(
                 title: localized("Couldn’t inspect worktree"),
-                message: localized("git no longer tracks “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
+                message: localized("git can no longer inspect “\(displayName)”, and its folder still holds files. Delete the folder to remove the worktree.")
             )
         case .unreadable:
             return .refuse(
@@ -331,6 +354,12 @@ extension TermioStore {
     /// `folderEvidence` discounted. Nothing recursive, so a folder that gained a
     /// file between the decision and here survives, and the removal that follows
     /// fails loudly instead of taking it.
+    ///
+    /// Reached only for `.emptyFolder`, which is what makes the `.DS_Store`
+    /// unlink safe: `unlink` follows symlinks, so on a path that is itself a
+    /// symlink this would reach into a directory the decision never inspected.
+    /// `folderEvidence` classifies that path `.occupied` instead, and this is
+    /// not called for it.
     private func clearEmptyFolder(at path: String) {
         let dsStore = (path as NSString).appendingPathComponent(".DS_Store")
         _ = dsStore.withCString { unlink($0) }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1315,10 +1315,15 @@ final class TermioStore: ObservableObject {
             if let folders, !projectOwns(project, anyOf: folders) { continue }
             let id = project.id
             let path = project.path
+            // The spellings this pass will compare, handed over so they can be
+            // resolved off the main actor with the git read.
+            let known = project.worktrees.map(\.path)
+                + project.sessions.compactMap(\.worktreePath)
             Task { [weak self] in
                 // `nil` means git errored (not a repo, transient) → leave the list untouched.
-                guard let discovered = await WorktreeService.linkedWorktrees(in: path) else { return }
-                await MainActor.run { self?.applyDiscoveredWorktrees(discovered, to: id) }
+                guard let reconciled = await WorktreeService.reconcile(in: path, against: known)
+                else { return }
+                await MainActor.run { self?.applyDiscoveredWorktrees(reconciled, to: id) }
             }
         }
     }
@@ -1341,13 +1346,24 @@ final class TermioStore: ObservableObject {
     /// A path git no longer reports is pruned — unless a live session still points at it,
     /// so an in-use worktree never vanishes from under its sessions. Only writes back when
     /// something actually changed, so a stable repo doesn't churn the persisted tree.
-    private func applyDiscoveredWorktrees(_ discovered: [String], to projectID: Project.ID) {
+    func applyDiscoveredWorktrees(
+        _ reconciled: WorktreeService.Reconcile, to projectID: Project.ID
+    ) {
         guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return }
         // Matched the way the removal matches (`WorktreeService.canonicalPath`),
         // which resolves symlinks rather than only standardizing. Under a
         // symlinked ancestor git's spelling never equalled a stored row's, so
         // this appended a *second* row for a checkout that already had one.
-        let canonical = WorktreeService.canonicalPath
+        //
+        // Looked up, never computed: those spellings were resolved off-main with
+        // the git read. A path that appeared since then — a row added in the last
+        // moments — falls back to the lexical form for this pass and is resolved
+        // on the next one, which is a stale match at worst and never a stalled
+        // main thread.
+        let canonical = { (path: String) in
+            reconciled.canonical[path] ?? Self.standardizedPath(path)
+        }
+        let discovered = reconciled.discovered
         let discoveredSet = Set(discovered.map(canonical))
         let existing = projects[index].worktrees
         let byPath = Dictionary(existing.map { (canonical($0.path), $0) },
@@ -1364,6 +1380,28 @@ final class TermioStore: ObservableObject {
         }
 
         if projects[index].worktrees != rebuilt { projects[index].worktrees = rebuilt }
+        adoptWorktreeSpellings(in: index, canonical: canonical)
+    }
+
+    /// Moves each session onto the spelling of the worktree row it belongs to.
+    ///
+    /// Sessions are matched to rows by exact path elsewhere in the app, so a
+    /// session left on a spelling no row carries belongs to no row: it drops out
+    /// of the sidebar entirely while staying in the saved roster, and nothing
+    /// short of editing state on disk brings it back. That is what merging two
+    /// rows for one checkout would otherwise do to the loser's sessions — and
+    /// those duplicate rows exist on disk today, made by the lexical matching
+    /// this pass replaces.
+    private func adoptWorktreeSpellings(in index: Int, canonical: (String) -> String) {
+        let rowsByKey = Dictionary(projects[index].worktrees.map { (canonical($0.path), $0.path) },
+                                   uniquingKeysWith: { first, _ in first })
+        for position in projects[index].sessions.indices {
+            guard let path = projects[index].sessions[position].worktreePath,
+                  let row = rowsByKey[canonical(path)],
+                  row != path
+            else { continue }
+            projects[index].sessions[position].worktreePath = row
+        }
     }
 
     private static func standardizedPath(_ path: String) -> String {

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1343,19 +1343,24 @@ final class TermioStore: ObservableObject {
     /// something actually changed, so a stable repo doesn't churn the persisted tree.
     private func applyDiscoveredWorktrees(_ discovered: [String], to projectID: Project.ID) {
         guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return }
-        let discoveredSet = Set(discovered)
+        // Matched the way the removal matches (`WorktreeService.canonicalPath`),
+        // which resolves symlinks rather than only standardizing. Under a
+        // symlinked ancestor git's spelling never equalled a stored row's, so
+        // this appended a *second* row for a checkout that already had one.
+        let canonical = WorktreeService.canonicalPath
+        let discoveredSet = Set(discovered.map(canonical))
         let existing = projects[index].worktrees
-        let byPath = Dictionary(existing.map { (Self.standardizedPath($0.path), $0) },
+        let byPath = Dictionary(existing.map { (canonical($0.path), $0) },
                                 uniquingKeysWith: { first, _ in first })
         let sessionAnchored = Set(projects[index].sessions.compactMap { $0.worktreePath }
-            .map(Self.standardizedPath))
+            .map(canonical))
 
         // Discovered worktrees first (reusing existing entries to preserve id/createdAt)…
-        var rebuilt = discovered.map { byPath[$0] ?? Worktree(path: $0) }
+        var rebuilt = discovered.map { byPath[canonical($0)] ?? Worktree(path: $0) }
         // …then any git-absent entry that still has a session, so it isn't yanked away.
         for worktree in existing {
-            let std = Self.standardizedPath(worktree.path)
-            if !discoveredSet.contains(std), sessionAnchored.contains(std) { rebuilt.append(worktree) }
+            let key = canonical(worktree.path)
+            if !discoveredSet.contains(key), sessionAnchored.contains(key) { rebuilt.append(worktree) }
         }
 
         if projects[index].worktrees != rebuilt { projects[index].worktrees = rebuilt }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1373,16 +1373,27 @@ final class TermioStore: ObservableObject {
 
         // Discovered worktrees first (reusing existing entries to preserve id/createdAt)…
         var rebuilt = discovered.map { byPath[canonical($0)] ?? Worktree(path: $0) }
-        // …then any git-absent entry that still has a session, so it isn't yanked
-        // away. One row per checkout here too: a worktree whose folder was
-        // deleted and whose row a session keeps alive is this feature's own
-        // case, and duplicates of it took this path rather than the merge above,
-        // so both survived every pass — the sessions moving onto the first and
-        // the second staying forever, empty and unremovable.
+        // …then any entry git no longer offers that still has a reason to stay: a
+        // session is in it, or git still holds a registration for it that only
+        // the user's own Remove can let go of. Dropping that second kind is what
+        // left a deleted-folder worktree unreachable — no row, so no way to
+        // reach the removal, and its registration and branch stayed in the
+        // repository for good. It is kept rather than swept because deregistering
+        // it without being asked would delete that worktree's HEAD, index and
+        // reflogs, and a folder that is merely unreachable — an unmounted share,
+        // a cloud provider that is not running — looks exactly like a deleted
+        // one from here.
+        //
+        // One row per checkout here too: duplicates took this path rather than
+        // the merge above, so both survived every pass — the sessions moving onto
+        // the first and the second staying forever, empty and unremovable.
+        let staleSet = Set(reconciled.stale.map(canonical))
         var kept = discoveredSet
         for worktree in existing {
             let key = canonical(worktree.path)
-            guard !kept.contains(key), sessionAnchored.contains(key) else { continue }
+            guard !kept.contains(key),
+                  sessionAnchored.contains(key) || staleSet.contains(key)
+            else { continue }
             kept.insert(key)
             rebuilt.append(worktree)
         }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1372,7 +1372,12 @@ final class TermioStore: ObservableObject {
             .map(canonical))
 
         // Discovered worktrees first (reusing existing entries to preserve id/createdAt)…
-        var rebuilt = discovered.map { byPath[canonical($0)] ?? Worktree(path: $0) }
+        var rebuilt = discovered.map { path -> Worktree in
+            var row = byPath[canonical(path)] ?? Worktree(path: path)
+            // git offers it again: whatever was wrong with it no longer is.
+            row.missing = false
+            return row
+        }
         // …then any entry git no longer offers that still has a reason to stay: a
         // session is in it, or git still holds a registration for it that only
         // the user's own Remove can let go of. Dropping that second kind is what
@@ -1395,7 +1400,12 @@ final class TermioStore: ObservableObject {
                   sessionAnchored.contains(key) || staleSet.contains(key)
             else { continue }
             kept.insert(key)
-            rebuilt.append(worktree)
+            var row = worktree
+            // Marked so nothing offers to start a session in a checkout that is
+            // not there. The row stays, because removing it is what the user
+            // still needs to be able to do.
+            row.missing = staleSet.contains(key)
+            rebuilt.append(row)
         }
 
         if projects[index].worktrees != rebuilt { projects[index].worktrees = rebuilt }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1373,10 +1373,18 @@ final class TermioStore: ObservableObject {
 
         // Discovered worktrees first (reusing existing entries to preserve id/createdAt)…
         var rebuilt = discovered.map { byPath[canonical($0)] ?? Worktree(path: $0) }
-        // …then any git-absent entry that still has a session, so it isn't yanked away.
+        // …then any git-absent entry that still has a session, so it isn't yanked
+        // away. One row per checkout here too: a worktree whose folder was
+        // deleted and whose row a session keeps alive is this feature's own
+        // case, and duplicates of it took this path rather than the merge above,
+        // so both survived every pass — the sessions moving onto the first and
+        // the second staying forever, empty and unremovable.
+        var kept = discoveredSet
         for worktree in existing {
             let key = canonical(worktree.path)
-            if !discoveredSet.contains(key), sessionAnchored.contains(key) { rebuilt.append(worktree) }
+            guard !kept.contains(key), sessionAnchored.contains(key) else { continue }
+            kept.insert(key)
+            rebuilt.append(worktree)
         }
 
         if projects[index].worktrees != rebuilt { projects[index].worktrees = rebuilt }
@@ -1395,13 +1403,21 @@ final class TermioStore: ObservableObject {
     private func adoptWorktreeSpellings(in index: Int, canonical: (String) -> String) {
         let rowsByKey = Dictionary(projects[index].worktrees.map { (canonical($0.path), $0.path) },
                                    uniquingKeysWith: { first, _ in first })
-        for position in projects[index].sessions.indices {
-            guard let path = projects[index].sessions[position].worktreePath,
+        // Built whole and assigned once. Writing through `projects` in the loop
+        // fired the store's own `didSet` per session — a synchronous state-file
+        // write each time, on the main actor, in a pass that runs on every git
+        // change. Nothing is assigned at all when no session moved.
+        var sessions = projects[index].sessions
+        var moved = false
+        for position in sessions.indices {
+            guard let path = sessions[position].worktreePath,
                   let row = rowsByKey[canonical(path)],
                   row != path
             else { continue }
-            projects[index].sessions[position].worktreePath = row
+            sessions[position].worktreePath = row
+            moved = true
         }
+        if moved { projects[index].sessions = sessions }
     }
 
     private static func standardizedPath(_ path: String) -> String {

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1070,6 +1070,11 @@ final class TermioStore: ObservableObject {
     /// Debounces the worktree re-scan so a burst of git-dir events (a rebase, a fetch)
     /// coalesces into one `git worktree list`.
     private var worktreeReconcileWork: DispatchWorkItem?
+    /// Issued to each reconcile pass, and the newest one each project has applied.
+    /// A pass that finishes after a newer one has landed is dropped rather than
+    /// overwriting what the newer one learned.
+    private var worktreeReconcileTicket = 0
+    private var appliedWorktreeReconcile: [Project.ID: Int] = [:]
     /// The folders whose git state changed since the last reconcile pass, plus whether
     /// a full pass (app activation) was requested meanwhile. One `.git` change used to
     /// re-scan *every* folder project — N git spawns for one repo's event; scoping the
@@ -1319,11 +1324,21 @@ final class TermioStore: ObservableObject {
             // resolved off the main actor with the git read.
             let known = project.worktrees.map(\.path)
                 + project.sessions.compactMap(\.worktreePath)
+            // Stamped so a pass that was overtaken cannot land on top of a newer
+            // one. The debounce cancels work that has not started; it cannot
+            // cancel a git read already running, and a result from before a
+            // worktree's folder came back would mark that row unusable again —
+            // stripping its verbs until some unrelated git event.
+            worktreeReconcileTicket += 1
+            let ticket = worktreeReconcileTicket
             Task { [weak self] in
                 // `nil` means git errored (not a repo, transient) → leave the list untouched.
                 guard let reconciled = await WorktreeService.reconcile(in: path, against: known)
                 else { return }
-                await MainActor.run { self?.applyDiscoveredWorktrees(reconciled, to: id) }
+                await MainActor.run {
+                    guard let self, self.acceptWorktreeReconcile(ticket, for: id) else { return }
+                    self.applyDiscoveredWorktrees(reconciled, to: id)
+                }
             }
         }
     }
@@ -1340,6 +1355,15 @@ final class TermioStore: ObservableObject {
                folders.contains(Self.standardizedPath(path)) { return true }
         }
         return false
+    }
+
+    /// Whether a finished reconcile is still the newest word on this project, and
+    /// claims that standing when it is. An older pass landing after a newer one
+    /// would undo what the newer one learned.
+    private func acceptWorktreeReconcile(_ ticket: Int, for projectID: Project.ID) -> Bool {
+        guard ticket > appliedWorktreeReconcile[projectID] ?? 0 else { return false }
+        appliedWorktreeReconcile[projectID] = ticket
+        return true
     }
 
     /// Merges git's linked-worktree paths into one project's `worktrees`, in git's order.
@@ -1393,6 +1417,9 @@ final class TermioStore: ObservableObject {
         // the merge above, so both survived every pass — the sessions moving onto
         // the first and the second staying forever, empty and unremovable.
         let staleSet = Set(reconciled.stale.map(canonical))
+        // Marked for having nowhere to work, not for git having lost track: a
+        // folder that is still there can be opened whatever git thinks of it.
+        let absentSet = Set(reconciled.absent.map(canonical))
         var kept = discoveredSet
         for worktree in existing {
             let key = canonical(worktree.path)
@@ -1404,7 +1431,7 @@ final class TermioStore: ObservableObject {
             // Marked so nothing offers to start a session in a checkout that is
             // not there. The row stays, because removing it is what the user
             // still needs to be able to do.
-            row.missing = staleSet.contains(key)
+            row.missing = absentSet.contains(key)
             rebuilt.append(row)
         }
 

--- a/Tests/termioTests/WorktreeReconcileGitTests.swift
+++ b/Tests/termioTests/WorktreeReconcileGitTests.swift
@@ -1,16 +1,22 @@
 import XCTest
 @testable import termio
 
-/// The reconcile's sweep of registrations whose checkouts are gone, against a
-/// real repository — it deregisters without anyone asking, so what it will and
-/// will not touch is worth holding down.
-final class WorktreeSweepTests: XCTestCase {
+/// What the automatic reconcile does to a repository, against a real one.
+///
+/// The answer has to be *nothing*: it is a background pass, triggered by a
+/// branch-watcher event or the app coming forward, with no user behind it.
+/// `git worktree remove` on a path that is missing deletes that worktree's HEAD,
+/// index, per-worktree refs and reflogs — and a folder that is merely
+/// unreachable, an unmounted share or a cloud provider that is not running,
+/// looks exactly like a deleted one from here. So the pass reports a vanished
+/// checkout and leaves the deregistering to the user's own Remove.
+final class WorktreeReconcileGitTests: XCTestCase {
     private var root: URL!
     private var repo: URL { root.appendingPathComponent("repo") }
 
     override func setUpWithError() throws {
         root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("worktree-sweep-\(UUID().uuidString)")
+            .appendingPathComponent("worktree-reconcile-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
         try git(["init", "--quiet"])
         try git(["commit", "--quiet", "--allow-empty", "-m", "init"])
@@ -20,11 +26,9 @@ final class WorktreeSweepTests: XCTestCase {
         try? FileManager.default.removeItem(at: root)
     }
 
-    /// A checkout whose folder is simply gone is deregistered, so the path can be
-    /// used again. Nothing else is: a folder still holding files, an emptied one,
-    /// and one git is holding with `lock` all stay for the user's own Remove to
-    /// decide on — and the sweep never deletes a file to get there.
-    func testOnlyAVanishedCheckoutIsSweptAway() async throws {
+    /// Every registration survives the pass, whatever shape its checkout is in,
+    /// and each unusable one is reported so its row keeps its place.
+    func testTheAutomaticPassDeregistersNothing() async throws {
         for name in ["gone", "work", "empty", "locked"] {
             try git(["worktree", "add", "--quiet", "-b", name, worktree(name).path, "HEAD"])
         }
@@ -39,34 +43,47 @@ final class WorktreeSweepTests: XCTestCase {
         try git(["worktree", "lock", worktree("locked").path])
         try FileManager.default.removeItem(at: worktree("locked"))
 
-        _ = await WorktreeService.reconcile(in: repo.path, against: [])
+        let reconciled = await WorktreeService.reconcile(in: repo.path, against: [])
+        let plan = try XCTUnwrap(reconciled)
 
         // Compared canonically, because git prints realpaths and the temporary
         // directory these live under is reached through a symlink.
         let registered = try registeredPaths()
-        XCTAssertFalse(registered.contains(key("gone")), "a vanished checkout is let go of")
-        XCTAssertTrue(registered.contains(key("work")), "work nobody inspected stays registered")
-        XCTAssertTrue(registered.contains(key("empty")), "an emptied folder is the user's call")
-        XCTAssertTrue(registered.contains(key("locked")), "a locked worktree is git's to hold")
-
+        for name in ["gone", "work", "empty", "locked"] {
+            XCTAssertTrue(registered.contains(key(name)),
+                          "\(name) must still be registered after an automatic pass")
+        }
+        // Nothing on disk is touched either.
         XCTAssertTrue(
             FileManager.default.fileExists(
-                atPath: worktree("work").appendingPathComponent("draft.txt").path),
-            "the sweep deletes no files")
+                atPath: worktree("work").appendingPathComponent("draft.txt").path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: worktree("empty").path))
-
-        // The point of letting go: the path is usable again. Before this, the
-        // registration leaked and a later add at the same path was refused.
-        try git(["worktree", "add", "--quiet", "-b", "again", worktree("gone").path, "HEAD"])
-
-        // The branch is left alone — deleting a ref is not something a pass
-        // nobody asked for should do.
         XCTAssertTrue(try branches().contains("gone"))
+
+        // What it does instead: every one git cannot offer is reported stale, so a
+        // row for it keeps its place and the user can reach the removal. None of
+        // these four is usable — each had its folder deleted or its `.git` taken
+        // away — so none is offered as a worktree to open.
+        let stale = Set(plan.stale.map(WorktreeService.canonicalPath))
+        for name in ["gone", "work", "empty", "locked"] {
+            XCTAssertTrue(stale.contains(key(name)), "\(name) must be reported as stale")
+        }
+        XCTAssertTrue(plan.discovered.isEmpty, "\(plan.discovered)")
     }
 
-    /// The sweep leaves what it cannot see. A path whose volume is not mounted
-    /// answers "no such file" for everything on it, and `/Volumes` with the
-    /// volume directory absent is what that looks like.
+    /// A healthy worktree is offered to open and is not reported stale — the
+    /// distinction the row-keeping rests on.
+    func testAHealthyWorktreeIsOfferedRatherThanReportedStale() async throws {
+        try git(["worktree", "add", "--quiet", "-b", "live", worktree("live").path, "HEAD"])
+        let reconciled = await WorktreeService.reconcile(in: repo.path, against: [])
+        let plan = try XCTUnwrap(reconciled)
+        XCTAssertEqual(plan.discovered.map(WorktreeService.canonicalPath), [key("live")])
+        XCTAssertTrue(plan.stale.isEmpty, "\(plan.stale)")
+    }
+
+    /// And the probe the removal leans on still fails closed: a path whose volume
+    /// is not mounted answers "no such file" for everything on it, which must not
+    /// read as a checkout someone deleted.
     func testAnUnmountedVolumeIsNotMistakenForADeletedCheckout() {
         XCTAssertEqual(
             WorktreeService.folderEvidence(at: "/Volumes/TermioNoSuchVolume/repo-wt"),

--- a/Tests/termioTests/WorktreeReconcileGitTests.swift
+++ b/Tests/termioTests/WorktreeReconcileGitTests.swift
@@ -71,6 +71,33 @@ final class WorktreeReconcileGitTests: XCTestCase {
         XCTAssertTrue(plan.discovered.isEmpty, "\(plan.discovered)")
     }
 
+    /// Stale is not the same question as having nowhere to work. git calls a
+    /// worktree prunable the moment its `.git` gitfile goes, with every one of the
+    /// user's files still sitting there — and a terminal opened in that folder is
+    /// exactly how they get those files out. Marking it absent took the verbs away
+    /// while the removal refused with advice that would have deleted the work.
+    func testAFolderThatStillHoldsFilesIsStaleButNotAbsent() async throws {
+        try git(["worktree", "add", "--quiet", "-b", "work", worktree("work").path, "HEAD"])
+        try "uncommitted".write(to: worktree("work").appendingPathComponent("draft.txt"),
+                                atomically: true, encoding: .utf8)
+        try FileManager.default.removeItem(at: worktree("work").appendingPathComponent(".git"))
+
+        try git(["worktree", "add", "--quiet", "-b", "vanished", worktree("vanished").path, "HEAD"])
+        try FileManager.default.removeItem(at: worktree("vanished"))
+
+        let reconciled = await WorktreeService.reconcile(in: repo.path, against: [])
+        let plan = try XCTUnwrap(reconciled)
+        let stale = Set(plan.stale.map(WorktreeService.canonicalPath))
+        let absent = Set(plan.absent.map(WorktreeService.canonicalPath))
+
+        // Neither can be offered as a worktree to open…
+        XCTAssertTrue(stale.contains(key("work")))
+        XCTAssertTrue(stale.contains(key("vanished")))
+        // …but only one of them has nowhere to work.
+        XCTAssertFalse(absent.contains(key("work")), "its folder and the user's files are right there")
+        XCTAssertTrue(absent.contains(key("vanished")))
+    }
+
     /// A healthy worktree is offered to open and is not reported stale — the
     /// distinction the row-keeping rests on.
     func testAHealthyWorktreeIsOfferedRatherThanReportedStale() async throws {

--- a/Tests/termioTests/WorktreeReconcileTests.swift
+++ b/Tests/termioTests/WorktreeReconcileTests.swift
@@ -77,6 +77,32 @@ final class WorktreeReconcileTests: XCTestCase {
         XCTAssertEqual(store.projects[0].sessions[0].worktreePath, "/tmp/scratch/wt-gone")
     }
 
+    /// Duplicates collapse on the git-absent path too, which is this feature's
+    /// own case: a worktree whose folder was deleted, kept in the sidebar only
+    /// because a session is still in it. Those rows never reach the merge above,
+    /// so both used to survive every pass — the sessions moving onto the first
+    /// and the second left behind, empty and anchored by a key nothing would
+    /// clear.
+    func testDuplicateRowsCollapseEvenWhenGitReportsNeither() {
+        let store = makeStore(
+            worktrees: ["/private/tmp/scratch/wt-gone", "/tmp/scratch/wt-gone"],
+            sessionPath: "/tmp/scratch/wt-gone")
+        let projectID = store.projects[0].id
+
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(
+                discovered: [],
+                canonical: [
+                    "/private/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone",
+                    "/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone",
+                ]),
+            to: projectID)
+
+        let project = store.projects[0]
+        XCTAssertEqual(project.worktrees.count, 1, "one row for one checkout")
+        XCTAssertEqual(project.sessions[0].worktreePath, project.worktrees[0].path)
+    }
+
     /// A path the off-main pass never saw — a row added since it started — is
     /// compared lexically for this round rather than resolved here, because
     /// resolving it would mean a `stat` on the main actor, on the very reconcile

--- a/Tests/termioTests/WorktreeReconcileTests.swift
+++ b/Tests/termioTests/WorktreeReconcileTests.swift
@@ -47,7 +47,7 @@ final class WorktreeReconcileTests: XCTestCase {
         // Both spellings are one checkout, which is what git reports.
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: ["/private/tmp/scratch/wt-a"], stale: [],
+                discovered: ["/private/tmp/scratch/wt-a"], stale: [], absent: [],
                 canonical: [
                     "/private/tmp/scratch/wt-a": "/tmp/scratch/wt-a",
                     "/tmp/scratch/wt-a": "/tmp/scratch/wt-a",
@@ -69,7 +69,7 @@ final class WorktreeReconcileTests: XCTestCase {
 
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: [], stale: [],
+                discovered: [], stale: [], absent: [],
                 canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
             to: projectID)
 
@@ -91,7 +91,7 @@ final class WorktreeReconcileTests: XCTestCase {
 
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: [], stale: [],
+                discovered: [], stale: [], absent: [],
                 canonical: [
                     "/private/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone",
                     "/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone",
@@ -113,7 +113,7 @@ final class WorktreeReconcileTests: XCTestCase {
 
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: [], stale: ["/tmp/scratch/wt-gone"],
+                discovered: [], stale: ["/tmp/scratch/wt-gone"], absent: ["/tmp/scratch/wt-gone"],
                 canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
             to: projectID)
 
@@ -123,7 +123,7 @@ final class WorktreeReconcileTests: XCTestCase {
         // The folder comes back and git offers the worktree again.
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: ["/tmp/scratch/wt-gone"], stale: [],
+                discovered: ["/tmp/scratch/wt-gone"], stale: [], absent: [],
                 canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
             to: projectID)
         XCTAssertFalse(store.projects[0].worktrees[0].missing)
@@ -138,7 +138,7 @@ final class WorktreeReconcileTests: XCTestCase {
 
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: [], stale: [],
+                discovered: [], stale: [], absent: [],
                 canonical: ["/tmp/scratch/wt-live": "/tmp/scratch/wt-live"]),
             to: projectID)
 
@@ -156,7 +156,7 @@ final class WorktreeReconcileTests: XCTestCase {
         let existing = store.projects[0].worktrees[0].id
 
         store.applyDiscoveredWorktrees(
-            WorktreeService.Reconcile(discovered: ["/tmp/scratch/wt-new"], stale: [], canonical: [:]),
+            WorktreeService.Reconcile(discovered: ["/tmp/scratch/wt-new"], stale: [], absent: [], canonical: [:]),
             to: projectID)
 
         let rows = store.projects[0].worktrees

--- a/Tests/termioTests/WorktreeReconcileTests.swift
+++ b/Tests/termioTests/WorktreeReconcileTests.swift
@@ -47,7 +47,7 @@ final class WorktreeReconcileTests: XCTestCase {
         // Both spellings are one checkout, which is what git reports.
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: ["/private/tmp/scratch/wt-a"],
+                discovered: ["/private/tmp/scratch/wt-a"], stale: [],
                 canonical: [
                     "/private/tmp/scratch/wt-a": "/tmp/scratch/wt-a",
                     "/tmp/scratch/wt-a": "/tmp/scratch/wt-a",
@@ -69,7 +69,7 @@ final class WorktreeReconcileTests: XCTestCase {
 
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: [],
+                discovered: [], stale: [],
                 canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
             to: projectID)
 
@@ -91,7 +91,7 @@ final class WorktreeReconcileTests: XCTestCase {
 
         store.applyDiscoveredWorktrees(
             WorktreeService.Reconcile(
-                discovered: [],
+                discovered: [], stale: [],
                 canonical: [
                     "/private/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone",
                     "/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone",
@@ -113,7 +113,7 @@ final class WorktreeReconcileTests: XCTestCase {
         let existing = store.projects[0].worktrees[0].id
 
         store.applyDiscoveredWorktrees(
-            WorktreeService.Reconcile(discovered: ["/tmp/scratch/wt-new"], canonical: [:]),
+            WorktreeService.Reconcile(discovered: ["/tmp/scratch/wt-new"], stale: [], canonical: [:]),
             to: projectID)
 
         let rows = store.projects[0].worktrees

--- a/Tests/termioTests/WorktreeReconcileTests.swift
+++ b/Tests/termioTests/WorktreeReconcileTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import termio
+
+/// The merge of git's worktrees into a project's rows. The canonical spellings
+/// arrive as data — resolved off the main actor together with the git read — so
+/// these need no filesystem at all.
+@MainActor
+final class WorktreeReconcileTests: XCTestCase {
+    /// A project holding `worktrees`, with one session in the worktree spelled
+    /// `sessionPath` when given.
+    private func makeStore(
+        worktrees: [String], sessionPath: String? = nil
+    ) -> TermioStore {
+        let workspace = Workspace(name: "Test")
+        var sessions: [Session] = []
+        if let sessionPath {
+            var session = Session(title: "claude")
+            session.worktreePath = sessionPath
+            sessions = [session]
+        }
+        let project = Project(
+            workspaceID: workspace.id, name: "repo", path: "/tmp/scratch/repo",
+            branch: "main", sessions: sessions,
+            worktrees: worktrees.map { Worktree(path: $0) })
+        let defaults = UserDefaults(suiteName: "worktree-reconcile-\(UUID().uuidString)")
+            ?? UserDefaults.standard
+        return TermioStore(
+            workspaces: [workspace], projects: [project],
+            settings: AppSettings(defaults: defaults))
+    }
+
+    /// Two rows for one checkout exist on disk today, left by the lexical
+    /// matching this pass replaces — and they persist exactly where a session
+    /// holds one of them. Merging them has to carry that session onto the row
+    /// that survives: sessions are matched to rows by exact path, so one left on
+    /// the spelling that lost belongs to no row, renders nowhere in the sidebar,
+    /// and stays in the saved roster where nothing short of editing state on
+    /// disk reaches it.
+    func testMergingDuplicateRowsCarriesSessionsOntoTheSurvivor() {
+        // The session is on the old lexical spelling — the row git's realpath
+        // never matched, which is why a second one was appended beside it.
+        let store = makeStore(
+            worktrees: ["/private/tmp/scratch/wt-a", "/tmp/scratch/wt-a"],
+            sessionPath: "/tmp/scratch/wt-a")
+        let projectID = store.projects[0].id
+
+        // Both spellings are one checkout, which is what git reports.
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(
+                discovered: ["/private/tmp/scratch/wt-a"],
+                canonical: [
+                    "/private/tmp/scratch/wt-a": "/tmp/scratch/wt-a",
+                    "/tmp/scratch/wt-a": "/tmp/scratch/wt-a",
+                ]),
+            to: projectID)
+
+        let merged = store.projects[0]
+        XCTAssertEqual(merged.worktrees.count, 1)
+        XCTAssertEqual(merged.sessions[0].worktreePath, merged.worktrees[0].path,
+                       "the session must still name a row that exists")
+    }
+
+    /// A worktree git no longer reports keeps its row while a session is in it,
+    /// and that session is left on the spelling it already had.
+    func testAGitAbsentWorktreeKeepsItsRowAndItsSessionsSpelling() {
+        let store = makeStore(
+            worktrees: ["/tmp/scratch/wt-gone"], sessionPath: "/tmp/scratch/wt-gone")
+        let projectID = store.projects[0].id
+
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(
+                discovered: [],
+                canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
+            to: projectID)
+
+        XCTAssertEqual(store.projects[0].worktrees.map { $0.path }, ["/tmp/scratch/wt-gone"])
+        XCTAssertEqual(store.projects[0].sessions[0].worktreePath, "/tmp/scratch/wt-gone")
+    }
+
+    /// A path the off-main pass never saw — a row added since it started — is
+    /// compared lexically for this round rather than resolved here, because
+    /// resolving it would mean a `stat` on the main actor, on the very reconcile
+    /// that fires while an agent is committing.
+    func testAPathTheReconcileNeverSawIsStillMatched() {
+        let store = makeStore(worktrees: ["/tmp/scratch/wt-new"])
+        let projectID = store.projects[0].id
+        let existing = store.projects[0].worktrees[0].id
+
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(discovered: ["/tmp/scratch/wt-new"], canonical: [:]),
+            to: projectID)
+
+        let rows = store.projects[0].worktrees
+        XCTAssertEqual(rows.count, 1, "no second row for a checkout that already had one")
+        XCTAssertEqual(rows[0].id, existing, "and the existing row is the one kept")
+    }
+}

--- a/Tests/termioTests/WorktreeReconcileTests.swift
+++ b/Tests/termioTests/WorktreeReconcileTests.swift
@@ -103,6 +103,49 @@ final class WorktreeReconcileTests: XCTestCase {
         XCTAssertEqual(project.sessions[0].worktreePath, project.worktrees[0].path)
     }
 
+    /// A row git still registers but cannot offer is kept *and* marked, so the
+    /// sidebar stops offering to start work in a checkout that is not there while
+    /// the row itself stays reachable for removal. The mark clears the moment git
+    /// offers the worktree again.
+    func testAStaleRowIsKeptButMarkedSoNothingStartsWorkInIt() {
+        let store = makeStore(worktrees: ["/tmp/scratch/wt-gone"])
+        let projectID = store.projects[0].id
+
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(
+                discovered: [], stale: ["/tmp/scratch/wt-gone"],
+                canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
+            to: projectID)
+
+        XCTAssertEqual(store.projects[0].worktrees.count, 1, "the row stays, so Remove is reachable")
+        XCTAssertTrue(store.projects[0].worktrees[0].missing)
+
+        // The folder comes back and git offers the worktree again.
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(
+                discovered: ["/tmp/scratch/wt-gone"], stale: [],
+                canonical: ["/tmp/scratch/wt-gone": "/tmp/scratch/wt-gone"]),
+            to: projectID)
+        XCTAssertFalse(store.projects[0].worktrees[0].missing)
+    }
+
+    /// A row kept only because a session is in it is not marked: git still offers
+    /// that checkout, so there is somewhere to work.
+    func testARowHeldBySessionAloneIsNotMarkedMissing() {
+        let store = makeStore(
+            worktrees: ["/tmp/scratch/wt-live"], sessionPath: "/tmp/scratch/wt-live")
+        let projectID = store.projects[0].id
+
+        store.applyDiscoveredWorktrees(
+            WorktreeService.Reconcile(
+                discovered: [], stale: [],
+                canonical: ["/tmp/scratch/wt-live": "/tmp/scratch/wt-live"]),
+            to: projectID)
+
+        XCTAssertEqual(store.projects[0].worktrees.count, 1)
+        XCTAssertFalse(store.projects[0].worktrees[0].missing)
+    }
+
     /// A path the off-main pass never saw — a row added since it started — is
     /// compared lexically for this round rather than resolved here, because
     /// resolving it would mean a `stat` on the main actor, on the very reconcile

--- a/Tests/termioTests/WorktreeRecordTests.swift
+++ b/Tests/termioTests/WorktreeRecordTests.swift
@@ -71,6 +71,54 @@ final class WorktreeRecordTests: XCTestCase {
         XCTAssertFalse(records[1].prunable)
     }
 
+    /// The removal matches a sidebar row against git's own records by canonical
+    /// path, and it has to keep matching after the folder is deleted — which is
+    /// the case the whole feature exists for.
+    ///
+    /// A worktree under a symlinked ancestor is stored with the spelling that
+    /// created it while git prints the resolved one. Canonicalizing the leaf
+    /// alone worked only while the folder existed: `resolvingSymlinksInPath`
+    /// returns a missing path unchanged, so the two stopped matching the moment
+    /// the folder went, the record read as absent, and the row was dropped while
+    /// git kept the registration for good — the branch never tidied, the row
+    /// never coming back to retry, and a later `git worktree add` at that path
+    /// refused as "already registered".
+    func testAPathKeepsOneSpellingAfterItsFolderIsDeleted() throws {
+        let manager = FileManager.default
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("worktree-canon-\(ProcessInfo.processInfo.processIdentifier)")
+        try? manager.removeItem(at: root)
+        try manager.createDirectory(at: root.appendingPathComponent("real/wts/w1"),
+                                    withIntermediateDirectories: true)
+        try manager.createSymbolicLink(at: root.appendingPathComponent("linked"),
+                                       withDestinationURL: root.appendingPathComponent("real"))
+        defer { try? manager.removeItem(at: root) }
+
+        // What the sidebar row keeps, and what `git worktree list` prints.
+        let stored = root.appendingPathComponent("linked/wts/w1").path
+        let git = root.appendingPathComponent("real/wts/w1").path
+        XCTAssertEqual(WorktreeService.canonicalPath(stored), WorktreeService.canonicalPath(git))
+
+        // The folder is deleted by another tool: they must still agree.
+        try manager.removeItem(at: root.appendingPathComponent("real/wts/w1"))
+        XCTAssertEqual(WorktreeService.canonicalPath(stored), WorktreeService.canonicalPath(git))
+
+        // And with the directories above it gone too, down to the symlink the
+        // spellings differ through. (Deleting what that symlink itself points
+        // at is a different shape: the link dangles, Foundation resolves it no
+        // further, and nothing can tell the two spellings are one path. The
+        // symlinked ancestors this matters for — `/tmp`, `/var`, a linked home
+        // — are not the thing anyone deletes.)
+        try manager.removeItem(at: root.appendingPathComponent("real/wts"))
+        XCTAssertEqual(WorktreeService.canonicalPath(stored), WorktreeService.canonicalPath(git))
+
+        // Different worktrees still read as different ones.
+        XCTAssertNotEqual(
+            WorktreeService.canonicalPath(root.appendingPathComponent("real/wts/w1").path),
+            WorktreeService.canonicalPath(root.appendingPathComponent("real/wts/w2").path)
+        )
+    }
+
     /// The disk is the only witness left once git cannot inspect a checkout, so
     /// this probe decides whether a worktree may be deregistered and its sessions
     /// closed. Every failure has to land on the refusing side: a folder nothing
@@ -138,6 +186,21 @@ final class WorktreeRecordTests: XCTestCase {
         let replaced = root.appendingPathComponent("replaced")
         try "not a checkout".write(to: replaced, atomically: true, encoding: .utf8)
         XCTAssertEqual(WorktreeService.folderEvidence(at: replaced.path), .occupied)
+
+        // An unmounted volume answers "no such file" for everything on it. That
+        // must not read as a deleted checkout: the worktree is still on the
+        // drive, and letting go of it would deregister work that is merely
+        // unplugged.
+        XCTAssertEqual(
+            WorktreeService.folderEvidence(at: "/Volumes/TermioNoSuchVolume/repo-wt"),
+            .unreadable
+        )
+        // A volume that *is* mounted still reports a genuinely deleted checkout
+        // as gone — the root volume stands in for one here.
+        XCTAssertEqual(
+            WorktreeService.folderEvidence(at: root.appendingPathComponent("still-gone").path),
+            .gone
+        )
 
         // A symlink is `.occupied` too, and deliberately not followed: whatever
         // is on the other side was never part of the checkout, and classifying

--- a/Tests/termioTests/WorktreeRecordTests.swift
+++ b/Tests/termioTests/WorktreeRecordTests.swift
@@ -105,18 +105,19 @@ final class WorktreeRecordTests: XCTestCase {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        // Deleted out from under git: nothing to lose.
+        // Deleted out from under git: nothing to lose, and nothing to clear.
         XCTAssertEqual(
             WorktreeService.folderEvidence(at: root.appendingPathComponent("gone").path),
-            .nothingToProtect
+            .gone
         )
 
-        // Emptied and recreated, including the one Finder leaves behind.
+        // Emptied and recreated, including the one Finder leaves behind. This is
+        // the shape that has to be cleared before git will deregister it.
         let emptied = root.appendingPathComponent("emptied")
         try FileManager.default.createDirectory(at: emptied, withIntermediateDirectories: true)
-        XCTAssertEqual(WorktreeService.folderEvidence(at: emptied.path), .nothingToProtect)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: emptied.path), .emptyFolder)
         try "".write(to: emptied.appendingPathComponent(".DS_Store"), atomically: true, encoding: .utf8)
-        XCTAssertEqual(WorktreeService.folderEvidence(at: emptied.path), .nothingToProtect)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: emptied.path), .emptyFolder)
 
         // The `.git` gitfile deleted with the work still there: git marks this
         // prunable, and the files are exactly what must not be let go of.
@@ -129,10 +130,24 @@ final class WorktreeRecordTests: XCTestCase {
         )
         XCTAssertEqual(WorktreeService.folderEvidence(at: working.path), .mayHoldWork)
 
-        // A path that is no longer a directory holds no checkout.
+        // A path that is no longer a directory holds no checkout — but it is not
+        // ours to delete either, and `rmdir` would fail `ENOTDIR` on it, so it
+        // is kept apart from the shapes the removal may clear. git refuses to
+        // deregister a worktree whose path exists without a `.git` in it
+        // (`--force` included), so this one can only be reported with a remedy.
         let replaced = root.appendingPathComponent("replaced")
         try "not a checkout".write(to: replaced, atomically: true, encoding: .utf8)
-        XCTAssertEqual(WorktreeService.folderEvidence(at: replaced.path), .nothingToProtect)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: replaced.path), .occupied)
+
+        // A symlink is `.occupied` too, and deliberately not followed: whatever
+        // is on the other side was never part of the checkout, and classifying
+        // it by its target would authorize clearing a directory nothing here
+        // inspected.
+        let linked = root.appendingPathComponent("linked")
+        let target = root.appendingPathComponent("target")
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: linked, withDestinationURL: target)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: linked.path), .occupied)
     }
 
     func testABareEntryIsMarkedAndALockReasonStillReadsAsLocked() {

--- a/Tests/termioTests/WorktreeRecordTests.swift
+++ b/Tests/termioTests/WorktreeRecordTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import termio
+
+/// `WorktreeService.records(from:)` is what `removeWorktree` decides on: which
+/// checkout git still knows, whether git itself judges it gone (`prunable`),
+/// whether git refuses to let go of it (`locked`), and which branch to tidy.
+/// The fixtures are verbatim `git worktree list --porcelain` output.
+final class WorktreeRecordTests: XCTestCase {
+    func testRecordsCarryEveryAttributeTheRemovalDecidesOn() {
+        let listing = """
+        worktree /Users/u/repo
+        HEAD b5ff2439a788da78e1b548099d6b69c828bc45d3
+        branch refs/heads/main
+
+        worktree /Users/u/wt-healthy
+        HEAD b5ff2439a788da78e1b548099d6b69c828bc45d3
+        branch refs/heads/feature-1
+
+        worktree /Users/u/wt-locked
+        HEAD b5ff2439a788da78e1b548099d6b69c828bc45d3
+        branch refs/heads/feature-2
+        locked
+
+        worktree /Users/u/wt-gone
+        HEAD b5ff2439a788da78e1b548099d6b69c828bc45d3
+        branch refs/heads/feature-3
+        prunable gitdir file points to non-existent location
+
+        worktree /Users/u/wt-detached
+        HEAD b5ff2439a788da78e1b548099d6b69c828bc45d3
+        detached
+        """
+        let records = WorktreeService.records(from: listing)
+        XCTAssertEqual(records.count, 5)
+        XCTAssertEqual(records[0].path, "/Users/u/repo")
+        XCTAssertEqual(records[0].branch, "main")
+
+        XCTAssertEqual(records[1].branch, "feature-1")
+        XCTAssertFalse(records[1].prunable)
+        XCTAssertFalse(records[1].locked)
+
+        XCTAssertTrue(records[2].locked)
+        XCTAssertFalse(records[2].prunable)
+
+        XCTAssertTrue(records[3].prunable)
+        XCTAssertEqual(records[3].branch, "feature-3")
+
+        // A detached HEAD has no branch to tidy — nil, not a sentinel string.
+        XCTAssertNil(records[4].branch)
+    }
+
+    func testABareEntryIsMarkedAndALockReasonStillReadsAsLocked() {
+        let listing = """
+        worktree /Users/u/repo.git
+        bare
+
+        worktree /Users/u/wt
+        HEAD b5ff2439a788da78e1b548099d6b69c828bc45d3
+        branch refs/heads/main
+        locked on an external drive
+        """
+        let records = WorktreeService.records(from: listing)
+        XCTAssertEqual(records.count, 2)
+        XCTAssertTrue(records[0].bare)
+        XCTAssertNil(records[0].branch)
+        XCTAssertTrue(records[1].locked)
+    }
+}

--- a/Tests/termioTests/WorktreeRecordTests.swift
+++ b/Tests/termioTests/WorktreeRecordTests.swift
@@ -49,6 +49,28 @@ final class WorktreeRecordTests: XCTestCase {
         XCTAssertNil(records[4].branch)
     }
 
+    /// Verbatim output for a locked worktree whose folder was deleted (git 2.47):
+    /// git marks it `locked` and *not* `prunable`, which is why `removeWorktree`
+    /// has to test `locked` before it branches on `prunable` — inside that branch
+    /// the check could never fire, and a checkout on unplugged removable media
+    /// would take the deregistration path instead of the locked message.
+    func testALockedWorktreeIsNeverMarkedPrunableEvenWithItsFolderGone() {
+        let listing = """
+        worktree /Users/u/repo
+        HEAD 1a96c165970cec53355f4dc6c1b58b2fa79850ae
+        branch refs/heads/main
+
+        worktree /Users/u/w1
+        HEAD 1a96c165970cec53355f4dc6c1b58b2fa79850ae
+        branch refs/heads/b1
+        locked
+        """
+        let records = WorktreeService.records(from: listing)
+        XCTAssertEqual(records.count, 2)
+        XCTAssertTrue(records[1].locked)
+        XCTAssertFalse(records[1].prunable)
+    }
+
     func testABareEntryIsMarkedAndALockReasonStillReadsAsLocked() {
         let listing = """
         worktree /Users/u/repo.git

--- a/Tests/termioTests/WorktreeRecordTests.swift
+++ b/Tests/termioTests/WorktreeRecordTests.swift
@@ -103,14 +103,21 @@ final class WorktreeRecordTests: XCTestCase {
         try manager.removeItem(at: root.appendingPathComponent("real/wts/w1"))
         XCTAssertEqual(WorktreeService.canonicalPath(stored), WorktreeService.canonicalPath(git))
 
-        // And with the directories above it gone too, down to the symlink the
-        // spellings differ through. (Deleting what that symlink itself points
-        // at is a different shape: the link dangles, Foundation resolves it no
-        // further, and nothing can tell the two spellings are one path. The
-        // symlinked ancestors this matters for — `/tmp`, `/var`, a linked home
-        // — are not the thing anyone deletes.)
+        // And with the directories above it gone too.
         try manager.removeItem(at: root.appendingPathComponent("real/wts"))
         XCTAssertEqual(WorktreeService.canonicalPath(stored), WorktreeService.canonicalPath(git))
+
+        // Including when what the symlink points at is itself deleted, so the
+        // link dangles. `resolvingSymlinksInPath` gives up there, which used to
+        // make the row unmatchable against git's record — and an unmatchable row
+        // is the one that gets dropped while git keeps its registration for good.
+        try manager.removeItem(at: root.appendingPathComponent("real"))
+        XCTAssertEqual(WorktreeService.canonicalPath(stored), WorktreeService.canonicalPath(git))
+
+        // A link pointing at itself terminates rather than spinning.
+        let loop = root.appendingPathComponent("loop")
+        try manager.createSymbolicLink(at: loop, withDestinationURL: loop)
+        XCTAssertFalse(WorktreeService.canonicalPath(loop.appendingPathComponent("w1").path).isEmpty)
 
         // Different worktrees still read as different ones.
         XCTAssertNotEqual(

--- a/Tests/termioTests/WorktreeRecordTests.swift
+++ b/Tests/termioTests/WorktreeRecordTests.swift
@@ -71,6 +71,70 @@ final class WorktreeRecordTests: XCTestCase {
         XCTAssertFalse(records[1].prunable)
     }
 
+    /// The disk is the only witness left once git cannot inspect a checkout, so
+    /// this probe decides whether a worktree may be deregistered and its sessions
+    /// closed. Every failure has to land on the refusing side: a folder nothing
+    /// could read is not a folder known to be empty.
+    func testFolderEvidenceFailsClosedOnAFolderItCannotRead() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("worktree-evidence-\(ProcessInfo.processInfo.processIdentifier)")
+        try? FileManager.default.removeItem(at: root)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let unreadable = root.appendingPathComponent("denied")
+        try FileManager.default.createDirectory(at: unreadable, withIntermediateDirectories: true)
+        try "uncommitted work".write(
+            to: unreadable.appendingPathComponent("draft.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: unreadable.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: unreadable.path) }
+
+        // Running as root defeats the permission bits, so the denial this asserts
+        // on would not happen; the case is real for the user the app runs as.
+        try XCTSkipIf(getuid() == 0, "root reads a 000 directory")
+        XCTAssertEqual(WorktreeService.folderEvidence(at: unreadable.path), .unreadable)
+    }
+
+    func testFolderEvidenceSeparatesAnEmptyCheckoutFromOneHoldingWork() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("worktree-evidence-shapes-\(ProcessInfo.processInfo.processIdentifier)")
+        try? FileManager.default.removeItem(at: root)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Deleted out from under git: nothing to lose.
+        XCTAssertEqual(
+            WorktreeService.folderEvidence(at: root.appendingPathComponent("gone").path),
+            .nothingToProtect
+        )
+
+        // Emptied and recreated, including the one Finder leaves behind.
+        let emptied = root.appendingPathComponent("emptied")
+        try FileManager.default.createDirectory(at: emptied, withIntermediateDirectories: true)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: emptied.path), .nothingToProtect)
+        try "".write(to: emptied.appendingPathComponent(".DS_Store"), atomically: true, encoding: .utf8)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: emptied.path), .nothingToProtect)
+
+        // The `.git` gitfile deleted with the work still there: git marks this
+        // prunable, and the files are exactly what must not be let go of.
+        let working = root.appendingPathComponent("working")
+        try FileManager.default.createDirectory(at: working, withIntermediateDirectories: true)
+        try "uncommitted".write(
+            to: working.appendingPathComponent("draft.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        XCTAssertEqual(WorktreeService.folderEvidence(at: working.path), .mayHoldWork)
+
+        // A path that is no longer a directory holds no checkout.
+        let replaced = root.appendingPathComponent("replaced")
+        try "not a checkout".write(to: replaced, atomically: true, encoding: .utf8)
+        XCTAssertEqual(WorktreeService.folderEvidence(at: replaced.path), .nothingToProtect)
+    }
+
     func testABareEntryIsMarkedAndALockReasonStillReadsAsLocked() {
         let listing = """
         worktree /Users/u/repo.git

--- a/Tests/termioTests/WorktreeSweepTests.swift
+++ b/Tests/termioTests/WorktreeSweepTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import termio
+
+/// The reconcile's sweep of registrations whose checkouts are gone, against a
+/// real repository — it deregisters without anyone asking, so what it will and
+/// will not touch is worth holding down.
+final class WorktreeSweepTests: XCTestCase {
+    private var root: URL!
+    private var repo: URL { root.appendingPathComponent("repo") }
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("worktree-sweep-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try git(["init", "--quiet"])
+        try git(["commit", "--quiet", "--allow-empty", "-m", "init"])
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// A checkout whose folder is simply gone is deregistered, so the path can be
+    /// used again. Nothing else is: a folder still holding files, an emptied one,
+    /// and one git is holding with `lock` all stay for the user's own Remove to
+    /// decide on — and the sweep never deletes a file to get there.
+    func testOnlyAVanishedCheckoutIsSweptAway() async throws {
+        for name in ["gone", "work", "empty", "locked"] {
+            try git(["worktree", "add", "--quiet", "-b", name, worktree(name).path, "HEAD"])
+        }
+        try FileManager.default.removeItem(at: worktree("gone"))
+        // Its `.git` gitfile deleted with the work still there: git calls this
+        // prunable, and those files are exactly what must survive.
+        try "uncommitted".write(to: worktree("work").appendingPathComponent("draft.txt"),
+                                atomically: true, encoding: .utf8)
+        try FileManager.default.removeItem(at: worktree("work").appendingPathComponent(".git"))
+        try FileManager.default.removeItem(at: worktree("empty"))
+        try FileManager.default.createDirectory(at: worktree("empty"), withIntermediateDirectories: true)
+        try git(["worktree", "lock", worktree("locked").path])
+        try FileManager.default.removeItem(at: worktree("locked"))
+
+        _ = await WorktreeService.reconcile(in: repo.path, against: [])
+
+        // Compared canonically, because git prints realpaths and the temporary
+        // directory these live under is reached through a symlink.
+        let registered = try registeredPaths()
+        XCTAssertFalse(registered.contains(key("gone")), "a vanished checkout is let go of")
+        XCTAssertTrue(registered.contains(key("work")), "work nobody inspected stays registered")
+        XCTAssertTrue(registered.contains(key("empty")), "an emptied folder is the user's call")
+        XCTAssertTrue(registered.contains(key("locked")), "a locked worktree is git's to hold")
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: worktree("work").appendingPathComponent("draft.txt").path),
+            "the sweep deletes no files")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktree("empty").path))
+
+        // The point of letting go: the path is usable again. Before this, the
+        // registration leaked and a later add at the same path was refused.
+        try git(["worktree", "add", "--quiet", "-b", "again", worktree("gone").path, "HEAD"])
+
+        // The branch is left alone — deleting a ref is not something a pass
+        // nobody asked for should do.
+        XCTAssertTrue(try branches().contains("gone"))
+    }
+
+    /// The sweep leaves what it cannot see. A path whose volume is not mounted
+    /// answers "no such file" for everything on it, and `/Volumes` with the
+    /// volume directory absent is what that looks like.
+    func testAnUnmountedVolumeIsNotMistakenForADeletedCheckout() {
+        XCTAssertEqual(
+            WorktreeService.folderEvidence(at: "/Volumes/TermioNoSuchVolume/repo-wt"),
+            .unreadable)
+    }
+
+    // MARK: Helpers
+
+    private func worktree(_ name: String) -> URL {
+        root.appendingPathComponent("wt-\(name)")
+    }
+
+    private func key(_ name: String) -> String {
+        WorktreeService.canonicalPath(worktree(name).path)
+    }
+
+    private func registeredPaths() throws -> [String] {
+        (WorktreeService.records(in: repo.path) ?? []).map { WorktreeService.canonicalPath($0.path) }
+    }
+
+    private func branches() throws -> [String] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = ["-C", repo.path, "branch", "--format=%(refname:short)"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(decoding: data, as: UTF8.self)
+            .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    private func git(_ args: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = repo
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, "git \(args.joined(separator: " ")) failed")
+    }
+}


### PR DESCRIPTION
Removing a worktree ran `git status` inside the checkout, so a worktree whose folder another tool had already deleted always failed with "git couldn't check … for changes, so it was not removed" — and could never be removed from the app. A live session is what keeps a git-absent worktree in the sidebar (`applyDiscoveredWorktrees` protects session-anchored entries from the reconcile), and the remove action was the only way out, so the entry was stuck forever.

The removal now decides once, before it touches anything. One `git worktree list --porcelain` read in the parent repo answers everything: whether git still knows the checkout, whether git itself judges it gone, whether it is locked, and which branch to tidy afterward — the checkout cannot be asked once its folder is damaged. That verdict is crossed with what the folder itself shows, and every exit passes the same gate, holding two invariants: a read that fails refuses the removal rather than authorizing it, and no path deregisters a checkout or closes its sessions while it may still hold work.

Where git's own verdict says the checkout is gone, the removal is a targeted `git worktree remove` — not a repo-wide `prune`, which would deregister every other prunable worktree of the repo, including ones still holding uncommitted work. A locked worktree is refused with the remedy named, since `git worktree lock` is git's documented protection for removable media. An empty leftover folder is cleared first, because git's own validation refuses to remove a worktree whose folder still exists without a `.git`. The safe `branch -d` tidy still applies, so a branch with unmerged commits is kept.

`WorktreeService` now owns one porcelain record parser (path, branch, bare, locked, prunable) that both the discovery pass and the removal read, instead of two parsers that could drift apart.

Verified against a scratch repo on git 2.47: `git status` fails in the missing directory (the old dead end); `worktree list --porcelain` still reports the branch with a `prunable` marker; `git worktree remove` succeeds once the path is gone and fails validation when an empty folder remains; and a locked worktree is reported `locked` and never `prunable`. `swift build`, `swift test`, and `scripts/check-strings.sh` pass.

Release Notes:
- Fixed: a worktree deleted by another app can now be removed from the sidebar.
