### PR TITLE
Stamp a deploy's observation into the device registry

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1406,7 +1406,8 @@ extension TermioStore {
                     message: "termiod on \(host) answered without saying which machine it is."))
             }
             return .success(TermiodDevice(
-                id: hostID, daemonVersion: version, routes: [.ssh(host)], lastSeen: Date()))
+                id: hostID, daemonVersion: version, routes: [.ssh(host)],
+                negotiatedProtocol: report.proto, lastSeen: Date()))
         case .staged:
             return .failure(RemoteSetupError(
                 state: .staged,

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1024,6 +1024,7 @@ extension Termiod {
         let desired: String
         let version: String?
         let hostId: String?
+        let proto: Int?
         let newer: Bool?
         let daemon: String?
         let busy: [BusySession]?

--- a/Sources/termio/Terminal/Termiod/TermiodDevice.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodDevice.swift
@@ -128,12 +128,16 @@ final class TermiodDeviceRegistry: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
+        // The registry has a second, occasional writer: a CLI deploy stamps
+        // what its handshake revealed (termiod/src/remote.rs). Its stamp may be
+        // newer than this app's picture, and `save` writes the whole map from
+        // memory — so newer on-disk observations are folded in first, or the
+        // next handshake with *any* device would silently undo the deploy's.
+        mergeNewerObservationsFromDiskLocked()
+
         // A route that used to lead elsewhere is taken away from its old device
         // first, so the two never both claim it.
-        if let previous = deviceIDByRoute[route], previous != hostID {
-            devicesByID[previous]?.routes.removeAll { $0 == route }
-        }
-        deviceIDByRoute[route] = hostID
+        claimLocked(route, for: hostID)
 
         var device = devicesByID[hostID]
             ?? TermiodDevice(id: hostID, daemonVersion: daemonVersion, routes: [], lastSeen: nil)
@@ -153,6 +157,49 @@ final class TermiodDeviceRegistry: @unchecked Sendable {
 
         save()
         return device
+    }
+
+    /// Must hold `lock`. Points `route` at `id`, taking it away from whichever
+    /// device claimed it before — a route belongs to exactly one device.
+    private func claimLocked(_ route: TermiodRoute, for id: String) {
+        if let previous = deviceIDByRoute[route], previous != id {
+            devicesByID[previous]?.routes.removeAll { $0 == route }
+        }
+        deviceIDByRoute[route] = id
+    }
+
+    /// Must hold `lock`. Folds observations written to `devices.json` since the
+    /// last load into memory, newest per device winning: a row this app has
+    /// never seen is adopted whole, and a row observed more recently than the
+    /// copy in memory updates the facts a handshake learns (version, protocol,
+    /// routes, the stamp). Memory wins ties, so a normal app-only lifetime is
+    /// byte-for-byte what it was before this existed.
+    private func mergeNewerObservationsFromDiskLocked() {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let data = try? Data(contentsOf: fileURL),
+              let devices = try? decoder.decode([TermiodDevice].self, from: data)
+        else { return }
+        for disk in devices {
+            guard var memory = devicesByID[disk.id] else {
+                devicesByID[disk.id] = disk
+                for route in disk.routes { claimLocked(route, for: disk.id) }
+                continue
+            }
+            guard (disk.observedAt ?? .distantPast) > (memory.observedAt ?? .distantPast) else {
+                continue
+            }
+            memory.daemonVersion = disk.daemonVersion
+            if let negotiated = disk.negotiatedProtocol {
+                memory.negotiatedProtocol = negotiated
+            }
+            memory.observedAt = disk.observedAt
+            for route in disk.routes where !memory.routes.contains(route) {
+                memory.routes.append(route)
+            }
+            devicesByID[disk.id] = memory
+            for route in disk.routes { claimLocked(route, for: disk.id) }
+        }
     }
 
     /// The device a route is known to lead to, from an earlier handshake. `nil`

--- a/Tests/termioTests/TermiodDeviceRegistryTests.swift
+++ b/Tests/termioTests/TermiodDeviceRegistryTests.swift
@@ -179,4 +179,64 @@ final class TermiodDeviceRegistryTests: XCTestCase {
         XCTAssertEqual(device?.negotiatedProtocol, 1)
         XCTAssertNotNil(device?.observedAt)
     }
+
+    // MARK: - The registry's second writer
+
+    // A CLI deploy stamps its handshake's observation into `devices.json`
+    // (termiod/src/remote.rs) while this app may hold an older picture in
+    // memory — and `save` writes the whole map from memory. These pin the merge
+    // that keeps the newer observation, whichever side made it.
+
+    private func write(_ json: String) throws {
+        try Data(json.utf8).write(to: directory.appendingPathComponent("devices.json"))
+    }
+
+    func testAHandshakeKeepsANewerObservationWrittenBehindItsBack() throws {
+        try write("""
+        [{"id": "h_box", "daemonVersion": "0.50.0+1913", "proto": 1,
+          "observedAt": "2026-09-08T08:47:17Z", "routes": ["ssh:box"]}]
+        """)
+        let registry = makeRegistry()
+        // A CLI deploy stamps a fresh observation while the app holds the old one.
+        try write("""
+        [{"id": "h_box", "daemonVersion": "0.52.0+1944", "proto": 1,
+          "observedAt": "2026-09-08T17:58:00Z", "routes": ["ssh:box"]}]
+        """)
+        registry.record(hostID: "h_mac", daemonVersion: macDaemon, route: .local)
+
+        let box = makeRegistry().device(id: "h_box")
+        XCTAssertEqual(box?.daemonVersion, "0.52.0+1944",
+                       "the save must not write the stale in-memory row over the deploy's stamp")
+        XCTAssertNotNil(makeRegistry().device(id: "h_mac"))
+    }
+
+    func testAnOlderRowOnDiskNeverRollsMemoryBack() throws {
+        try write("""
+        [{"id": "h_box", "daemonVersion": "0.52.0+1944", "proto": 1,
+          "observedAt": "2026-09-08T17:58:00Z", "routes": ["ssh:box"]}]
+        """)
+        let registry = makeRegistry()
+        try write("""
+        [{"id": "h_box", "daemonVersion": "0.50.0+1913", "proto": 1,
+          "observedAt": "2026-09-08T08:47:17Z", "routes": ["ssh:box"]}]
+        """)
+        registry.record(hostID: "h_mac", daemonVersion: macDaemon, route: .local)
+
+        XCTAssertEqual(makeRegistry().device(id: "h_box")?.daemonVersion, "0.52.0+1944")
+    }
+
+    /// The first-ever deploy to a box happens from the CLI, before the app has
+    /// ever attached: the row exists only on disk and is adopted whole.
+    func testADeviceFirstSeenByTheCliIsAdoptedWhole() throws {
+        try write("[]")
+        let registry = makeRegistry()
+        try write("""
+        [{"id": "h_new", "daemonVersion": "0.52.0+1944", "proto": 1,
+          "observedAt": "2026-09-08T17:58:00Z", "routes": ["ssh:box"]}]
+        """)
+        registry.record(hostID: "h_mac", daemonVersion: macDaemon, route: .local)
+
+        XCTAssertEqual(registry.device(for: .ssh("box"))?.id, "h_new")
+        XCTAssertEqual(makeRegistry().all.count, 2)
+    }
 }

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -911,6 +911,10 @@ pub enum Outcome {
     Current {
         version: String,
         host_id: String,
+        /// The protocol the verifying handshake negotiated (`hello_ok.proto`).
+        /// Optional so a report written by an older build still parses.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        proto: Option<u32>,
         /// Another control plane put a newer build here. Left alone.
         newer: bool,
     },
@@ -955,6 +959,7 @@ impl Report {
                 version,
                 host_id,
                 newer,
+                ..
             } => format!(
                 "{node}: termiod {version} is running (host {host_id}){}",
                 if *newer {
@@ -1179,6 +1184,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             Ok(Outcome::Current {
                 version: hello.version.unwrap_or_default(),
                 host_id: hello.host_id,
+                proto: Some(hello.proto),
                 newer: version > want,
             })
         }

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -195,7 +195,146 @@ pub async fn run(cmd: RemoteCmd) -> Result<()> {
 
 /// The lifecycle loop against a host, for the build this binary is.
 pub async fn reconcile(node: &SshNode, options: Options) -> Report {
-    lifecycle::reconcile(node, lifecycle::BUILD_VERSION, options).await
+    let report = lifecycle::reconcile(node, lifecycle::BUILD_VERSION, options).await;
+    if let lifecycle::Outcome::Current {
+        version,
+        host_id,
+        proto,
+        ..
+    } = &report.outcome
+    {
+        record_observation(&node.host, host_id, version, *proto);
+    }
+    report
+}
+
+/// Stamps what a successful deploy's handshake revealed into the app's device
+/// registry (`devices.json`), so `termio version` shows the deploy-time
+/// observation instead of a row from the app's last pane attach. Without this,
+/// a CLI deploy leaves the table claiming the old version until the next
+/// attach — which reads as "the update didn't work".
+///
+/// The app remains the registry's writer while it runs: it merges newer
+/// on-disk observations before each save (`TermiodDeviceRegistry`), so this
+/// stamp survives instead of racing it. Best effort — the deploy already
+/// succeeded, so a failed stamp is a note on stderr, never a failed command.
+fn record_observation(alias: &str, host_id: &str, version: &str, proto: Option<u32>) {
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+    let (channel, _) = crate::channel::resolve();
+    let Some(home) = std::env::var_os("HOME") else {
+        return;
+    };
+    let path = PathBuf::from(home)
+        .join("Library/Application Support")
+        .join(&channel.support_dir_name)
+        .join("devices.json");
+    if let Err(error) = record_observation_in(&path, alias, host_id, version, proto, &iso8601_utc_now()) {
+        eprintln!("[deploy] couldn't record the observation in {}: {error:#}", path.display());
+    }
+}
+
+fn record_observation_in(
+    path: &Path,
+    alias: &str,
+    host_id: &str,
+    version: &str,
+    proto: Option<u32>,
+    observed_at: &str,
+) -> Result<()> {
+    let mut devices: Vec<serde_json::Value> = match std::fs::read_to_string(path) {
+        Ok(raw) => serde_json::from_str(&raw).context("reading the device registry")?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error).context("reading the device registry"),
+    };
+    let route = format!("ssh:{alias}");
+    // The route moves to the device that just answered on it — a reinstall
+    // (new host_id behind the same alias) must not leave two rows claiming it.
+    for device in devices.iter_mut() {
+        if device.get("id").and_then(|value| value.as_str()) == Some(host_id) {
+            continue;
+        }
+        if let Some(routes) = device.get_mut("routes").and_then(|value| value.as_array_mut()) {
+            routes.retain(|entry| entry.as_str() != Some(route.as_str()));
+        }
+    }
+    let entry = devices
+        .iter_mut()
+        .find(|device| device.get("id").and_then(|value| value.as_str()) == Some(host_id));
+    match entry {
+        Some(device) => {
+            device["daemonVersion"] = version.into();
+            device["observedAt"] = observed_at.into();
+            if let Some(proto) = proto {
+                device["proto"] = proto.into();
+            }
+            let routes = device
+                .get_mut("routes")
+                .and_then(|value| value.as_array_mut());
+            match routes {
+                Some(routes) => {
+                    // Most recently used first, matching the app's own rule.
+                    routes.retain(|entry| entry.as_str() != Some(route.as_str()));
+                    routes.insert(0, route.into());
+                }
+                None => device["routes"] = serde_json::json!([route]),
+            }
+        }
+        None => {
+            let mut device = serde_json::json!({
+                "id": host_id,
+                "daemonVersion": version,
+                "observedAt": observed_at,
+                "routes": [route],
+            });
+            if let Some(proto) = proto {
+                device["proto"] = proto.into();
+            }
+            devices.push(device);
+        }
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("creating the registry directory")?;
+    }
+    // Write-then-rename so the app never reads a half-written registry.
+    let staging = path.with_extension("json.new");
+    let body = serde_json::to_vec_pretty(&devices).context("encoding the device registry")?;
+    std::fs::write(&staging, body).context("writing the device registry")?;
+    std::fs::rename(&staging, path).context("replacing the device registry")?;
+    Ok(())
+}
+
+/// `2026-09-08T17:58:53Z` — the shape the registry uses and `termio version`
+/// parses. Civil-from-days (Howard Hinnant's algorithm), the inverse of the
+/// parser in version.rs, avoiding a time crate for one fixed-format field.
+fn iso8601_utc_now() -> String {
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0);
+    let days = seconds.div_euclid(86_400);
+    let time_of_day = seconds.rem_euclid(86_400);
+    let shifted = days + 719_468;
+    let era = shifted.div_euclid(146_097);
+    let day_of_era = shifted - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_shifted = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_shifted + 2) / 5 + 1;
+    let month = if month_shifted < 10 {
+        month_shifted + 3
+    } else {
+        month_shifted - 9
+    };
+    let year = year_of_era + era * 400 + if month <= 2 { 1 } else { 0 };
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}:{:02}Z",
+        time_of_day / 3_600,
+        (time_of_day % 3_600) / 60,
+        time_of_day % 60
+    )
 }
 
 fn run_blocking(cmd: RemoteCmd) -> Result<()> {
@@ -703,5 +842,78 @@ mod tests {
             node.install_directory(),
             ("$HOME/.local/bin".to_string(), ".local/bin".to_string())
         );
+    }
+
+    fn scratch_registry(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("termiod-registry-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("devices.json")
+    }
+
+    /// A deploy against a known device refreshes its row in place and leaves
+    /// every field it did not learn (and every other device) untouched.
+    #[test]
+    fn a_deploy_refreshes_the_devices_own_row() {
+        let path = scratch_registry("refresh");
+        std::fs::write(
+            &path,
+            r#"[
+                {"id": "h_other", "daemonVersion": "0.40.0+1", "routes": ["unix"]},
+                {"id": "h_box", "daemonVersion": "0.50.0+1913", "proto": 1,
+                 "observedAt": "2026-09-08T08:47:17Z", "routes": ["ssh:box"], "extra": "kept"}
+            ]"#,
+        )
+        .unwrap();
+        record_observation_in(&path, "box", "h_box", "0.52.0+1944", Some(1), "2026-09-08T17:58:00Z")
+            .unwrap();
+        let devices: Vec<serde_json::Value> =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let row = devices.iter().find(|d| d["id"] == "h_box").unwrap();
+        assert_eq!(row["daemonVersion"], "0.52.0+1944");
+        assert_eq!(row["observedAt"], "2026-09-08T17:58:00Z");
+        assert_eq!(row["proto"], 1);
+        assert_eq!(row["extra"], "kept");
+        assert_eq!(row["routes"], serde_json::json!(["ssh:box"]));
+        let other = devices.iter().find(|d| d["id"] == "h_other").unwrap();
+        assert_eq!(other["daemonVersion"], "0.40.0+1");
+    }
+
+    /// A reinstall (new host id behind the same alias) moves the route: the
+    /// old row must not keep claiming it, and a first-ever deploy creates the
+    /// registry rather than requiring the app to have connected once.
+    #[test]
+    fn a_route_belongs_to_the_device_that_just_answered_on_it() {
+        let path = scratch_registry("move");
+        std::fs::write(
+            &path,
+            r#"[{"id": "h_old", "daemonVersion": "0.50.0+1913", "routes": ["ssh:box"]}]"#,
+        )
+        .unwrap();
+        record_observation_in(&path, "box", "h_new", "0.52.0+1944", Some(1), "2026-09-08T17:58:00Z")
+            .unwrap();
+        let devices: Vec<serde_json::Value> =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let old = devices.iter().find(|d| d["id"] == "h_old").unwrap();
+        assert_eq!(old["routes"], serde_json::json!([]));
+        let new = devices.iter().find(|d| d["id"] == "h_new").unwrap();
+        assert_eq!(new["routes"], serde_json::json!(["ssh:box"]));
+
+        let fresh = scratch_registry("fresh");
+        record_observation_in(&fresh, "box", "h_new", "0.52.0+1944", None, "2026-09-08T17:58:00Z")
+            .unwrap();
+        let devices: Vec<serde_json::Value> =
+            serde_json::from_str(&std::fs::read_to_string(&fresh).unwrap()).unwrap();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0]["id"], "h_new");
+        assert!(devices[0].get("proto").is_none());
+    }
+
+    /// The stamp is the exact shape version.rs parses back.
+    #[test]
+    fn the_timestamp_round_trips_through_the_version_tables_parser() {
+        let stamp = iso8601_utc_now();
+        assert_eq!(stamp.len(), 20, "{stamp}");
+        assert!(stamp.ends_with('Z'), "{stamp}");
     }
 }


