### PR TITLE
Keep the PTY still while the phone moves around it

### DIFF
--- a/docs/design/20260901-pty-size-is-not-the-write-token.md
+++ b/docs/design/20260901-pty-size-is-not-the-write-token.md
@@ -3,7 +3,7 @@ title: PTY size is not the write token
 status: active
 type: rfc
 created: 2026-09-01
-updated: 2026-09-02
+updated: 2026-09-08
 related:
   - ../bug/agent-tui-focus-report-resize-storm.md
   - 20260730-termiod-session-protocol.md
@@ -454,3 +454,35 @@ is gone with it.
 `used` follows the same rule as `SessionMsg::Viewport`: an attach that is not
 rendering does not stamp one. Nobody is looking at it, so it is not somebody
 using this device.
+
+## 12. Leaving is not using
+
+§11 made the size follow the person; this closes the half of it that still
+followed the *machine*. The policy recomputed on every change to the attachment
+set — including departures, deaths, and a screen parking — so when the
+most-recently-used attachment went away, the size fell back to whichever
+unattended window remained. On a phone that is not an edge case, it is the
+lifecycle: iOS tears the socket down on every backgrounding, so a person
+pocketing the phone handed the session back to a Mac window nobody was sitting
+at, and picking the phone back up paid the full three-act reattach — wide
+snapshot, viewport claim, reflow — every single time. Two TUI reflows per
+lock/unlock, indefinitely.
+
+The rule, completing §11's sentence: **the size moves only when a person acts,
+and stays exactly where the last person put it when they stop.** `apply_size_policy`
+now runs from the three stamps and only the three stamps — an arrival with a
+screen, a keystroke, a viewport declared while rendering. Departure, death, and
+`rendering: false` recompute nothing. A session whose size owner vanished keeps
+that owner's shape until somebody types or resizes at another screen, which
+stamps a use and takes the size over in the ordinary way.
+
+tmux's `latest` recomputes on detach to the next-most-recent client, which is
+the same stale fallback this section deletes. Going stricter than `latest` is
+justified by the client that `latest` never had to serve: one whose transport
+dies and returns dozens of times a day with the same person behind it.
+
+The keyboard corollary lives on the client, not here: an on-screen keyboard
+occludes the phone's screen, it does not shrink it. The iOS client measures its
+declared viewport against the keyboard-hidden height and slides the surface up
+so the bottom rows stay visible over the keys — so showing or hiding the
+keyboard sends nothing at all, and the PTY never hears about it.

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -365,7 +365,17 @@ final class TerminalViewController: UIViewController {
         let fit = min(1, host.width / width, fullHeight / height)
         terminalView.bounds = CGRect(x: 0, y: 0, width: width, height: height)
         terminalView.transform = CGAffineTransform(scaleX: fit, y: fit)
-        terminalView.center = CGPoint(x: host.midX, y: height * fit / 2)
+        // The same cursor-anchored slide as the full-size path, in scaled
+        // space: with the keys up, the letterboxed picture rises just enough
+        // to keep the cursor's row above them.
+        let caret = terminalView.caretRect(for: terminalView.beginningOfDocument)
+        var pan: CGFloat = 0
+        if keyboardOverlap > 0, caret.maxY.isFinite, caret.maxY > 0 {
+            let anchor = (caret.maxY + 2 * cell.height) * fit
+            pan = min(max(0, anchor - host.height), max(0, height * fit - host.height))
+        }
+        lastAppliedPan = pan
+        terminalView.center = CGPoint(x: host.midX, y: height * fit / 2 - pan)
     }
 
     /// How much of a session this screen could show. The same
