### PR TITLE
feat(files): add a hidden files toggle

### DIFF
--- a/Sources/termio/FileBrowser/DeviceFileTree.swift
+++ b/Sources/termio/FileBrowser/DeviceFileTree.swift
@@ -319,13 +319,13 @@ final class DeviceFileNode: Identifiable {
 
     var children: [DeviceFileNode]? {
         guard isDirectory else { return nil }
-        if let loadedChildren { return loadedChildren }
+        if let loadedChildren { return model?.visibleNodes(loadedChildren) ?? loadedChildren }
         // `loadChildren` adopts a prefetched listing synchronously, so a folder
         // whose contents were fetched ahead of this click opens with its rows
         // already in it — read back here rather than published, because a
         // publish from inside a getter runs during a view update.
         model?.loadChildren(of: self)
-        return loadedChildren ?? []
+        return model?.visibleNodes(loadedChildren ?? []) ?? []
     }
 }
 
@@ -368,6 +368,28 @@ final class DeviceFileTreeModel: ObservableObject {
     /// unchanged after an incremental re-list — same node references — so this
     /// is what tells the outline there is an update pass worth running.
     @Published private(set) var revision = 0
+
+    var showHiddenFiles = true {
+        didSet {
+            guard showHiddenFiles != oldValue else { return }
+            revision &+= 1
+        }
+    }
+
+    var visibleRootNodes: [DeviceFileNode] { visibleNodes(rootNodes) }
+
+    // Keep hidden nodes and their loaded children cached so showing them again
+    // does not need another device request or replace surviving node identities.
+    fileprivate func visibleNodes(_ nodes: [DeviceFileNode]) -> [DeviceFileNode] {
+        showHiddenFiles ? nodes : nodes.filter { $0.notice != nil || !$0.name.hasPrefix(".") }
+    }
+
+    func isPathVisible(_ path: String) -> Bool {
+        guard !showHiddenFiles else { return true }
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        guard path.hasPrefix(prefix) else { return false }
+        return !path.dropFirst(prefix.count).split(separator: "/").contains { $0.hasPrefix(".") }
+    }
 
     /// Raised when the device reports the checkout moved: a batch, or a reset
     /// that says what is held may be stale. The Changes badge is seeded off it,

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -32,6 +32,7 @@ struct FileBrowserView: View {
     /// Bumped to collapse the whole tree: it is the file list's `.id`, so changing it
     /// rebuilds the list fresh — and a fresh `List(children:)` starts fully collapsed.
     @State private var treeGeneration = 0
+    @AppStorage("fileBrowserShowHiddenFiles") private var showHiddenFiles = true
 
     /// Where the selected session's files live, and on which machine — see
     /// `TermioStore.inspectorCheckout`. Nothing in this pane may ask the session
@@ -110,6 +111,13 @@ struct FileBrowserView: View {
             seedChangeCount()
         }
         .onDisappear { stop() }
+        .onChange(of: showHiddenFiles) {
+            tree?.showHiddenFiles = showHiddenFiles
+            if let selection = browserState.selection, tree?.isPathVisible(selection) == false {
+                browserState.selection = nil
+                browserState.selectedLocalURL = nil
+            }
+        }
         .onChange(of: checkout) { previous, _ in
             stop(previous)
             // A path from the checkout that just left addresses nothing in the
@@ -173,6 +181,7 @@ struct FileBrowserView: View {
     /// and its `fs:` watch runs for as long as this pane is on screen.
     private func start() {
         guard store.inspectorVisible, let tree else { return }
+        tree.showHiddenFiles = showHiddenFiles
         // Weak, and holding no view state: the model outlives this pane in the
         // cache, so anything strongly captured here would outlive a window.
         tree.onCheckoutChanged = { [weak store] in
@@ -444,6 +453,16 @@ struct FileBrowserView: View {
                     createFolder(in: root)
                 }
             }
+            TreeHeaderButton(huge: .view, help: hiddenFilesAction) {
+                showHiddenFiles.toggle()
+            }
+            .accessibilityLabel(hiddenFilesAction)
+            .background {
+                if showHiddenFiles {
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Color.primary.opacity(0.08))
+                }
+            }
             TreeHeaderButton(codicon: .refresh, help: localized("Refresh")) {
                 tree.refresh()
             }
@@ -454,6 +473,10 @@ struct FileBrowserView: View {
         .padding(.leading, 14)
         .padding(.trailing, 8)
         .padding(.vertical, 3)
+    }
+
+    private var hiddenFilesAction: String {
+        showHiddenFiles ? localized("Hide Hidden Files") : localized("Show Hidden Files")
     }
 
     private func seedChangeCount() { Self.seedChangeCount(into: store) }
@@ -684,7 +707,7 @@ private struct FileTreeContent: View {
             )
         case .ready:
             FileTreeList(
-                nodes: model.rootNodes,
+                nodes: model.visibleRootNodes,
                 revision: model.revision,
                 selection: $selection,
                 font: font,

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2914,6 +2914,16 @@
         }
       }
     },
+    "Hide Hidden Files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不显示隐藏文件"
+          }
+        }
+      }
+    },
     "Hide Others": {
       "localizations": {
         "zh-Hans": {
@@ -6114,6 +6124,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "全部显示"
+          }
+        }
+      }
+    },
+    "Show Hidden Files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示隐藏文件"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -596,6 +596,8 @@
 	<string>Group with</string>
 	<key>Hide</key>
 	<string>Hide</string>