### PR DESCRIPTION
A CLI `termio remote deploy` learned the remote's fresh version and host id, then threw the observation away: `devices.json` was only written by the app's pane-attach handshake, so `termio version` kept showing the last attach's row — a box already upgraded to 0.52.0+1944 still read `0.50.0+1913 (as of last connect, 9h ago)`, which looks exactly like a failed update.

- The deploy's `current` outcome now carries the negotiated proto from the verifying handshake (optional in JSON, so reports from older builds still parse).
- The ssh reconcile stamps version, proto, `observedAt`, and the route into `devices.json` after a successful deploy — atomically, moving the route if the host id changed, creating the registry on a first-ever deploy, and never failing the deploy itself. The Settings ▸ Machines path gets this for free, since it shells out to the same `remote deploy --json`.
- The app stays the registry's writer while it runs: `TermiodDeviceRegistry` folds newer on-disk observations into memory before each save, so a handshake with any device no longer clobbers the stamp. Memory wins ties, so an app-only lifetime behaves exactly as before.

Verified against a real box: after `termio remote deploy ukvps`, `termio version` shows `ukvps 0.52.0+1944 proto 1 (as of last connect, just now)`. New tests pin the stamp shape and route move (Rust) and the no-clobber merge (Swift); full suites pass on both sides.

Release Notes:
- `termio version` now reflects a `termio remote deploy` immediately, instead of showing the version from the app's last connect to the box.