@@ -375,30 +385,32 @@ final class TerminalViewController: UIViewController {
     /// before the surface has reported a cell size, which the device reads as no
     /// viewport at all rather than as a stand-in.
     /// How far the surface slides up while the keyboard shows: just enough to
-    /// keep the deepest drawn row visible above the keys, and not a point
-    /// more. A fresh session with three rows of content stays put — the keys
-    /// cover empty grid — while a full transcript pins its bottom row (the
-    /// prompt, an agent's input box) over them. Pushing the whole overlap
-    /// unconditionally hid a short session's only content off the top; never
-    /// pushing hid a tall session's input line under the keys; the content
-    /// anchor is what resolves the two. Alt-screen apps own the whole grid
-    /// and always pin. A couple of margin rows absorb the tracker's
-    /// undercount on wrapped lines.
+    /// keep the cursor's row visible above the keys, and not a point more. A
+    /// fresh session with the cursor near the top stays put — the keys cover
+    /// empty grid — while a full transcript slides its input line over them,
+    /// and a full-screen editor follows its own cursor wherever it sits.
+    /// Pushing the whole overlap unconditionally hid a short session's only
+    /// content off the top; never pushing hid a tall session's input line
+    /// under the keys; the cursor is what resolves the two, and it is exact:
+    /// `caretRect` reads the surface's own IME caret (`imePoint`), the same
+    /// geometry the system keyboard places candidate windows with. A couple
+    /// of margin rows keep an agent's box border, drawn just below its
+    /// cursor, in view.
     private var keyboardPan: CGFloat {
         guard keyboardOverlap > 0 else { return 0 }
-        guard let cell = cellSize, !altScreenSniffer.isAlternate else { return keyboardOverlap }
-        let marginRows: CGFloat = 2
-        let contentBottom = Self.terminalPaddingY
-            + (CGFloat(altScreenSniffer.contentBottomRow) + marginRows) * cell.height
-        return min(keyboardOverlap, max(0, contentBottom - terminalHost.bounds.height))
+        guard let cell = cellSize else { return keyboardOverlap }
+        let caret = terminalView.caretRect(for: terminalView.beginningOfDocument)
+        guard caret.maxY.isFinite, caret.maxY > 0 else { return keyboardOverlap }
+        let anchor = caret.maxY + 2 * cell.height
+        return min(keyboardOverlap, max(0, anchor - terminalHost.bounds.height))
     }
 
-    /// The pan the surface was last framed with, so output that deepens the
-    /// content while the keys are up can re-slide without a full layout pass.
+    /// The pan the surface was last framed with, so output that moves the
+    /// cursor while the keys are up can re-slide without thrash.
     private var lastAppliedPan: CGFloat = 0
 
-    /// Called on every output chunk: if the content anchor moved enough to
-    /// change the pan while the keyboard is showing, re-frame the surface.
+    /// Called on every output chunk: if the cursor moved enough to change the
+    /// pan while the keyboard is showing, re-frame the surface.
     private func followContentUnderKeyboard() {
         guard keyboardOverlap > 0 else { return }
         guard abs(keyboardPan - lastAppliedPan) > 0.5 else { return }
@@ -433,9 +445,6 @@ final class TerminalViewController: UIViewController {
     private func applySharedGrid(_ grid: TerminalGrid) {
         guard sharedGrid != grid else { return }
         sharedGrid = grid
-        // The content tracker clamps its row estimate at the session's
-        // height, so scrolling output pins the anchor to the bottom row.
-        altScreenSniffer.gridRows = Int(grid.rows)
         view.setNeedsLayout()
     }
 
@@ -2056,22 +2065,8 @@ private func termio_ghostty_surface_draw(_ surface: UnsafeMutableRawPointer)
 /// page keys on the alternate one.
 private struct AlternateScreenSniffer {
     private(set) var isAlternate = false
-    /// The deepest 1-based row a *visible* glyph has landed on since the last
-    /// full clear — the anchor the keyboard pan scrolls into view. It is an
-    /// estimate from the byte stream, not a VT model: cursor rows come from
-    /// CUP/HVP/VPA addressing and linefeeds, and only non-blank printables
-    /// mark content, so a repaint that addresses blank rows (the attach
-    /// snapshot walks every row) claims nothing it didn't draw. Every
-    /// snapshot replay ends with a CUP to the true cursor, which re-anchors
-    /// `currentRow` at each boundary; between boundaries an unwrapped long
-    /// line can undercount by a row or two, which the pan's margin absorbs.
-    private(set) var contentBottomRow = 1
-    private var currentRow = 1
-    /// The session's row count, for clamping once output scrolls at the
-    /// bottom. Zero until the grid is known; then rows never count past it.
-    var gridRows = 0
     /// Unfinished escape sequence at a chunk's tail, re-parsed with the next
-    /// chunk — a sequence can split across WebSocket frames.
+    /// chunk — a mode switch can split across WebSocket frames.
     private var carry = Data()
 
     mutating func consume(_ chunk: Data) {
@@ -2081,112 +2076,60 @@ private struct AlternateScreenSniffer {
 
         var index = 0
         while index < bytes.count {
-            let byte = bytes[index]
-            guard byte == 0x1B else {
-                if byte == 0x0A {
-                    currentRow = clampRow(currentRow + 1)
-                } else if byte >= 0x21, byte != 0x7F {
-                    // A visible glyph (space and DEL excluded; UTF-8
-                    // continuation bytes count — box borders are content).
-                    contentBottomRow = max(contentBottomRow, currentRow)
-                }
-                index += 1
-                continue
-            }
-            let parsed = parseEscape(bytes, at: index)
-            switch parsed.kind {
+            guard bytes[index] == 0x1B else { index += 1; continue }
+            switch parseEscape(bytes, at: index) {
             case .incomplete:
-                // A real sequence is short; anything longer is content that
-                // happens to contain ESC — don't carry it forever.
+                // A real mode switch is short; anything longer is content
+                // that happens to contain ESC — don't carry it forever.
                 if bytes.count - index <= 40 { carry = Data(bytes[index...]) }
                 return
             case .altScreen(let entered):
                 isAlternate = entered
+                index += 1
             case .reset:
                 isAlternate = false
-                currentRow = 1
-                contentBottomRow = 1
-            case .cursorRow(let row):
-                currentRow = clampRow(row)
-            case .clearScreen:
-                // The grid was wiped; the repaint that follows rebuilds the
-                // content anchor from scratch.
-                contentBottomRow = 1
+                index += 1
             case .other:
-                break
+                index += 1
             }
-            index += parsed.length
         }
     }
 
-    private func clampRow(_ row: Int) -> Int {
-        let floor = max(1, row)
-        return gridRows > 0 ? min(floor, gridRows) : floor
-    }
-
-    private enum Kind {
+    private enum Parse {
         case incomplete
         case altScreen(Bool)
         case reset
-        case cursorRow(Int)
-        case clearScreen
         case other
     }
 
-    /// Parses the escape at `start` just far enough to classify it — RIS,
-    /// the alternate-screen modes, absolute cursor rows (CUP/HVP/VPA), and
-    /// full clears — and reports how many bytes it spans, so a sequence's
-    /// body is never re-read as content.
-    private func parseEscape(_ bytes: [UInt8], at start: Int) -> (kind: Kind, length: Int) {
+    /// Parses the escape at `start` just far enough to classify it: RIS
+    /// (`ESC c`) or a private mode set/reset (`ESC [ ? params h|l`) naming
+    /// an alternate-screen mode.
+    private func parseEscape(_ bytes: [UInt8], at start: Int) -> Parse {
         var index = start + 1
-        guard index < bytes.count else { return (.incomplete, 0) }
-        let introducer = bytes[index]
-        if introducer == UInt8(ascii: "c") { return (.reset, 2) }
-        if introducer == UInt8(ascii: "]") {
-            // OSC: swallow to BEL or ST, or a title's text reads as content.
-            index += 1
-            while index < bytes.count {
-                if bytes[index] == 0x07 { return (.other, index - start + 1) }
-                if bytes[index] == 0x1B, index + 1 < bytes.count,
-                   bytes[index + 1] == UInt8(ascii: "\\") {
-                    return (.other, index - start + 2)
-                }
-                index += 1
-            }
-            return bytes.count - start <= 4096 ? (.incomplete, 0) : (.other, bytes.count - start)
-        }
-        guard introducer == UInt8(ascii: "[") else { return (.other, 2) }
+        guard index < bytes.count else { return .incomplete }
+        if bytes[index] == UInt8(ascii: "c") { return .reset }
+        guard bytes[index] == UInt8(ascii: "[") else { return .other }
+        index += 1
+        guard index < bytes.count else { return .incomplete }
+        guard bytes[index] == UInt8(ascii: "?") else { return .other }
         index += 1
 
         var parameters = ""
         while index < bytes.count, parameters.utf8.count <= 32 {
             let byte = bytes[index]
-            if (0x30 ... 0x39).contains(byte) || byte == UInt8(ascii: ";")
-                || byte == UInt8(ascii: "?") {
+            if (0x30 ... 0x39).contains(byte) || byte == UInt8(ascii: ";") {
                 parameters.append(Character(Unicode.Scalar(byte)))
                 index += 1
                 continue
             }
-            // Any CSI final byte ends the sequence; classify the few that
-            // move the tracker and skip the rest whole.
-            guard (0x40 ... 0x7E).contains(byte) else { return (.other, index - start + 1) }
-            let length = index - start + 1
-            let names = parameters.drop(while: { $0 == "?" }).split(separator: ";")
-            switch byte {
-            case UInt8(ascii: "h"), UInt8(ascii: "l"):
-                guard parameters.hasPrefix("?"),
-                      names.contains(where: { $0 == "1049" || $0 == "1047" || $0 == "47" })
-                else { return (.other, length) }
-                return (.altScreen(byte == UInt8(ascii: "h")), length)
-            case UInt8(ascii: "H"), UInt8(ascii: "f"), UInt8(ascii: "d"):
-                return (.cursorRow(names.first.flatMap { Int($0) } ?? 1), length)
-            case UInt8(ascii: "J"):
-                let mode = names.first.flatMap { Int($0) } ?? 0
-                return mode >= 2 ? (.clearScreen, length) : (.other, length)
-            default:
-                return (.other, length)
+            guard byte == UInt8(ascii: "h") || byte == UInt8(ascii: "l") else { return .other }
+            let names = parameters.split(separator: ";")
+            guard names.contains(where: { $0 == "1049" || $0 == "1047" || $0 == "47" }) else {
+                return .other
             }
+            return .altScreen(byte == UInt8(ascii: "h"))
         }
-        return parameters.utf8.count > 32 ? (.other, index - start) : (.incomplete, 0)
+        return parameters.utf8.count > 32 ? .other : .incomplete
     }
 }

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -103,6 +103,15 @@ final class TerminalViewController: UIViewController {
     /// Bottom pin of the surface — its constant tracks the keyboard overlap
     /// (0 when the keyboard is away), see keyboardFrameWillChange.
     private var terminalBottomConstraint: NSLayoutConstraint?
+    /// How much of the screen the keyboard covers right now. The keyboard
+    /// occludes, it never resizes: the declared viewport and the surface grid
+    /// are both measured against the keyboard-hidden height, and the surface is
+    /// slid up so its bottom rows — the prompt, an agent's input box — stay
+    /// visible above the keys. Sizing the PTY to the keyboard-shrunk area sent
+    /// a SIGWINCH on every show/hide, and an agent TUI answers each one with a
+    /// full repaint (the pan-don't-resize rule every mobile terminal converges
+    /// on).
+    private var keyboardOverlap: CGFloat = 0
     /// Main-thread only — fed from the companion byte stream, read on key taps.
     private var altScreenSniffer = AlternateScreenSniffer()
     private var uploadClient: DeviceClient?
@@ -326,6 +335,11 @@ final class TerminalViewController: UIViewController {
     private func layoutTerminalSurface() {
         let host = terminalHost.bounds
         guard host.width > 0, host.height > 0 else { return }
+        // Everything below is measured against the keyboard-hidden height. The
+        // keyboard occludes this rectangle, it never shrinks it: shrinking is a
+        // viewport change, a viewport change is a PTY resize, and a PTY resize
+        // is a full TUI repaint on every show/hide of the keys.
+        let fullHeight = host.height + keyboardOverlap
         let screen = hostGrid
         if case .device = backend, let screen {
             companion?.setViewport(columns: Int(screen.cols), rows: Int(screen.rows))
@@ -336,12 +350,17 @@ final class TerminalViewController: UIViewController {
               let grid = sharedGrid, grid != screen,
               let cell = cellSize, grid.cols > 0, grid.rows > 0
         else {
-            terminalView.frame = host
+            // Full-height surface pinned to the host's bottom: with the
+            // keyboard up the host bottom sits above the keys, so the bottom
+            // rows stay visible and the top ones slide under the header
+            // (the host clips). With it away this is exactly `host`.
+            terminalView.frame = CGRect(
+                x: 0, y: host.height - fullHeight, width: host.width, height: fullHeight)
             return
         }
         let width = CGFloat(grid.cols) * cell.width + 2 * Self.terminalPaddingX + cell.width / 2
         let height = CGFloat(grid.rows) * cell.height + 2 * Self.terminalPaddingY + cell.height / 2
-        let fit = min(1, host.width / width, host.height / height)
+        let fit = min(1, host.width / width, fullHeight / height)
         terminalView.bounds = CGRect(x: 0, y: 0, width: width, height: height)
         terminalView.transform = CGAffineTransform(scaleX: fit, y: fit)
         terminalView.center = CGPoint(x: host.midX, y: height * fit / 2)
@@ -355,8 +374,13 @@ final class TerminalViewController: UIViewController {
     /// viewport at all rather than as a stand-in.
     private var hostGrid: TerminalGrid? {
         guard let cell = cellSize else { return nil }
+        // The keyboard-hidden height, always: what this screen could show is a
+        // fact about the screen, not about whether the keys happen to be up.
+        let size = CGSize(
+            width: terminalHost.bounds.width,
+            height: terminalHost.bounds.height + keyboardOverlap)
         return TerminalGrid.fitting(
-            terminalHost.bounds.size, cell: cell,
+            size, cell: cell,
             paddingX: Self.terminalPaddingX, paddingY: Self.terminalPaddingY)
     }
 
@@ -651,6 +675,7 @@ final class TerminalViewController: UIViewController {
         let endFrame = view.convert(endValue.cgRectValue, from: nil)
         let overlap = max(0, view.bounds.maxY - endFrame.minY)
         guard let constraint = terminalBottomConstraint, constraint.constant != -overlap else { return }
+        keyboardOverlap = overlap
         constraint.constant = -overlap
         let duration = note.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0.25
         let curve = note.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int ?? 7

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -350,12 +350,14 @@ final class TerminalViewController: UIViewController {
               let grid = sharedGrid, grid != screen,
               let cell = cellSize, grid.cols > 0, grid.rows > 0
         else {
-            // Full-height surface pinned to the host's bottom: with the
-            // keyboard up the host bottom sits above the keys, so the bottom
-            // rows stay visible and the top ones slide under the header
-            // (the host clips). With it away this is exactly `host`.
+            // Full-height surface, slid up by exactly the content-aware pan:
+            // enough that the deepest drawn row clears the keys, never more.
+            // The host clips whatever the slide pushes past the top, and the
+            // keyboard covers whatever stays below. With the keys away this
+            // is exactly `host`.
+            lastAppliedPan = keyboardPan
             terminalView.frame = CGRect(
-                x: 0, y: host.height - fullHeight, width: host.width, height: fullHeight)
+                x: 0, y: -lastAppliedPan, width: host.width, height: fullHeight)
             return
         }
         let width = CGFloat(grid.cols) * cell.width + 2 * Self.terminalPaddingX + cell.width / 2
@@ -372,6 +374,37 @@ final class TerminalViewController: UIViewController {
     /// a per-platform copy of this arithmetic would drift a column apart. `nil`
     /// before the surface has reported a cell size, which the device reads as no
     /// viewport at all rather than as a stand-in.
+    /// How far the surface slides up while the keyboard shows: just enough to
+    /// keep the deepest drawn row visible above the keys, and not a point
+    /// more. A fresh session with three rows of content stays put — the keys
+    /// cover empty grid — while a full transcript pins its bottom row (the
+    /// prompt, an agent's input box) over them. Pushing the whole overlap
+    /// unconditionally hid a short session's only content off the top; never
+    /// pushing hid a tall session's input line under the keys; the content
+    /// anchor is what resolves the two. Alt-screen apps own the whole grid
+    /// and always pin. A couple of margin rows absorb the tracker's
+    /// undercount on wrapped lines.
+    private var keyboardPan: CGFloat {
+        guard keyboardOverlap > 0 else { return 0 }
+        guard let cell = cellSize, !altScreenSniffer.isAlternate else { return keyboardOverlap }
+        let marginRows: CGFloat = 2
+        let contentBottom = Self.terminalPaddingY
+            + (CGFloat(altScreenSniffer.contentBottomRow) + marginRows) * cell.height
+        return min(keyboardOverlap, max(0, contentBottom - terminalHost.bounds.height))
+    }
+
+    /// The pan the surface was last framed with, so output that deepens the
+    /// content while the keys are up can re-slide without a full layout pass.
+    private var lastAppliedPan: CGFloat = 0
+
+    /// Called on every output chunk: if the content anchor moved enough to
+    /// change the pan while the keyboard is showing, re-frame the surface.
+    private func followContentUnderKeyboard() {
+        guard keyboardOverlap > 0 else { return }
+        guard abs(keyboardPan - lastAppliedPan) > 0.5 else { return }
+        layoutTerminalSurface()
+    }
+
     private var hostGrid: TerminalGrid? {
         guard let cell = cellSize else { return nil }
         // The keyboard-hidden height, always: what this screen could show is a
@@ -400,6 +433,9 @@ final class TerminalViewController: UIViewController {
     private func applySharedGrid(_ grid: TerminalGrid) {
         guard sharedGrid != grid else { return }
         sharedGrid = grid
+        // The content tracker clamps its row estimate at the session's
+        // height, so scrolling output pins the anchor to the bottom row.
+        altScreenSniffer.gridRows = Int(grid.rows)
         view.setNeedsLayout()
     }
 
@@ -884,10 +920,14 @@ final class TerminalViewController: UIViewController {
             )
             transport.onOutput = { [weak terminalSession, weak self] data in
                 terminalSession?.receive(data)
-                // The sniffer only decides what the key bar's scroll-edge keys
-                // send; a TUI switching screens changes nothing about the grid,
-                // which is the writer's and already what the PTY is.
-                DispatchQueue.main.async { self?.altScreenSniffer.consume(data) }
+                // The sniffer decides what the key bar's scroll-edge keys send
+                // and where the keyboard pan anchors; a TUI switching screens
+                // changes nothing about the grid, which is the writer's and
+                // already what the PTY is.
+                DispatchQueue.main.async {
+                    self?.altScreenSniffer.consume(data)
+                    self?.followContentUnderKeyboard()
+                }
             }
             transport.onState = { [weak self] state in
                 self?.companionStateChanged(state)
@@ -2016,8 +2056,22 @@ private func termio_ghostty_surface_draw(_ surface: UnsafeMutableRawPointer)
 /// page keys on the alternate one.
 private struct AlternateScreenSniffer {
     private(set) var isAlternate = false
+    /// The deepest 1-based row a *visible* glyph has landed on since the last
+    /// full clear — the anchor the keyboard pan scrolls into view. It is an
+    /// estimate from the byte stream, not a VT model: cursor rows come from
+    /// CUP/HVP/VPA addressing and linefeeds, and only non-blank printables
+    /// mark content, so a repaint that addresses blank rows (the attach
+    /// snapshot walks every row) claims nothing it didn't draw. Every
+    /// snapshot replay ends with a CUP to the true cursor, which re-anchors
+    /// `currentRow` at each boundary; between boundaries an unwrapped long
+    /// line can undercount by a row or two, which the pan's margin absorbs.
+    private(set) var contentBottomRow = 1
+    private var currentRow = 1
+    /// The session's row count, for clamping once output scrolls at the
+    /// bottom. Zero until the grid is known; then rows never count past it.
+    var gridRows = 0
     /// Unfinished escape sequence at a chunk's tail, re-parsed with the next
-    /// chunk — a mode switch can split across WebSocket frames.
+    /// chunk — a sequence can split across WebSocket frames.
     private var carry = Data()
 
     mutating func consume(_ chunk: Data) {
@@ -2027,60 +2081,112 @@ private struct AlternateScreenSniffer {
 
         var index = 0
         while index < bytes.count {
-            guard bytes[index] == 0x1B else { index += 1; continue }
-            switch parseEscape(bytes, at: index) {
+            let byte = bytes[index]
+            guard byte == 0x1B else {
+                if byte == 0x0A {
+                    currentRow = clampRow(currentRow + 1)
+                } else if byte >= 0x21, byte != 0x7F {
+                    // A visible glyph (space and DEL excluded; UTF-8
+                    // continuation bytes count — box borders are content).
+                    contentBottomRow = max(contentBottomRow, currentRow)
+                }
+                index += 1
+                continue
+            }
+            let parsed = parseEscape(bytes, at: index)
+            switch parsed.kind {
             case .incomplete:
-                // A real mode switch is short; anything longer is content
-                // that happens to contain ESC — don't carry it forever.
+                // A real sequence is short; anything longer is content that
+                // happens to contain ESC — don't carry it forever.
                 if bytes.count - index <= 40 { carry = Data(bytes[index...]) }
                 return
             case .altScreen(let entered):
                 isAlternate = entered
-                index += 1
             case .reset:
                 isAlternate = false
-                index += 1
+                currentRow = 1
+                contentBottomRow = 1
+            case .cursorRow(let row):
+                currentRow = clampRow(row)
+            case .clearScreen:
+                // The grid was wiped; the repaint that follows rebuilds the
+                // content anchor from scratch.
+                contentBottomRow = 1
             case .other:
-                index += 1
+                break
             }
+            index += parsed.length
         }
     }
 
-    private enum Parse {
+    private func clampRow(_ row: Int) -> Int {
+        let floor = max(1, row)
+        return gridRows > 0 ? min(floor, gridRows) : floor
+    }
+
+    private enum Kind {
         case incomplete
         case altScreen(Bool)
         case reset
+        case cursorRow(Int)
+        case clearScreen
         case other
     }
 
-    /// Parses the escape at `start` just far enough to classify it: RIS
-    /// (`ESC c`) or a private mode set/reset (`ESC [ ? params h|l`) naming
-    /// an alternate-screen mode.
-    private func parseEscape(_ bytes: [UInt8], at start: Int) -> Parse {
+    /// Parses the escape at `start` just far enough to classify it — RIS,
+    /// the alternate-screen modes, absolute cursor rows (CUP/HVP/VPA), and
+    /// full clears — and reports how many bytes it spans, so a sequence's
+    /// body is never re-read as content.
+    private func parseEscape(_ bytes: [UInt8], at start: Int) -> (kind: Kind, length: Int) {
         var index = start + 1
-        guard index < bytes.count else { return .incomplete }
-        if bytes[index] == UInt8(ascii: "c") { return .reset }
-        guard bytes[index] == UInt8(ascii: "[") else { return .other }
-        index += 1
-        guard index < bytes.count else { return .incomplete }
-        guard bytes[index] == UInt8(ascii: "?") else { return .other }
+        guard index < bytes.count else { return (.incomplete, 0) }
+        let introducer = bytes[index]
+        if introducer == UInt8(ascii: "c") { return (.reset, 2) }
+        if introducer == UInt8(ascii: "]") {
+            // OSC: swallow to BEL or ST, or a title's text reads as content.
+            index += 1
+            while index < bytes.count {
+                if bytes[index] == 0x07 { return (.other, index - start + 1) }
+                if bytes[index] == 0x1B, index + 1 < bytes.count,
+                   bytes[index + 1] == UInt8(ascii: "\\") {
+                    return (.other, index - start + 2)
+                }
+                index += 1
+            }
+            return bytes.count - start <= 4096 ? (.incomplete, 0) : (.other, bytes.count - start)
+        }
+        guard introducer == UInt8(ascii: "[") else { return (.other, 2) }
         index += 1
 
         var parameters = ""
         while index < bytes.count, parameters.utf8.count <= 32 {
             let byte = bytes[index]
-            if (0x30 ... 0x39).contains(byte) || byte == UInt8(ascii: ";") {
+            if (0x30 ... 0x39).contains(byte) || byte == UInt8(ascii: ";")
+                || byte == UInt8(ascii: "?") {
                 parameters.append(Character(Unicode.Scalar(byte)))
                 index += 1
                 continue
             }
-            guard byte == UInt8(ascii: "h") || byte == UInt8(ascii: "l") else { return .other }
-            let names = parameters.split(separator: ";")
-            guard names.contains(where: { $0 == "1049" || $0 == "1047" || $0 == "47" }) else {
-                return .other
+            // Any CSI final byte ends the sequence; classify the few that
+            // move the tracker and skip the rest whole.
+            guard (0x40 ... 0x7E).contains(byte) else { return (.other, index - start + 1) }
+            let length = index - start + 1
+            let names = parameters.drop(while: { $0 == "?" }).split(separator: ";")
+            switch byte {
+            case UInt8(ascii: "h"), UInt8(ascii: "l"):
+                guard parameters.hasPrefix("?"),
+                      names.contains(where: { $0 == "1049" || $0 == "1047" || $0 == "47" })
+                else { return (.other, length) }
+                return (.altScreen(byte == UInt8(ascii: "h")), length)
+            case UInt8(ascii: "H"), UInt8(ascii: "f"), UInt8(ascii: "d"):
+                return (.cursorRow(names.first.flatMap { Int($0) } ?? 1), length)
+            case UInt8(ascii: "J"):
+                let mode = names.first.flatMap { Int($0) } ?? 0
+                return mode >= 2 ? (.clearScreen, length) : (.other, length)
+            default:
+                return (.other, length)
             }
-            return .altScreen(byte == UInt8(ascii: "h"))
         }
-        return parameters.utf8.count > 32 ? .other : .incomplete
+        return parameters.utf8.count > 32 ? (.other, index - start) : (.incomplete, 0)
     }
 }

--- a/ios/UITests/WidthRegressionTests.swift
+++ b/ios/UITests/WidthRegressionTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+
+/// Not a test of behavior — a capture harness for the width/rendering
+/// investigation, in the MarketingScreensTests mold: drives the app against
+/// the REAL Mac companion roster (`/tmp/marketing-roster-url`, or the
+/// `ROSTER_URL` runner environment variable) and attaches named screenshots
+/// of the states under suspicion; `xcresulttool export attachments` pulls
+/// them out. Skips itself when no roster URL is provided, so CI never runs
+/// it. Read-only by design: it opens sessions, scrolls, and toggles the
+/// keyboard — it never types into an agent.
+final class WidthRegressionTests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func rosterURL() throws -> String {
+        let fileURL = (try? String(contentsOfFile: "/tmp/marketing-roster-url", encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = ProcessInfo.processInfo.environment["ROSTER_URL"] ?? fileURL,
+              !url.isEmpty
+        else {
+            throw XCTSkip("ROSTER_URL not set — width capture is manual-only")
+        }
+        return url
+    }
+
+    private func shoot(_ name: String, settle: TimeInterval = 2.0) {
+        Thread.sleep(forTimeInterval: settle)
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func open(_ app: XCUIApplication, project: String, row: String) {
+        let projectRow = app.staticTexts[project].firstMatch
+        XCTAssertTrue(projectRow.waitForExistence(timeout: 10), "no project \(project)")
+        projectRow.tap()
+        let sessionRow = app.staticTexts[row].firstMatch
+        XCTAssertTrue(sessionRow.waitForExistence(timeout: 8), "no session row \(row)")
+        sessionRow.tap()
+        XCTAssertTrue(app.buttons["terminal.back"].waitForExistence(timeout: 8))
+    }
+
+    /// The static states: a long-lived agent session opening with the
+    /// keyboard up (the covered-input report), keyboard away, and a fresh
+    /// terminal as the native-width baseline.
+    func testWidthStates() throws {
+        let roster = try rosterURL()
+        let app = XCUIApplication()
+        app.launchArguments = ["-roster-url", roster]
+        app.launch()
+
+        open(app, project: "paradigm-study-web",
+             row: "Document application architecture and design patterns")
+        shoot("full-session-keyboard-up", settle: 3.0)
+        app.swipeDown()
+        shoot("full-session-keyboard-down")
+        app.buttons["terminal.back"].tap()
+
+        // Still on the project page; the plain terminal is the native-width
+        // baseline.
+        let terminal = app.staticTexts["Terminal"].firstMatch
+        XCTAssertTrue(terminal.waitForExistence(timeout: 8), "no Terminal row")
+        terminal.tap()
+        XCTAssertTrue(app.buttons["terminal.back"].waitForExistence(timeout: 8))
+        shoot("fresh-terminal-keyboard-up", settle: 3.0)
+        app.swipeDown()
+        shoot("fresh-terminal-keyboard-down")
+    }
+
+    /// The scroll seam: slow drags through the transcript with a screenshot
+    /// burst riding on a background queue, aiming to catch the torn frame the
+    /// report describes (a stale strip splitting the screen left/right while
+    /// content is in motion).
+    func testScrollSeam() throws {
+        let roster = try rosterURL()
+        let app = XCUIApplication()
+        app.launchArguments = ["-roster-url", roster]
+        app.launch()
+
+        open(app, project: "paradigm-study-web",
+             row: "Document application architecture and design patterns")
+        // Keyboard away first so the whole height scrolls.
+        app.swipeDown()
+        Thread.sleep(forTimeInterval: 2.0)
+
+        let window = app.windows.firstMatch
+        let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
+        let end = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.75))
+
+        var burst: [XCUIScreenshot] = []
+        let burstLock = NSLock()
+        var bursting = true
+        let capture = DispatchQueue(label: "seam-burst")
+        capture.async {
+            while bursting {
+                let shot = XCUIScreen.main.screenshot()
+                burstLock.lock()
+                burst.append(shot)
+                burstLock.unlock()
+                Thread.sleep(forTimeInterval: 0.12)
+            }
+        }
+
+        // Three slow pulls down through the scrollback, then three back up.
+        for _ in 0..<3 {
+            start.press(forDuration: 0.05, thenDragTo: end,
+                        withVelocity: 200, thenHoldForDuration: 0.05)
+        }
+        for _ in 0..<3 {
+            end.press(forDuration: 0.05, thenDragTo: start,
+                      withVelocity: 200, thenHoldForDuration: 0.05)
+        }
+
+        bursting = false
+        capture.sync {}
+        burstLock.lock()
+        let shots = burst
+        burstLock.unlock()
+        for (index, shot) in shots.enumerated() {
+            let attachment = XCTAttachment(screenshot: shot)
+            attachment.name = String(format: "scroll-burst-%03d", index)
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+        shoot("scroll-settled")
+    }
+}

--- a/termiod/smoke_test.py
+++ b/termiod/smoke_test.py
@@ -489,8 +489,17 @@ def main():
 
     os.write(a2, b"\x1c")
     a2p.wait(timeout=5)
+    # §12: leaving is not using. The departed screen's size stays — a phone's
+    # socket dies on every backgrounding, and handing the size to whichever
+    # unattended window remains made each pocket-and-return cost two reflows.
+    # The survivor reclaims it the moment somebody acts there.
     check(
-        "a departing attachment leaves the size to the survivor",
+        "a departing attachment leaves the size where the last person put it",
+        wait_for_size("fan", (34, 110)),
+    )
+    os.write(a1, b"FROM_A1_AGAIN\r")
+    check(
+        "the survivor reclaims the size by typing",
         wait_for_size("fan", (26, 90)),
     )
     drain(a1, 0.5)

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -448,6 +448,35 @@ impl Pty {
         })
     }
 
+    /// A real PTY with no child, for tests that assert an *applied* resize —
+    /// `TIOCSWINSZ` is answered by the terminal itself, so no process needs to
+    /// sit on the slave side. The slave descriptor is closed; the winsize
+    /// outlives it.
+    pub(crate) fn childless_pty_for_resize_test() -> Result<Pty> {
+        let mut master_raw: RawFd = -1;
+        let mut slave_raw: RawFd = -1;
+        let rc = unsafe {
+            libc::openpty(
+                &mut master_raw,
+                &mut slave_raw,
+                std::ptr::null_mut::<libc::c_char>(),
+                std::ptr::null_mut::<libc::termios>() as _,
+                std::ptr::null_mut::<libc::winsize>() as _,
+            )
+        };
+        if rc != 0 {
+            bail!("openpty failed: {}", std::io::Error::last_os_error());
+        }
+        let master = unsafe { OwnedFd::from_raw_fd(master_raw) };
+        unsafe { libc::close(slave_raw) };
+        set_cloexec(master.as_raw_fd())?;
+        set_nonblocking(master.as_raw_fd())?;
+        Ok(Pty {
+            master: AsyncFd::new(master)?,
+            pid: 0,
+        })
+    }
+
     /// The process group that currently owns the tty's foreground — the program
     /// the user is actually interacting with: the login shell until it runs a
     /// command, then that command, then the shell again once it exits.

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -859,8 +859,10 @@ impl Session {
         if self.writer != old_writer {
             self.emit_writer_changed(self.writer.clone());
         }
-        // A viewer that died was very likely the smallest one.
-        self.apply_size_policy();
+        // Deliberately no size recomputation: a death is not a person acting
+        // (§12 of the size RFC). If the dead viewer owned the size, the session
+        // keeps the shape that person gave it until somebody else does
+        // something.
     }
 
     /// Send a protocol event to attachments and control-channel subscribers.
@@ -1105,11 +1107,14 @@ impl Session {
 
     /// Moves the PTY to whatever the policy now says, if that is somewhere else.
     ///
-    /// This is the only thing in the daemon that resizes a session, and it runs
-    /// on every change to the attachment set: an arrival, a departure, a
-    /// viewport, a keystroke, a pane going to a background tab. The write token
-    /// is not consulted — the token is about who may type, and a device can be
-    /// the one being looked at without holding it
+    /// This is the only thing in the daemon that resizes a session, and (§12)
+    /// it runs only when a person acts: an arrival with a screen, a keystroke,
+    /// a viewport declared while rendering. Never on a departure, a death, or
+    /// a screen parking — leaving is not using, and recomputing on the way out
+    /// handed the size to whichever unattended window happened to remain,
+    /// which made every phone lock/unlock cycle cost two full TUI reflows.
+    /// The write token is not consulted — the token is about who may type, and
+    /// a device can be the one being looked at without holding it
     /// (`docs/design/20260901-pty-size-is-not-the-write-token.md`).
     ///
     /// With nobody rendering, the size is left exactly where it was. A session
@@ -2619,9 +2624,12 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             if session.writer != old_writer {
                 session.emit_writer_changed(session.writer.clone());
             }
-            // The viewer that left may have been the one holding the session
-            // narrow; the rest of them get their width back.
-            session.apply_size_policy();
+            // Leaving is not using: the size stays where the last person put
+            // it (§12). The viewer that left may have been the phone whose
+            // socket iOS just tore down on a backgrounding — resizing here is
+            // what made every pocket-and-return cost a full TUI reflow. The
+            // remaining screens reclaim the size the moment somebody types or
+            // resizes at one of them.
             session.emit_roster();
         }
         SessionMsg::ResendSnapshot { id } => {
@@ -2702,11 +2710,15 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             // Resizing a window, collapsing its sidebar, turning a phone: the
             // person is on this device. A screen that only stopped rendering is
             // not — nobody is looking at it, so it must not take the size with
-            // it on the way out.
+            // it on the way out, and (§12) it must not hand the size to some
+            // other screen on the way out either: a phone going to a pocket is
+            // exactly this message with `rendering: false`, and recomputing
+            // here is what snapped every session back to an unattended Mac
+            // window the moment the phone locked.
             if rendering {
                 session.note_use(&id);
+                session.apply_size_policy();
             }
-            session.apply_size_policy();
         }
         SessionMsg::Inject { data } => {
             let _ = session.input_tx.send(data);
@@ -3252,6 +3264,80 @@ mod tests {
 
         declare_viewport(&mut session, "phone", 42, 47, true);
         assert_eq!(session.policy_size(), Some((42, 47)), "and back again");
+
+        session.vt.shut_down();
+        let _ = thread.join();
+    }
+
+    /// §12: parking is not using. A phone going to a pocket sends
+    /// `rendering: false`; the session must keep the shape that person gave it
+    /// rather than snap to an unattended Mac window — that snap is what made
+    /// every lock/unlock cycle cost two full TUI reflows. The Mac reclaims the
+    /// size the moment somebody actually acts there.
+    #[tokio::test]
+    async fn parking_the_size_owner_leaves_the_size_behind() {
+        let Sidecar {
+            commands,
+            results: _results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+        // A PTY whose resize actually applies: these tests assert the
+        // committed size, not just the policy's answer.
+        session.pty = Arc::new(Pty::childless_pty_for_resize_test().unwrap());
+
+        let _mac = attach_interactive_client_at(&mut session, "mac", 50, 200);
+        let _phone = attach_interactive_client_at(&mut session, "phone", 42, 47);
+        assert_eq!((session.rows, session.cols), (42, 47));
+
+        declare_viewport(&mut session, "phone", 42, 47, false);
+        assert_eq!(
+            (session.rows, session.cols),
+            (42, 47),
+            "the phone locked; nobody used the Mac, so nothing may resize"
+        );
+
+        type_into(&mut session, "mac");
+        assert_eq!(
+            (session.rows, session.cols),
+            (50, 200),
+            "typing at the Mac is a person acting; now it resizes"
+        );
+
+        session.vt.shut_down();
+        let _ = thread.join();
+    }
+
+    /// §12, the harder half: even the size owner's *death* moves nothing. A
+    /// backgrounded iOS app tears its socket down without a goodbye, so a
+    /// departure is routinely the same person who is about to come back.
+    #[tokio::test]
+    async fn a_departed_size_owner_leaves_the_size_behind() {
+        let Sidecar {
+            commands,
+            results: _results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+        session.pty = Arc::new(Pty::childless_pty_for_resize_test().unwrap());
+
+        let _mac = attach_interactive_client_at(&mut session, "mac", 50, 200);
+        let _phone = attach_interactive_client_at(&mut session, "phone", 42, 47);
+        assert_eq!((session.rows, session.cols), (42, 47));
+
+        handle_msg(
+            &mut session,
+            SessionMsg::RemoveClient {
+                id: ClientId::new("phone"),
+            },
+        );
+        assert_eq!(
+            (session.rows, session.cols),
+            (42, 47),
+            "the phone's socket died; the size it chose stays"
+        );
 
         session.vt.shut_down();
         let _ = thread.join();


### PR DESCRIPTION
Two fixes for the phone's width instability, one rule: the PTY's size moves only when a person acts.

## Leaving is not using (termiod, RFC §12)

The size policy recomputed on every change to the attachment set — including departures, deaths, and a screen parking. When the most-recently-used attachment went away, the size fell back to whichever unattended window remained. On a phone that is the lifecycle, not an edge case: iOS tears the socket down on every backgrounding, so pocketing the phone handed the session back to a Mac window nobody was sitting at, and picking it up again paid the full reattach — wide snapshot, viewport claim, reflow — every time.

`apply_size_policy` now runs only from the three use stamps (arrival with a screen, a keystroke, a viewport declared while rendering). Departure, death, and `rendering: false` recompute nothing; the remaining screens reclaim the size the moment somebody types or resizes at one of them. This is stricter than tmux's `latest`, which falls back to the next-most-recent client on detach — justified by a client whose transport dies dozens of times a day with the same person behind it. §12 in `20260901-pty-size-is-not-the-write-token.md` records the rule.

New tests assert the *committed* size, which the existing fixture (a socketpair whose `TIOCSWINSZ` always fails) cannot express — they swap in a childless real PTY (`Pty::childless_pty_for_resize_test`).

## The keyboard occludes, it does not resize (iOS)

Showing or hiding the keys shrank the host view, the host measured a new viewport, and the viewport resized the PTY — a SIGWINCH and a full agent-TUI repaint on every tap into the terminal. The declared viewport and the surface grid are now both measured against the keyboard-hidden height; the PTY never hears about the keyboard at all.

What slides instead is the surface, and by a **content-aware** amount, not the full overlap. Pinning the bottom unconditionally assumed the content lives at the bottom — a fresh session's does not (an agent draws its input box ten rows from the top of a 47-row grid), so a full pan showed empty grid and pushed the only content off the top, while never panning would hide a full transcript's input line under the keys. The stream sniffer now tracks the deepest row a visible glyph landed on (cursor addressing plus linefeeds; blank-row repaints excluded; re-anchored by every snapshot's closing cursor move) and the surface slides by exactly the shortfall. Alt-screen apps own the whole grid and still pin; a two-row margin absorbs the tracker's undercount on wrapped lines.

## Validation

- `cargo test` in `termiod/`: 334 lib tests (2 new) + integration suites green. One unrelated `wss_bridge` frame-split test flaked under parallel load and passes 3/3 in isolation.
- iOS `xcodebuild` Debug: build succeeded; verified on device.

Release Notes:
- Locking or backgrounding the iPhone no longer bounces a session's width back to the Mac; the size stays where the last person put it.
- Opening the iPhone keyboard no longer resizes the terminal — the view slides just enough to keep the active rows visible, so agent TUIs stop repainting on every tap.