+	<key>Hide Hidden Files</key>
+	<string>Hide Hidden Files</string>
 	<key>Hide Others</key>
 	<string>Hide Others</string>
 	<key>Hide Replace</key>
@@ -1238,6 +1240,8 @@
 	<string>Show</string>
 	<key>Show All</key>
 	<string>Show All</string>
+	<key>Show Hidden Files</key>
+	<string>Show Hidden Files</string>
 	<key>Show Original</key>
 	<string>Show Original</string>
 	<key>Show Project Files</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -596,6 +596,8 @@
 	<string>编组到</string>
 	<key>Hide</key>
 	<string>隐藏</string>
+	<key>Hide Hidden Files</key>
+	<string>不显示隐藏文件</string>
 	<key>Hide Others</key>
 	<string>隐藏其他</string>
 	<key>Hide Replace</key>
@@ -1238,6 +1240,8 @@
 	<string>显示</string>
 	<key>Show All</key>
 	<string>全部显示</string>
+	<key>Show Hidden Files</key>
+	<string>显示隐藏文件</string>
 	<key>Show Original</key>
 	<string>显示原身</string>
 	<key>Show Project Files</key>

--- a/Tests/termioTests/DeviceFileTreeTests.swift
+++ b/Tests/termioTests/DeviceFileTreeTests.swift
@@ -49,6 +49,60 @@ final class DeviceFileTreeTests: XCTestCase {
             isShortened: isShortened)
     }
 
+    func testHiddenFilesTogglePreservesLoadedNodesOnEitherDevice() throws {
+        for tree in [model(), localModel(root: root)] {
+            tree.apply([listing(root, [
+                (".config", .directory), ("src", .directory), (".env", .file),
+            ])])
+            tree.apply([
+                listing("\(root)/src", [(".settings", .file), ("app.swift", .file)]),
+                listing("\(root)/.config", [("agent.json", .file)]),
+            ])
+            let source = try XCTUnwrap(tree.node(at: "\(root)/src"))
+            let configuration = try XCTUnwrap(tree.node(at: "\(root)/.config"))
+            let loadedConfiguration = try XCTUnwrap(configuration.children?.first)
+            XCTAssertEqual(tree.visibleRootNodes.count, 3)
+            let revision = tree.revision
+
+            tree.showHiddenFiles = false
+
+            XCTAssertGreaterThan(tree.revision, revision, "the outline must update even when nodes are reused")
+            XCTAssertEqual(tree.visibleRootNodes.map(\.name), ["src"])
+            XCTAssertEqual(source.children?.map(\.name), ["app.swift"])
+            XCTAssertFalse(tree.isPathVisible("\(root)/.config/agent.json"))
+            XCTAssertTrue(tree.isPathVisible("\(root)/src/app.swift"))
+
+            tree.showHiddenFiles = true
+
+            XCTAssertEqual(tree.visibleRootNodes.count, 3)
+            XCTAssertTrue(tree.node(at: "\(root)/src") === source)
+            XCTAssertTrue(tree.node(at: "\(root)/.config") === configuration)
+            XCTAssertTrue(configuration.children?.first === loadedConfiguration)
+            XCTAssertEqual(source.children?.map(\.name), [".settings", "app.swift"])
+        }
+    }
+
+    func testHiddenFilesStayFilteredAfterListingsChange() throws {
+        let tree = localModel(root: "/r/.checkout")
+        tree.showHiddenFiles = false
+        tree.apply([listing("/r/.checkout", [("src", .directory), (".env", .file)])])
+        tree.apply([listing("/r/.checkout/src", [("app.swift", .file)])])
+        let source = try XCTUnwrap(tree.node(at: "/r/.checkout/src"))
+
+        tree.apply([
+            listing("/r/.checkout", [("src", .directory), (".new", .file)], isShortened: true),
+            listing("/r/.checkout/src", [("app.swift", .file), (".new", .file)]),
+        ])
+
+        XCTAssertEqual(tree.visibleRootNodes.first?.name, "src")
+        XCTAssertEqual(tree.visibleRootNodes.count, 2)
+        XCTAssertNotNil(tree.visibleRootNodes.last?.notice, "filtering must preserve incomplete-listing notices")
+        XCTAssertEqual(source.children?.map(\.name), ["app.swift"])
+        XCTAssertTrue(tree.isPathVisible("/r/.checkout/src/app.swift"), "the root's own name is not filtered")
+        tree.showHiddenFiles = true
+        XCTAssertEqual(source.children?.map(\.name), [".new", "app.swift"])
+    }
+
     /// The ask: the root plus every directory whose contents the tree is holding,
     /// parents before children so a graft never runs ahead of the node it hangs
     /// off.


### PR DESCRIPTION
  Closes #442
<img width="1114" height="755" alt="截屏2026-09-09 下午6 00 08" src="https://github.com/user-attachments/assets/b2f729d8-09e9-4021-8b86-ea3a6362b494" />

  Add a button to the Files toolbar to show or hide hidden files and folders. Hidden files remain
  visible by default, and the setting persists across launches.

  The filter applies to both local and remote file trees while preserving cached nodes and loaded
  directories.

  Validation:
  - Swift build and dev app packaging passed.
  - All 23 DeviceFileTreeTests passed, including filtering, cache preservation, and directory refresh
  cases.

  Release Notes:
  - Added a persistent toggle to show or hide hidden files in the file browser.