### PR TITLE
Keep agent screens rewrapping when a tool subshell holds the terminal

### DIFF
--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1072,13 +1072,19 @@ impl Session {
         const SHELLS: [&str; 9] = [
             "sh", "bash", "zsh", "fish", "dash", "ksh", "tcsh", "csh", "nu",
         ];
-        let Some(argv0) = self
-            .foreground
-            .current()
-            .argv
-            .as_ref()
-            .and_then(|argv| argv.first())
-        else {
+        let sample = self.foreground.current();
+        // A job holding the terminal is not the shell whose redisplay the
+        // truncating resize protects, whatever its name says. The name check
+        // alone called an agent's tool subshell a shell, so a resize landing
+        // mid-command truncated a screen the agent's TUI had painted — tails
+        // lost from rows the resize should have rewrapped (the phone's
+        // stale-tail blend). Only the session's own child at the prompt does
+        // old-width cursor arithmetic; a nested interactive shell loses this
+        // protection, which is the cheaper edge by far.
+        if sample.job {
+            return false;
+        }
+        let Some(argv0) = sample.argv.as_ref().and_then(|argv| argv.first()) else {
             return true;
         };
         let name = argv0
@@ -3463,6 +3469,18 @@ mod tests {
         // conservative one.
         session.foreground.set_argv_for_tests(None);
         assert!(session.foreground_is_a_shell());
+
+        // A shell running as a *job* — an agent's tool subshell, `claude`
+        // shelling out mid-turn — is not the shell whose redisplay the
+        // truncating resize protects: the screen it would truncate belongs to
+        // the TUI that spawned it.
+        session.foreground.set_argv_for_tests(Some(vec!["/bin/zsh".to_string()]));
+        session.foreground.set_job_for_tests(true);
+        assert!(
+            !session.foreground_is_a_shell(),
+            "a tool subshell must not switch the resize to truncation"
+        );
+        session.foreground.set_job_for_tests(false);
 
         session.vt.shut_down();
         let _ = thread.join();

--- a/termiod/src/session/foreground.rs
+++ b/termiod/src/session/foreground.rs
@@ -88,6 +88,13 @@ impl Foreground {
         self.sample.argv = argv;
     }
 
+    /// Pins the job bit the same way: whether the sampled group is something
+    /// the child put in the foreground rather than the child itself.
+    #[cfg(test)]
+    pub(super) fn set_job_for_tests(&mut self, job: bool) {
+        self.sample.job = job;
+    }
+
     pub(super) fn current(&self) -> &ForegroundSample {
         &self.sample
     }

--- a/termiod/vt/tests/resize_reflow.rs
+++ b/termiod/vt/tests/resize_reflow.rs
@@ -362,6 +362,31 @@ fn redraw_winning_the_resize_race_blanks_until_the_nudged_redraw() {
     assert_eq!(copies, 1, "the nudged redraw restored one prompt, rows: {rows:?}");
 }
 
+/// Narrowing is the same contract in the other direction: a line the program's
+/// autowrap broke at the old width is re-joined and re-broken at the new one,
+/// with nothing lost at the seam. What shipped instead truncated the first
+/// physical row at the new width and left the continuation row in its old
+/// form — the phone's "and r … ntent." stale-tail blend: characters 40..49
+/// vanished and a fragment wrapped for the old width survived beside new text.
+#[test]
+fn narrowing_with_reflow_rewraps_without_losing_the_seam() {
+    let mut vt = VtTerminal::new(24, 49).unwrap();
+    // 73 columns of text in a 49-column terminal: autowrap breaks it after
+    // "…directly"'s fifth character, exactly the phone transcript's shape.
+    vt.vt_write(
+        b"players call contentGeneration.star actions directly and re-render the co",
+    );
+    vt.resize_reflowing(24, 39).unwrap();
+    assert_eq!(
+        visible(&vt.format_vt().unwrap()),
+        vec![
+            "players call contentGeneration.star act".to_string(),
+            "ions directly and re-render the co".to_string(),
+        ],
+        "the wrapped line is re-joined and re-broken at 39 columns, keeping the seam"
+    );
+}
+
 /// The other half of the rule: with a job on screen rather than the shell, the
 /// same widening re-joins the line, which is what every terminal the program was
 /// written for does and what the user is comparing against.


### PR DESCRIPTION
The phone's stale-tail blend — a settled row holding new-wrap text beside a fragment wrapped for an older, wider grid — traced to the resize semantics switch, not to the reflow engine.

## What was wrong

`foreground_is_a_shell` name-matched whatever process group held the terminal. An agent running one Bash tool command puts a subshell in the foreground for a few seconds; a resize landing in that window took the truncating path (`resize_for_shell`, unmarked → truncate) over a screen the agent's TUI had painted. Tails vanished from rows the resize should have rewrapped, and repeated width flips between a Mac and a phone composed the visible debris.

The engine itself is exonerated: a new pin test (`narrowing_with_reflow_rewraps_without_losing_the_seam`) shows `resize_reflowing` re-joins and re-breaks a soft-wrapped line correctly in the narrowing direction, matching the existing widening pin.

## The fix

The foreground sample already distinguishes a *job* (foreground group ≠ the session's own child) from the child at its prompt. A job's shell does no old-width cursor arithmetic — the redisplay the truncating resize protects belongs to the shell sitting at the prompt — so the job bit now short-circuits the name check. Accepted edge: a nested interactive shell loses the truncate protection, which is by far the cheaper miss.

Verified end to end against a scratch daemon: a shell session with a foreground job painted with soft-wrapped content, narrowed 49→39 — the wrapped line re-joins with no lost span, hard-row tails wrap instead of dropping.

## Validation

- `cargo test`: 334 lib + all integration suites green (new: the vt narrowing pin, the job-subshell case in `only_a_shell_gets_the_mark_gated_resize`).

Release Notes:
- Resizing a session while its agent is running a shell command no longer truncates the agent's screen — lines rewrap to the new width with nothing lost, so switching between Mac and phone stops leaving stale fragments in the transcript.