### PR TITLE
Ship the termio client to boxes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,19 +137,27 @@ jobs:
       # work at all and they are plain files in Resources, so nothing else would
       # notice them going missing: the app would install, launch, and fail only
       # when someone pointed it at a VPS.
-      - name: Verify the daemons survived into the DMG
+      #
+      # The `termio` clients ship beside them and sit in exactly that position:
+      # a deploy refuses outright when the client slice for a box's target is
+      # missing (`remote::shipped_client`), so a lost one turns deploying from
+      # something that works into something that cannot be done at all.
+      - name: Verify the daemons and clients survived into the DMG
         run: |
           mount_point="$RUNNER_TEMP/dmg-check"
           mkdir -p "$mount_point"
           hdiutil attach "$DMG_PATH" -mountpoint "$mount_point" -nobrowse -quiet
           resources="$mount_point/${APP_NAME}.app/Contents/Resources"
           status=0
-          for daemon in \
+          for binary in \
             "termiod:Mach-O" \
             "termiod-x86_64-unknown-linux-musl:ELF 64-bit" \
-            "termiod-aarch64-unknown-linux-musl:ELF 64-bit"; do
-            name="${daemon%%:*}"
-            want="${daemon#*:}"
+            "termiod-aarch64-unknown-linux-musl:ELF 64-bit" \
+            "termio:Mach-O" \
+            "termio-x86_64-unknown-linux-musl:ELF 64-bit" \
+            "termio-aarch64-unknown-linux-musl:ELF 64-bit"; do
+            name="${binary%%:*}"
+            want="${binary#*:}"
             if [ ! -f "$resources/$name" ]; then
               echo "error: $name is missing from the shipped app" >&2
               status=1

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1454,9 +1454,12 @@ extension TermioStore {
         let names = (report.busy ?? [])
             .map { "• \($0.label)" }
             .joined(separator: "\n")
+        // The client rides this rung too, and a machine whose `termio` did not
+        // install says so wherever it says anything else.
+        let client = report.client.map { "\n\($0)" } ?? ""
         return "termiod \(report.desired) is ready on \(label) and takes over once "
             + "this finishes:\n\(names)\n"
-            + "Update Anyway stops it now."
+            + "Update Anyway stops it now.\(client)"
     }
 
     // MARK: - This Mac's own daemon

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1411,9 +1411,12 @@ extension TermioStore {
             // would block a healthy box over the CLI inside its sessions, which
             // the next deploy installs again anyway.
             if let clientTrouble = report.client {
+                let summary = report.clientFailed == true
+                    ? "is current, but its termio client is not"
+                    : "is current; its termio client could not be checked"
                 Log.termiod.error("""
-                termiod on \(host, privacy: .public) is current, but its termio client \
-                is not: \(clientTrouble, privacy: .public)
+                termiod on \(host, privacy: .public) \(summary, privacy: .public): \
+                \(clientTrouble, privacy: .public)
                 """)
             }
             return .success(TermiodDevice(
@@ -1527,8 +1530,10 @@ extension TermioStore {
             Log.termiod.info(
                 "this Mac's termiod is current at \(report.version ?? desired, privacy: .public)")
             if let clientTrouble = report.client {
-                Log.termiod.error(
-                    "this Mac's termio client is not: \(clientTrouble, privacy: .public)")
+                let summary = report.clientFailed == true
+                    ? "this Mac's termio client is not"
+                    : "this Mac's termio client could not be checked"
+                Log.termiod.error("\(summary, privacy: .public): \(clientTrouble, privacy: .public)")
             }
         case .staged:
             Log.termiod.info("""

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1405,6 +1405,17 @@ extension TermioStore {
                     state: .failed,
                     message: "termiod on \(host) answered without saying which machine it is."))
             }
+            // A client that did not verify does not make the machine unusable:
+            // its daemon is the build wanted and every session on it works, so
+            // the machine is adopted and the trouble is logged. Refusing here
+            // would block a healthy box over the CLI inside its sessions, which
+            // the next deploy installs again anyway.
+            if let clientTrouble = report.client {
+                Log.termiod.error("""
+                termiod on \(host, privacy: .public) is current, but its termio client \
+                is not: \(clientTrouble, privacy: .public)
+                """)
+            }
             return .success(TermiodDevice(
                 id: hostID, daemonVersion: version, routes: [.ssh(host)],
                 negotiatedProtocol: report.proto, lastSeen: Date()))
@@ -1515,6 +1526,10 @@ extension TermioStore {
             // PTY carried. Nothing was at risk, so nobody is asked.
             Log.termiod.info(
                 "this Mac's termiod is current at \(report.version ?? desired, privacy: .public)")
+            if let clientTrouble = report.client {
+                Log.termiod.error(
+                    "this Mac's termio client is not: \(clientTrouble, privacy: .public)")
+            }
         case .staged:
             Log.termiod.info("""
             staged termiod \(report.version ?? desired, privacy: .public) for this Mac's daemon; \

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1030,6 +1030,12 @@ extension Termiod {
         let busy: [BusySession]?
         let message: String?
         let rolledBack: Bool?
+        /// What went wrong with the `termio` client the deploy installs beside
+        /// the daemon, when something did. It rides the `current` state because
+        /// the daemon is the build wanted and the machine is usable — the next
+        /// deploy installs the client again — so this is a note about a machine
+        /// that works, never a reason to refuse it.
+        let client: String?
 
         static func decode(_ data: Data) throws -> LifecycleReport {
             let decoder = JSONDecoder()

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1030,12 +1030,17 @@ extension Termiod {
         let busy: [BusySession]?
         let message: String?
         let rolledBack: Bool?
-        /// What went wrong with the `termio` client the deploy installs beside
-        /// the daemon, when something did. It rides the `current` state because
-        /// the daemon is the build wanted and the machine is usable — the next
-        /// deploy installs the client again — so this is a note about a machine
-        /// that works, never a reason to refuse it.
+        /// What is wrong with the `termio` client the deploy installs beside the
+        /// daemon, or what could not be learned about it. It rides the `current`
+        /// state because the daemon is the build wanted and the machine is usable
+        /// — so this is a note about a machine that works, never a reason to
+        /// refuse it.
         let client: String?
+        /// Whether that note is the client's own fault rather than something the
+        /// deploy could not find out — ssh being flaky for the length of one
+        /// probe says nothing about the binary, and must not be reported as if
+        /// it had.
+        let clientFailed: Bool?
 
         static func decode(_ data: Data) throws -> LifecycleReport {
             let decoder = JSONDecoder()

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -336,17 +336,22 @@ else
                 rustup target add "$linux_target" >/dev/null 2>&1 || true
                 cargo build --release --target "$linux_target"
             )
-            built="$repo_root/termiod/target/$linux_target/release/$daemon_name"
-            # A binary that links is not a binary that runs on the VPS. Asserted
-            # here as well as in CI, because this is the copy users receive.
-            if ! file "$built" | grep -q "ELF 64-bit"; then
-                echo "error: $built is not a Linux ELF binary — $(file "$built")" >&2
-                exit 1
-            fi
-            cp "$built" "$resources_dir/$daemon_name-$linux_target"
-            chmod +x "$resources_dir/$daemon_name-$linux_target"
+            # The client deploys to boxes in the same pass as the daemon
+            # (issue #628); the cargo build above already produced both, so
+            # shipping it is only a copy.
+            for built_name in "$daemon_name" termio; do
+                built="$repo_root/termiod/target/$linux_target/release/$built_name"
+                # A binary that links is not a binary that runs on the VPS. Asserted
+                # here as well as in CI, because this is the copy users receive.
+                if ! file "$built" | grep -q "ELF 64-bit"; then
+                    echo "error: $built is not a Linux ELF binary — $(file "$built")" >&2
+                    exit 1
+                fi
+                cp "$built" "$resources_dir/$built_name-$linux_target"
+                chmod +x "$resources_dir/$built_name-$linux_target"
+            done
         done
-        echo "==> Bundled Linux $daemon_name slices: x86_64 + aarch64"
+        echo "==> Bundled Linux $daemon_name + termio slices: x86_64 + aarch64"
     fi
 fi
 

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -107,7 +107,8 @@ rustup target add x86_64-unknown-linux-musl     # Intel/AMD VPS
 
 `termio remote deploy <host>` runs `uname -sm` on the host, picks the matching
 target — the slice bundled beside the binary when there is one, a cross-compile
-otherwise — and installs. Manual build:
+otherwise — and installs. The `termio` client installs beside the daemon in the
+same pass, so a box's client and daemon are always the same build. Manual build:
 
 ```sh
 cargo build --release --target x86_64-unknown-linux-musl
@@ -157,12 +158,18 @@ does not hold it up. `--force` overrides.
 The version compared is the app's build stamp (`0.44.0+1533`), carried by the
 daemon at `hello`; a box a newer app set up is left alone.
 
-Install path is `~/.local/bin/termiod`. Override with `TERMIOD_REMOTE_BIN`
-(e.g. `/usr/local/bin/termiod`) on the client for both deploy and attach.
+Install path is `~/.local/bin/termiod`, with the `termio` client beside it.
+Override with `TERMIOD_REMOTE_BIN` (e.g. `/usr/local/bin/termiod`) on the
+client for both deploy and attach; the client's path moves with it. Verification
+covers both: the daemon must answer `hello` as the new build, and the installed
+client must answer `--version` with the same stamp.
 
-Make sure `~/.local/bin` is on the remote `PATH` if you want to run `termiod`
-bare over SSH; the `remote` subcommands always call the absolute path, so this
-is only for your own convenience.
+Sessions the daemon spawns find both binaries without any dotfile write: termiod
+prepends its own directory to the `PATH` of every session it starts. A bare SSH
+login outside termio keeps whatever the box's own profile does, so make sure
+`~/.local/bin` is on the remote `PATH` if you want to run `termiod` bare over
+SSH; the `remote` subcommands always call the absolute path, so this is only
+for your own convenience.
 
 ## Starting the daemon: on-demand (default)
 

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -160,16 +160,25 @@ daemon at `hello`; a box a newer app set up is left alone.
 
 Install path is `~/.local/bin/termiod`, with the `termio` client beside it.
 Override with `TERMIOD_REMOTE_BIN` (e.g. `/usr/local/bin/termiod`) on the
-client for both deploy and attach; the client's path moves with it. Verification
-covers both: the daemon must answer `hello` as the new build, and the installed
-client must answer `--version` with the same stamp.
+client for both deploy and attach; the client's path moves with it, unless the
+override also renames the daemon, which deploys the daemon alone rather than
+renaming the box's own client aside. Verification covers both: the daemon must
+answer `hello` as the new build, and the installed client must answer
+`--version` with the same stamp.
 
-Sessions the daemon spawns find both binaries without any dotfile write: termiod
-prepends its own directory to the `PATH` of every session it starts. A bare SSH
-login outside termio keeps whatever the box's own profile does, so make sure
-`~/.local/bin` is on the remote `PATH` if you want to run `termiod` bare over
-SSH; the `remote` subcommands always call the absolute path, so this is only
-for your own convenience.
+Sessions find the client without any dotfile write: termiod keeps a directory
+holding one symlink to the paired `termio` and leads every session's `PATH`
+with it. A directory of its own rather than the daemon's — leading with, say,
+`/usr/local/bin` would put every binary in it ahead of the user's own `PATH`.
+
+A session started with a command (every agent) re-asserts that entry on the
+login shell's own command line, after its startup files have run. A plain
+terminal has no such line, so on a box whose `/etc/profile` reassigns `PATH`
+outright — Debian and Ubuntu do — a plain terminal resolves `termio` only if
+the install directory is on the `PATH` that profile builds. `~/.local/bin` is,
+for the shells that read `~/.profile`. So put the install directory on the
+remote `PATH` if you want to type `termio` in a plain terminal there; the
+`remote` subcommands and the agent hooks always have it.
 
 ## Starting the daemon: on-demand (default)
 

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -107,8 +107,11 @@ rustup target add x86_64-unknown-linux-musl     # Intel/AMD VPS
 
 `termio remote deploy <host>` runs `uname -sm` on the host, picks the matching
 target — the slice bundled beside the binary when there is one, a cross-compile
-otherwise — and installs. The `termio` client installs beside the daemon in the
-same pass, so a box's client and daemon are always the same build. Manual build:
+otherwise — and installs. On a Linux box the `termio` client installs beside the
+daemon in the same pass, so a box's client and daemon are always the same build.
+A Mac is sent no client: its own app bundle links one into `/usr/local/bin` and
+keeps it current, and a second copy in `~/.local/bin` would only shadow it.
+Manual build:
 
 ```sh
 cargo build --release --target x86_64-unknown-linux-musl
@@ -158,13 +161,15 @@ does not hold it up. `--force` overrides.
 The version compared is the app's build stamp (`0.44.0+1533`), carried by the
 daemon at `hello`; a box a newer app set up is left alone.
 
-Install path is `~/.local/bin/termiod`, with the `termio` client beside it.
-Override with `TERMIOD_REMOTE_BIN` (e.g. `/usr/local/bin/termiod`) on the
-client for both deploy and attach; the client's path moves with it, unless the
-override also renames the daemon, which deploys the daemon alone rather than
+Install path is `~/.local/bin/termiod`, with the `termio` client beside it on a
+Linux box. Override with `TERMIOD_REMOTE_BIN` (e.g. `/usr/local/bin/termiod`) on
+the client for both deploy and attach; the client's path moves with it, unless
+the override also renames the daemon, which deploys the daemon alone rather than
 renaming the box's own client aside. Verification covers both: the daemon must
-answer `hello` as the new build, and the installed client must answer
-`--version` with the same stamp.
+answer `hello` as the new build, and an installed client must answer `--version`
+with at least that stamp. A client that fails leaves the machine running and
+reported as current with the trouble named — nothing on the box is stopped for
+it, and the next deploy installs the client again.
 
 Sessions find the client without any dotfile write: termiod keeps a directory
 holding one symlink to the paired `termio` and leads every session's `PATH`

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -525,11 +525,40 @@ fn resolve_spawn_argv(spec: &crate::protocol::CreateSpec) -> Vec<String> {
     let Some(command) = spec.command.as_ref().filter(|line| !line.trim().is_empty()) else {
         return Vec::new();
     };
-    vec![
-        crate::agent::machine::login_shell(),
-        "-ilc".to_string(),
-        format!("exec {command}"),
-    ]
+    let shell = crate::agent::machine::login_shell();
+    let line = login_shell_command(
+        command,
+        crate::session::own_binary_directory().as_deref(),
+        &shell,
+    );
+    vec![shell, "-ilc".to_string(), line]
+}
+
+/// The `-c` line a login shell runs for a `command` spec.
+///
+/// The daemon's directory is prepended to the session's `PATH` in its
+/// environment (`session::daemon_owned_env`), but a *login* shell's startup
+/// files rebuild `PATH` after that — Debian's `/etc/profile` reassigns it
+/// unconditionally — which is exactly the stale-`termio` skew the prepend
+/// exists to rule out. The `-c` line runs after every startup file, so
+/// re-asserting the prepend here is the one place the login shell cannot
+/// undo it. Only for shells whose assignment syntax is POSIX; a fish or csh
+/// login shell reads no `/etc/profile`, so the environment prepend survives
+/// there on its own.
+fn login_shell_command(command: &str, client_directory: Option<&str>, shell: &str) -> String {
+    let posix = matches!(
+        std::path::Path::new(shell)
+            .file_name()
+            .and_then(|name| name.to_str()),
+        Some("sh" | "bash" | "zsh" | "dash" | "ksh" | "ash")
+    );
+    match client_directory.filter(|_| posix) {
+        Some(directory) => format!(
+            "PATH={}:\"$PATH\" exec {command}",
+            crate::lifecycle::shell_quote(directory)
+        ),
+        None => format!("exec {command}"),
+    }
 }
 
 /// Soft `RLIMIT_NOFILE` values to try for the daemon and everything it spawns,
@@ -3186,7 +3215,29 @@ mod spawn_argv_tests {
         let argv = resolve_spawn_argv(&spec);
         assert_eq!(argv.len(), 3);
         assert_eq!(argv[1], "-ilc");
-        assert_eq!(argv[2], "exec claude --continue");
+        assert!(argv[2].ends_with("exec claude --continue"), "{}", argv[2]);
+    }
+
+    /// The `-c` line re-asserts the client-directory prepend after the login
+    /// shell's startup files have rebuilt `PATH` — but only in shells whose
+    /// assignment syntax is POSIX, and only when there is a directory to lead
+    /// with.
+    #[test]
+    fn the_command_line_reasserts_the_path_prepend_after_startup_files() {
+        use super::login_shell_command;
+        assert_eq!(
+            login_shell_command("claude", Some("/home/u/.local/bin"), "/bin/bash"),
+            "PATH=/home/u/.local/bin:\"$PATH\" exec claude"
+        );
+        assert_eq!(
+            login_shell_command("claude", Some("/home/u/my bin"), "/usr/bin/zsh"),
+            "PATH='/home/u/my bin':\"$PATH\" exec claude"
+        );
+        assert_eq!(
+            login_shell_command("claude", Some("/home/u/.local/bin"), "/usr/bin/fish"),
+            "exec claude"
+        );
+        assert_eq!(login_shell_command("claude", None, "/bin/bash"), "exec claude");
     }
 
     #[test]

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -522,21 +522,35 @@ fn resolve_spawn_argv(spec: &crate::protocol::CreateSpec) -> Vec<String> {
     if !spec.argv.is_empty() {
         return spec.argv.clone();
     }
-    let Some(command) = spec.command.as_ref().filter(|line| !line.trim().is_empty()) else {
-        return Vec::new();
-    };
-    let shell = crate::agent::machine::login_shell();
-    let line = login_shell_command(
-        command,
-        crate::session::own_binary_directory().as_deref(),
-        &shell,
-    );
-    vec![shell, "-ilc".to_string(), line]
+    let command = spec
+        .command
+        .as_ref()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty());
+    let client_directory = crate::session::client_path_directory();
+    match command {
+        Some(command) => {
+            let shell = crate::agent::machine::login_shell();
+            let line = login_shell_command(command, client_directory.as_deref(), &shell);
+            vec![shell, "-ilc".to_string(), line]
+        }
+        // A plain terminal *is* the shell, so there is no `-c` line to hang a
+        // re-assertion on: it runs as `Pty::spawn`'s own login shell, carrying
+        // the environment prepend and whatever its startup files then do to
+        // `PATH`. Wrapping it in a second shell to re-assert was tried and
+        // rejected — `Pty::spawn` routes exactly one zsh startup through the
+        // OSC 133 shim (`shell_integration`), and the wrapper shell consumes
+        // it, leaving the interactive shell the user actually types into with
+        // no prompt marks and the host with no rows it may blank on resize.
+        // Trading the reflow those marks carry for a `PATH` entry is the wrong
+        // way round; `DEPLOY.md` says plainly where the prepend survives.
+        None => Vec::new(),
+    }
 }
 
 /// The `-c` line a login shell runs for a `command` spec.
 ///
-/// The daemon's directory is prepended to the session's `PATH` in its
+/// The client's directory is prepended to the session's `PATH` in its
 /// environment (`session::daemon_owned_env`), but a *login* shell's startup
 /// files rebuild `PATH` after that — Debian's `/etc/profile` reassigns it
 /// unconditionally — which is exactly the stale-`termio` skew the prepend
@@ -546,19 +560,23 @@ fn resolve_spawn_argv(spec: &crate::protocol::CreateSpec) -> Vec<String> {
 /// login shell reads no `/etc/profile`, so the environment prepend survives
 /// there on its own.
 fn login_shell_command(command: &str, client_directory: Option<&str>, shell: &str) -> String {
-    let posix = matches!(
-        std::path::Path::new(shell)
-            .file_name()
-            .and_then(|name| name.to_str()),
-        Some("sh" | "bash" | "zsh" | "dash" | "ksh" | "ash")
-    );
-    match client_directory.filter(|_| posix) {
+    match client_directory.filter(|_| shell_is_posix(shell)) {
         Some(directory) => format!(
             "PATH={}:\"$PATH\" exec {command}",
             crate::lifecycle::shell_quote(directory)
         ),
         None => format!("exec {command}"),
     }
+}
+
+/// Whether `shell` takes `VAR=value command` and `-c` the way POSIX says.
+fn shell_is_posix(shell: &str) -> bool {
+    matches!(
+        std::path::Path::new(shell)
+            .file_name()
+            .and_then(|name| name.to_str()),
+        Some("sh" | "bash" | "zsh" | "dash" | "ksh" | "ash")
+    )
 }
 
 /// Soft `RLIMIT_NOFILE` values to try for the daemon and everything it spawns,

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -561,8 +561,13 @@ fn resolve_spawn_argv(spec: &crate::protocol::CreateSpec) -> Vec<String> {
 /// there on its own.
 fn login_shell_command(command: &str, client_directory: Option<&str>, shell: &str) -> String {
     match client_directory.filter(|_| shell_is_posix(shell)) {
+        // `${PATH:+…}` keeps the separator off an empty `PATH`. A trailing empty
+        // field is the *working directory* to POSIX, so `PATH=dir:"$PATH"` would
+        // put whatever the session happens to be sitting in on its own search
+        // path — with this directory leading it. `path_led_by` guards the same
+        // case on the environment side.
         Some(directory) => format!(
-            "PATH={}:\"$PATH\" exec {command}",
+            "PATH={}${{PATH:+\":$PATH\"}} exec {command}",
             crate::lifecycle::shell_quote(directory)
         ),
         None => format!("exec {command}"),
@@ -3243,13 +3248,15 @@ mod spawn_argv_tests {
     #[test]
     fn the_command_line_reasserts_the_path_prepend_after_startup_files() {
         use super::login_shell_command;
+        // The `${PATH:+…}` guard is what keeps an empty `PATH` from gaining a
+        // trailing empty field, which POSIX resolves as the working directory.
         assert_eq!(
             login_shell_command("claude", Some("/home/u/.local/bin"), "/bin/bash"),
-            "PATH=/home/u/.local/bin:\"$PATH\" exec claude"
+            "PATH=/home/u/.local/bin${PATH:+\":$PATH\"} exec claude"
         );
         assert_eq!(
             login_shell_command("claude", Some("/home/u/my bin"), "/usr/bin/zsh"),
-            "PATH='/home/u/my bin':\"$PATH\" exec claude"
+            "PATH='/home/u/my bin'${PATH:+\":$PATH\"} exec claude"
         );
         assert_eq!(
             login_shell_command("claude", Some("/home/u/.local/bin"), "/usr/bin/fish"),

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -956,7 +956,16 @@ pub trait Node {
     /// and the `termio` client that ships beside it in the same pass
     /// (docker-lessons RFC §1.2), so a box's client and daemon are always the
     /// same build and skew between them is structurally impossible.
-    fn artifact(&self) -> impl std::future::Future<Output = Result<Artifacts>> + Send;
+    ///
+    /// `client_only` says the daemon plane is already current and only the
+    /// client is being repaired. A node that would have to *build* the daemon
+    /// to answer must decline instead: the machine is healthy, this runs before
+    /// every attach, and starting a cross-compile — or failing for the want of
+    /// one — is not something a client repair may cost.
+    fn artifact(
+        &self,
+        client_only: bool,
+    ) -> impl std::future::Future<Output = Result<Artifacts>> + Send;
     /// The client binary's path on the node, as the node's own shell should
     /// see it — or `None` on a node whose client ships another way (this
     /// Mac's lives inside the app bundle), which turns every client step of
@@ -1220,16 +1229,23 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             }
         },
     };
+    // What was on the node before this run staged anything, which is what says
+    // whether a `.prev` afterwards is this run's doing. Read here, from the
+    // observation already in hand, because the box cannot answer it later: a
+    // `.prev` on disk may be this run's or an older deploy's, and putting back
+    // the wrong one installs a build some earlier pass had replaced.
+    let daemon_present = !matches!(observed, Observed::Absent);
+    let client_present = matches!(&observed, Observed::Reported(status) if status.client.is_some());
+
     // What this run put on the node, per plane. Every undo below reads this and
     // nothing else: a run that staged only the client may not touch the daemon,
     // and one that staged no client may not touch the client — the box's own,
     // which it has been using all along, is not this run's to restore or remove.
-    let mut staged = Staged {
-        daemon: false,
-        client: false,
-    };
+    let mut staged = Staged::default();
     if let Some(plan) = plan {
         staged = stage(node, plan).await?;
+        staged.daemon_replaced = staged.daemon && daemon_present;
+        staged.client_replaced = staged.client && client_present;
         match (staged.daemon, staged.client) {
             (true, true) => eprintln!("[deploy] installed termiod {desired} and its client on {label}"),
             (true, false) => eprintln!("[deploy] installed termiod {desired} on {label}"),
@@ -1373,7 +1389,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // a daemon binary it never wrote — downgrading the box and spending
             // its one rollback point over an artifact it never touched.
             let rolled_back = (staged.daemon || plan.even_unstaged)
-                && roll_back(node, &plan, staged.client).await.is_ok();
+                && roll_back(node, &plan, staged).await.is_ok();
             return Ok(Outcome::Unhealthy {
                 message,
                 rolled_back,
@@ -1394,7 +1410,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // beside no client rather than beside a broken one: a skew, but a
             // bounded one the next pass closes with a `ClientOnly` restage, and
             // no session pays for it.
-            let put_back = roll_back_client(node).await.is_ok();
+            let put_back = roll_back_client(node, staged.client_replaced).await.is_ok();
             client_trouble = Some(format!(
                 "{error:#}{}",
                 if put_back {
@@ -1461,15 +1477,24 @@ async fn observe<N: Node>(node: &N) -> Result<Observed> {
 /// refuses to open a running executable for writing (`ETXTBSY`), so writing
 /// in place is the one shape that always fails when a box is in use.
 async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
-    let artifacts = node.artifact().await?;
-    let mut staged = Staged {
-        daemon: false,
-        client: false,
+    let client_only = plan == StagePlan::ClientOnly;
+    let artifacts = match node.artifact(client_only).await {
+        Ok(artifacts) => artifacts,
+        // A client-only pass repairs a machine whose daemon is already the
+        // build wanted, and it runs before every attach. A control plane that
+        // cannot produce the client leaves it alone rather than failing the
+        // reconcile — the alternative made attaching to a healthy box an error.
+        Err(error) if client_only => {
+            eprintln!("[deploy] {}; leaving {}'s client alone", format!("{error:#}"), node.label());
+            return Ok(Staged::default());
+        }
+        Err(error) => return Err(error),
     };
+    let mut staged = Staged::default();
     let mut command = String::new();
     if plan == StagePlan::Full {
         node.put(&artifacts.daemon, "termiod.new").await?;
-        command = swap_command(&node.binary());
+        command = swap_command(&node.binary(), "termiod_replaced");
         staged.daemon = true;
     }
     // The client lands in the same pass, with the same discipline, activated
@@ -1488,13 +1513,15 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
     // the artifact source names the one that is.
     if let (Some(local), Some(client)) = (&artifacts.client, node.client_binary()) {
         node.put(local, "termio.new").await?;
-        let client_swap = swap_command(&client);
+        let client_swap = swap_command(&client, "termio_replaced");
         command = if command.is_empty() {
             client_swap
         } else {
             format!(
                 "{command} && {{ {client_swap} || {{ {}; false; }}; }}",
-                restore_command(&node.binary())
+                // The daemon's undo reads the same shell variable its own swap
+                // set, so it puts back only what this command renamed aside.
+                shell_restore(&node.binary(), "termiod_replaced")
             )
         };
         staged.client = true;
@@ -1516,10 +1543,16 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
 /// Which planes a stage actually put on the node. A pass that shipped no client
 /// — because this build has none — turns the client plane off for the rest of
 /// the run, so nothing is verified against a client that was never sent.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 struct Staged {
     daemon: bool,
     client: bool,
+    /// Whether the stage renamed a previous build aside, per plane — the fact an
+    /// undo in a later ssh command needs and cannot read off the disk. Taken
+    /// from the observation this run made before staging: a `.prev` on the box
+    /// says nothing about whose it is.
+    daemon_replaced: bool,
+    client_replaced: bool,
 }
 
 impl Staged {
@@ -1532,39 +1565,46 @@ impl Staged {
 /// put the `.new` upload over the path — and if that last rename fails, undo it,
 /// so a partial swap never leaves the path empty.
 ///
-/// The rename-aside is also what makes `.prev` mean *this* run: it either moves
-/// this run's replaced build there, or, where there was nothing to replace,
-/// clears whatever an older run left. That is the fact [`restore_command`] needs
-/// and cannot otherwise learn — it runs in a separate ssh command later, so a
-/// shell variable could not carry it, but the file's own presence can. The
-/// `.prev` an operator reaches for with `handoff --binary` still means what it
-/// always did: the build the last stage replaced.
+/// `replaced` names a shell variable this records the answer in: set when the
+/// rename-aside actually moved something, empty when there was nothing at the
+/// path to move. That is what an undo needs, and it cannot be read off the disk
+/// afterwards — a `.prev` sitting there may be this run's or an older run's, and
+/// the two call for opposite moves. Restoring an older one installs the build
+/// some *earlier* deploy replaced: a 0.43 client beside a 0.44 daemon, reported
+/// as a successful rollback.
 ///
-/// Both halves sit in the *same* step on purpose. Clearing `.prev` in a step of
-/// its own ran before anything could put one back, so a stage that then failed
-/// at `chmod` — a short upload, a noexec mount — short-circuited the `&&` chain
-/// with no restore, and left a box running its old daemon with no rollback point
-/// for the next upgrade to hand back to.
-fn swap_command(target: &str) -> String {
+/// A `.prev` this run did not write is never deleted either. Clearing it up
+/// front — to make the file itself mean "this run" — threw away a working
+/// previous daemon whenever the binary happened to be missing at stage time,
+/// leaving a box that then failed verification with nothing to hand back to.
+fn swap_command(target: &str, replaced: &str) -> String {
     format!(
-        "chmod +x {target}.new && {{ if [ -e {target} ]; then mv -f {target} {target}.prev; else rm -f {target}.prev; fi; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
-        restore_command(target)
+        "chmod +x {target}.new && {{ if [ -e {target} ]; then mv -f {target} {target}.prev && {replaced}=1; else {replaced}=; fi; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
+        shell_restore(target, replaced)
     )
 }
 
-/// Put a path back the way *this run* found it: the build this run renamed
-/// aside, and *gone* when it renamed nothing.
-///
-/// Both halves are load-bearing, and both were bugs. The removal is what makes
-/// "a failed stage leaves the box as it was" true on a first install, where the
-/// swap had nothing to rename aside and a restore that only knew `.prev` left
-/// the box holding a binary from a stage that failed. And the restore is scoped
-/// to this run by [`swap_command`] clearing `.prev` first: restoring whatever
-/// `.prev` happened to be on the box would install the build some *earlier*
-/// deploy replaced — a 0.43 client beside a 0.44 daemon, reported as a
-/// successful rollback, which is the skew this whole pass exists to rule out.
-fn restore_command(target: &str) -> String {
-    format!("if [ -e {target}.prev ]; then mv -f {target}.prev {target}; else rm -f {target}; fi")
+/// The undo for a swap in the *same* shell command, reading the variable that
+/// swap set: the build it renamed aside, or removal where it installed onto an
+/// empty path.
+fn shell_restore(target: &str, replaced: &str) -> String {
+    format!("if [ -n \"${replaced}\" ]; then mv -f {target}.prev {target}; else rm -f {target}; fi")
+}
+
+/// The undo for a swap that happened in an *earlier* ssh command, where no shell
+/// variable survives. The control plane knows what that swap found — it observed
+/// the node before staging — so it says whether a previous build was renamed
+/// aside, and the same two moves follow.
+fn restore_command(target: &str, replaced: bool) -> String {
+    if replaced {
+        format!("mv -f {target}.prev {target}")
+    } else {
+        // Removal is what makes "a failed stage leaves the box as it was" true
+        // where this run installed onto an empty path. The `.prev` beside it is
+        // an older run's and stays untouched, still there for a `handoff
+        // --binary` to reach for.
+        format!("rm -f {target}")
+    }
 }
 
 /// Run the installed client over the node's own shell. Existence is not the
@@ -1637,7 +1677,7 @@ async fn verify_daemon<N: Node>(node: &N, want: Version) -> Result<(DaemonHello,
 /// the same pid keeps every PTY — and stopping only when that also fails, so
 /// an image that turned out bad costs the sessions only when there is no
 /// non-destructive way back.
-async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged_client: bool) -> Result<()> {
+async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged: Staged) -> Result<()> {
     let binary = node.binary();
     let label = node.label();
     let source = &plan.source;
@@ -1703,9 +1743,9 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged_client: bool) 
         // under one exit code reported the whole rollback as failed when only
         // the client would not move, telling an operator the box was left on
         // the build that broke it while the daemon had already been put back.
-        if staged_client {
+        if staged.client {
             if let Some(client) = node.client_binary() {
-                let restored = node.run(&restore_command(&client)).await;
+                let restored = node.run(&restore_command(&client, staged.client_replaced)).await;
                 if !matches!(&restored, Ok(run) if run.code == 0) {
                     eprintln!(
                         "[deploy] {label} is back on the previous daemon, but its client could not be \
@@ -1720,13 +1760,13 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged_client: bool) 
 
 /// Put the previous client back — the daemon plane was never touched, so
 /// this is the whole rollback for a client-only stage.
-async fn roll_back_client<N: Node>(node: &N) -> Result<()> {
+async fn roll_back_client<N: Node>(node: &N, replaced: bool) -> Result<()> {
     let Some(client) = node.client_binary() else {
         return Ok(());
     };
     let label = node.label();
     eprintln!("[deploy] rolling {label} back to the previous client…");
-    let run = node.run(&restore_command(&client)).await?;
+    let run = node.run(&restore_command(&client, replaced)).await?;
     if run.code != 0 {
         bail!(
             "restoring the previous client on {label}: {}",
@@ -1789,7 +1829,7 @@ impl Node for LocalNode {
         bail!("this machine's termiod ships inside the app; update the app to update it")
     }
 
-    async fn artifact(&self) -> Result<Artifacts> {
+    async fn artifact(&self, _client_only: bool) -> Result<Artifacts> {
         bail!("this machine's termiod ships inside the app; update the app to update it")
     }
 
@@ -2036,7 +2076,7 @@ mod tests {
             self.puts.borrow_mut().push(format!("{} → {name}", local.display()));
             Ok(())
         }
-        async fn artifact(&self) -> Result<Artifacts> {
+        async fn artifact(&self, _client_only: bool) -> Result<Artifacts> {
             Ok(Artifacts {
                 daemon: PathBuf::from("/bundle/termiod-aarch64-unknown-linux-musl"),
                 client: self.client_artifact.clone(),
@@ -2647,9 +2687,10 @@ mod tests {
             other => panic!("expected current with a client note, got {other:?}"),
         }
         let commands = node.commands.borrow();
-        let restore = commands.last().unwrap();
-        assert!(restore.contains("termio.prev"), "{restore}");
-        assert!(restore.contains("rm -f $HOME/.local/bin/termio"), "{restore}");
+        // The box had no client, so this run renamed nothing aside: the undo is
+        // the removal, and the `.prev` an older deploy left is not this run's to
+        // put back — installing it would be a build from before this one.
+        assert_eq!(commands.last().unwrap(), "rm -f $HOME/.local/bin/termio", "{commands:?}");
         // The daemon plane is untouched. A client-only pass may not reach the
         // daemon's rollback: `termiod.prev` is the box's one way back to the
         // build before this one, and moving it would downgrade a plane that
@@ -2709,7 +2750,9 @@ mod tests {
         // The client's own restore — whose other half deletes — never runs.
         // Matched whole, because `termiod`'s commands contain `termio`'s as a
         // prefix and a substring test would pass on the daemon's own removal.
-        let client_restore = restore_command("$HOME/.local/bin/termio");
+        // This run installed the client fresh (the box had none), so its
+        // undo is the removal half, not a `.prev` it never wrote.
+        let client_restore = restore_command("$HOME/.local/bin/termio", false);
         assert!(!commands.iter().any(|command| command == &client_restore), "{commands:?}");
     }
 
@@ -2809,11 +2852,75 @@ mod tests {
             !commands.iter().any(|command| command == "mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
             "{commands:?}"
         );
-        // The client's restore names the removal too: a first-time client has
-        // no `.prev` to come back from, and must not be left in place.
-        let client = commands.last().unwrap();
-        assert!(client.contains("mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"), "{client}");
-        assert!(client.contains("rm -f $HOME/.local/bin/termio"), "{client}");
+        // This run renamed the box's client aside, so the undo puts that one
+        // back — the one build it is certain about.
+        assert_eq!(
+            commands.last().unwrap(),
+            "mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio",
+            "{commands:?}"
+        );
+    }
+
+    /// The activation never deletes a `.prev` it did not write. Clearing one to
+    /// make the file itself mean "this run" threw away a working previous daemon
+    /// whenever the binary happened to be missing at stage time, leaving a box
+    /// that then failed verification with nothing to hand back to. What this run
+    /// renamed aside is recorded in a shell variable instead.
+    #[tokio::test]
+    async fn a_stage_never_deletes_a_previous_build_it_did_not_write() {
+        let node = FakeNode::new(
+            vec![
+                failed(127, "bash: /home/u/.local/bin/termiod: No such file or directory"),
+                ok(""),
+                ok(&status_json(WANT, None, false)),
+                client_answers(),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        let activation = node.commands.borrow()[1].clone();
+        assert!(!activation.contains("rm -f $HOME/.local/bin/termiod.prev"), "{activation}");
+        assert!(!activation.contains("rm -f $HOME/.local/bin/termio.prev"), "{activation}");
+        // It records what it renamed aside, which is what the undo reads.
+        assert!(activation.contains("termiod_replaced=1"), "{activation}");
+        assert!(activation.contains("termio_replaced=1"), "{activation}");
+    }
+
+    /// A client-only pass on a control plane that cannot produce a client leaves
+    /// the client alone instead of failing the reconcile. This runs before every
+    /// attach, and a checkout with no cross-toolchain would otherwise turn
+    /// reaching a healthy machine into an error.
+    #[tokio::test]
+    async fn a_client_only_pass_that_cannot_build_one_leaves_the_client_alone() {
+        struct NoClientBuild;
+        impl Node for NoClientBuild {
+            fn label(&self) -> String {
+                "box".into()
+            }
+            fn binary(&self) -> String {
+                "$HOME/.local/bin/termiod".into()
+            }
+            async fn run(&self, command: &str) -> Result<Run> {
+                assert!(command.ends_with("status --json"), "unexpected command: {command}");
+                Ok(ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())))
+            }
+            async fn put(&self, _: &Path, _: &str) -> Result<()> {
+                unreachable!("nothing to send")
+            }
+            async fn artifact(&self, client_only: bool) -> Result<Artifacts> {
+                assert!(client_only, "the daemon is current; only the client is missing");
+                bail!("no bundled client to repair box with")
+            }
+            fn client_binary(&self) -> Option<String> {
+                Some("$HOME/.local/bin/termio".into())
+            }
+            async fn hello(&self) -> Result<DaemonHello> {
+                hello(Some(WANT))
+            }
+        }
+        let report = reconcile(&NoClientBuild, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { client: None, .. }), "{report:?}");
     }
 
     /// A Mac reachable over ssh is current with no client of the deploy's: it
@@ -2939,7 +3046,7 @@ mod tests {
             async fn put(&self, _: &Path, _: &str) -> Result<()> {
                 unreachable!()
             }
-            async fn artifact(&self) -> Result<Artifacts> {
+            async fn artifact(&self, _client_only: bool) -> Result<Artifacts> {
                 unreachable!()
             }
             fn client_binary(&self) -> Option<String> {

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -392,11 +392,7 @@ pub async fn status() -> Result<NodeStatus> {
 /// attach: before this probe existed, `status` executed nothing beside
 /// itself, and a wedged client must not turn it into a hang.
 async fn client_beside_this_binary() -> Option<BinaryStatus> {
-    let exe = std::env::current_exe().ok()?;
-    let candidate = exe.parent()?.join("termio");
-    if !candidate.is_file() {
-        return None;
-    }
+    let candidate = paired_client()?;
     let answered = tokio::time::timeout(Duration::from_secs(5), async {
         tokio::process::Command::new(&candidate)
             .arg("--version")
@@ -416,6 +412,31 @@ async fn client_beside_this_binary() -> Option<BinaryStatus> {
         version: stamp.unwrap_or_default(),
         path: candidate.display().to_string(),
     })
+}
+
+/// The `termio` client installed beside this daemon binary, or `None` when
+/// there is none there.
+///
+/// The directory comes from `argv[0]` whenever this process was started by an
+/// absolute path, and from `current_exe` otherwise. The two differ exactly
+/// where the daemon's path is a symlink: `current_exe` resolves it
+/// (`/proc/self/exe` on Linux), so a daemon installed at
+/// `~/.local/bin/termiod` pointing into `/opt/termio` would report a client at
+/// `/opt/termio/termio` while the control plane stages and verifies
+/// `~/.local/bin/termio`. The two halves then disagree forever — the box
+/// verifies as unhealthy while being healthy, or restages every pass. `argv[0]`
+/// is the name the control plane actually used, so it is the one that answers.
+pub(crate) fn paired_client() -> Option<PathBuf> {
+    let invoked = std::env::args_os()
+        .next()
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute());
+    let directory = match invoked {
+        Some(path) => path.parent().map(Path::to_path_buf)?,
+        None => std::env::current_exe().ok()?.parent().map(Path::to_path_buf)?,
+    };
+    let candidate = directory.join("termio");
+    candidate.is_file().then_some(candidate)
 }
 
 /// Which init owns the daemon, if any. This is what decides what "restart"
@@ -1150,7 +1171,14 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     };
     let mut staged = None;
     if let Some(plan) = plan {
-        eprintln!("[deploy] installing termiod {desired} on {label}…");
+        match plan {
+            StagePlan::Full => eprintln!("[deploy] installing termiod {desired} on {label}…"),
+            // The daemon is deliberately untouched on this pass; saying it is
+            // being installed would describe the one plan that does not.
+            StagePlan::ClientOnly => {
+                eprintln!("[deploy] installing the termio {desired} client on {label}…")
+            }
+        }
         stage(node, plan).await?;
         staged = Some(plan);
         observed = observe(node).await?;
@@ -1389,11 +1417,8 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<()> {
 }
 
 /// Upload-activate for one binary: rename the current file to `.prev`, the
-/// `.new` upload over the path — and if that last rename fails, put `.prev`
-/// straight back, so a partial swap never leaves the path empty. The restore
-/// is scoped inside the swap on purpose: only a `.prev` this very command
-/// created may be moved back, because a stale `.prev` from an earlier deploy
-/// moved over a healthy binary is a silent downgrade.
+/// `.new` upload over the path — and if that last rename fails, undo it, so a
+/// partial swap never leaves the path empty.
 fn swap_command(target: &str) -> String {
     format!(
         "chmod +x {target}.new && {{ [ ! -e {target} ] || mv -f {target} {target}.prev; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
@@ -1401,9 +1426,16 @@ fn swap_command(target: &str) -> String {
     )
 }
 
-/// Move `.prev` back over the path, if there is one.
+/// Put a path back the way this run found it: the previous build over it when
+/// there is one, and *gone* when there is not.
+///
+/// The removal half is what makes "a failed stage leaves the box as it was"
+/// true on a first install. There, the swap renamed nothing aside (the path
+/// held nothing to rename), so a restore that only knew how to move `.prev`
+/// back was a no-op and the box kept a binary from a stage that had failed —
+/// reported as `Failed` while the new build sat on disk.
 fn restore_command(target: &str) -> String {
-    format!("{{ [ ! -e {target}.prev ] || mv -f {target}.prev {target}; }}")
+    format!("if [ -e {target}.prev ]; then mv -f {target}.prev {target}; else rm -f {target}; fi")
 }
 
 /// The daemon answering as the build wanted, and the client beside it
@@ -1539,19 +1571,28 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan) -> Result<()> {
     if plan.restores_path {
         // The rename keeps the old inode alive for the daemon now exec'd from
         // it, while the path serves the build that worked to the next
-        // autostart. The client comes back with it — same pass in, same pass
-        // out — guarded because a box first deployed by this build has no
-        // previous client to restore.
-        let mut restore = format!("mv -f {source} {binary}");
-        if let Some(client) = node.client_binary() {
-            restore.push_str(&format!(" && {}", client_restore_command(&client)));
-        }
-        let run = node.run(&restore).await?;
+        // autostart.
+        let run = node.run(&format!("mv -f {source} {binary}")).await?;
         if run.code != 0 {
             bail!(
                 "restoring the previous binary on {label}: {}",
                 last_line(&run.stderr)
             );
+        }
+        // The client comes back in its own command, and its failure is a note
+        // rather than the rollback's. Chained onto the daemon's restore and
+        // judged by one exit code, a client that would not move back reported
+        // the whole rollback as failed — telling an operator the box was left
+        // on the build that broke it, while the daemon had in fact already
+        // been put back, and inviting recovery the box did not need.
+        if let Some(client) = node.client_binary() {
+            let restored = node.run(&restore_command(&client)).await;
+            if !matches!(&restored, Ok(run) if run.code == 0) {
+                eprintln!(
+                    "[deploy] {label} is back on the previous daemon, but its client could not be \
+                     restored; the next deploy replaces it"
+                );
+            }
         }
     }
     Ok(())
@@ -1565,7 +1606,7 @@ async fn roll_back_client<N: Node>(node: &N) -> Result<()> {
     };
     let label = node.label();
     eprintln!("[deploy] rolling {label} back to the previous client…");
-    let run = node.run(&client_restore_command(&client)).await?;
+    let run = node.run(&restore_command(&client)).await?;
     if run.code != 0 {
         bail!(
             "restoring the previous client on {label}: {}",
@@ -1573,16 +1614,6 @@ async fn roll_back_client<N: Node>(node: &N) -> Result<()> {
         );
     }
     Ok(())
-}
-
-/// The client's way back: `.prev` over the path when there is one, and the
-/// failed install *removed* when there is not. A first-time client that
-/// failed verification has no previous build to return to, and leaving it in
-/// place would keep a broken binary leading every session's PATH while the
-/// report claims the box was restored — absent is the state the box was in,
-/// so absent is what restored means.
-fn client_restore_command(client: &str) -> String {
-    format!("if [ -e {client}.prev ]; then mv -f {client}.prev {client}; else rm -f {client}; fi")
 }
 
 /// The one line worth showing from a `handoff --json` reply, falling back to
@@ -2343,6 +2374,7 @@ mod tests {
                 ok(""),        // roll back: [ -e prev ]
                 handed_off(3), // roll back: handoff --binary prev
                 ok(""),        // roll back: mv prev back
+                ok(""),        // roll back: the client, in its own command
             ],
             (0..40)
                 .map(|_| Err(anyhow::anyhow!("no protocol reply")))
@@ -2356,7 +2388,36 @@ mod tests {
             "{commands:?}"
         );
         assert!(!commands.iter().any(|command| command.contains(" stop")), "{commands:?}");
-        assert!(commands.last().unwrap().starts_with("mv -f"), "{commands:?}");
+        assert!(
+            commands.iter().any(|command| command == "mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
+            "{commands:?}"
+        );
+        assert!(commands.last().unwrap().contains("termio.prev"), "{commands:?}");
+    }
+
+    /// The daemon is what a rollback is judged on. A client that will not move
+    /// back is a note, not a failed rollback: the box really is on the build
+    /// that worked, and saying otherwise sends an operator after a recovery
+    /// that already happened.
+    #[tokio::test]
+    async fn a_client_that_cannot_be_restored_does_not_fail_the_rollback() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""), // stage
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(3),
+                ok(""), // roll back: [ -e prev ]
+                handed_off(3),
+                ok(""), // roll back: the daemon is back
+                failed(1, "mv: cannot move: Read-only file system"), // the client is not
+            ],
+            (0..40)
+                .map(|_| Err(anyhow::anyhow!("no protocol reply")))
+                .collect(),
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
     }
 
     /// A new daemon that never verifies and cannot hand back is rolled back the
@@ -2374,6 +2435,7 @@ mod tests {
                 failed(1, "the daemon did not answer hello in time"), // roll back: handoff
                 ok(""), // roll back: stop --force
                 ok(""), // roll back: mv prev
+                ok(""), // roll back: the client
             ],
             (0..40)
                 .map(|_| Err(anyhow::anyhow!("no protocol reply")))
@@ -2383,7 +2445,10 @@ mod tests {
         assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
         let commands = node.commands.borrow();
         assert!(commands.iter().any(|command| command.contains("stop --force")), "{commands:?}");
-        assert!(commands.last().unwrap().contains("termiod.prev"), "{commands:?}");
+        assert!(
+            commands.iter().any(|command| command.contains("termiod.prev")),
+            "{commands:?}"
+        );
     }
 
     /// A box another, newer control plane set up is left alone and reported as
@@ -2508,7 +2573,8 @@ mod tests {
                 failed(126, "cannot execute binary file"), // termio --version
                 ok(""),        // roll back: [ -e prev ]
                 handed_off(2), // roll back: handoff --binary prev
-                ok(""),        // roll back: mv prev back, client too
+                ok(""),        // roll back: the daemon
+                ok(""),        // roll back: the client
             ],
             vec![hello(Some(WANT))],
         );
@@ -2521,9 +2587,15 @@ mod tests {
             other => panic!("expected unhealthy, got {other:?}"),
         }
         let commands = node.commands.borrow();
-        let restore = commands.last().unwrap();
-        assert!(restore.contains("mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"), "{restore}");
-        assert!(restore.contains("mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"), "{restore}");
+        assert!(
+            commands.iter().any(|command| command == "mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
+            "{commands:?}"
+        );
+        // The client's restore names the removal too: a first-time client has
+        // no `.prev` to come back from, and must not be left in place.
+        let client = commands.last().unwrap();
+        assert!(client.contains("mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"), "{client}");
+        assert!(client.contains("rm -f $HOME/.local/bin/termio"), "{client}");
     }
 
     /// ssh failing is `unreachable`, kept apart from a step that ran and failed.

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -235,6 +235,11 @@ fn peer_pid(stream: &UnixStream) -> Option<i32> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeStatus {
     pub binary: BinaryStatus,
+    /// The `termio` client installed beside the daemon binary. Absent when the
+    /// file is not there — or when the report comes from a build too old to
+    /// look for it, which the loop reads the same way: something to install.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client: Option<BinaryStatus>,
     pub daemon: DaemonStatus,
     pub sessions: Vec<SessionSummary>,
     /// The identity written on the daemon's first start. Present without a
@@ -335,6 +340,9 @@ pub async fn status() -> Result<NodeStatus> {
             .map(|path| path.display().to_string())
             .unwrap_or_default(),
     };
+    let client = tokio::task::spawn_blocking(client_beside_this_binary)
+        .await
+        .unwrap_or(None);
     let host_id = paths::stored_host_id();
     let mut daemon = DaemonStatus {
         running: false,
@@ -368,10 +376,30 @@ pub async fn status() -> Result<NodeStatus> {
     }
     Ok(NodeStatus {
         binary,
+        client,
         daemon,
         sessions,
         host_id,
         supervisor: detect_supervisor().await,
+    })
+}
+
+/// The `termio` client beside this binary, answering for itself. Executed
+/// rather than stat'ed because installed means "answers `--version`": a
+/// half-copied file or a wrong-architecture slice is exactly what the deploy
+/// loop needs to read as something to replace, not something present. An
+/// unanswerable client reports with an empty version, which no build stamp
+/// parses as.
+fn client_beside_this_binary() -> Option<BinaryStatus> {
+    let exe = std::env::current_exe().ok()?;
+    let candidate = exe.parent()?.join("termio");
+    if !candidate.is_file() {
+        return None;
+    }
+    let (_, stamp) = binary_version(&candidate);
+    Some(BinaryStatus {
+        version: stamp.unwrap_or_default(),
+        path: candidate.display().to_string(),
     })
 }
 
@@ -410,6 +438,17 @@ async fn detect_supervisor() -> Supervisor {
 
 pub fn print_status(status: &NodeStatus) {
     println!("binary:  {} ({})", status.binary.version, status.binary.path);
+    if let Some(client) = &status.client {
+        println!(
+            "client:  {} ({})",
+            if client.version.is_empty() {
+                "does not answer --version"
+            } else {
+                &client.version
+            },
+            client.path
+        );
+    }
     match (&status.daemon.running, &status.daemon.version, status.daemon.pid) {
         (false, _, _) => println!("daemon:  not running ({})", status.daemon.socket),
         (true, version, pid) => println!(
@@ -847,8 +886,16 @@ pub trait Node {
     fn run(&self, command: &str) -> impl std::future::Future<Output = Result<Run>> + Send;
     /// Copy `local` to `<name>` beside the daemon binary on the node.
     fn put(&self, local: &Path, name: &str) -> impl std::future::Future<Output = Result<()>> + Send;
-    /// The daemon this control plane would install on the node.
-    fn artifact(&self) -> impl std::future::Future<Output = Result<PathBuf>> + Send;
+    /// The build this control plane would install on the node — the daemon,
+    /// and the `termio` client that ships beside it in the same pass
+    /// (docker-lessons RFC §1.2), so a box's client and daemon are always the
+    /// same build and skew between them is structurally impossible.
+    fn artifact(&self) -> impl std::future::Future<Output = Result<Artifacts>> + Send;
+    /// The client binary's path on the node, as the node's own shell should
+    /// see it — or `None` on a node whose client ships another way (this
+    /// Mac's lives inside the app bundle), which turns every client step of
+    /// the loop off.
+    fn client_binary(&self) -> Option<String>;
     /// Handshake with the node's daemon, starting it if nothing answers —
     /// which is the contact that brings a freshly staged binary up.
     fn hello(&self) -> impl std::future::Future<Output = Result<DaemonHello>> + Send;
@@ -871,6 +918,16 @@ pub trait Node {
     fn preserve_command(&self) -> Option<String> {
         None
     }
+}
+
+/// What [`Node::artifact`] stages: one build, both binaries. The client is not
+/// optional here on purpose — a deploy that shipped only half the build would
+/// recreate exactly the skew the same-pass rule exists to rule out — and a
+/// node with no client to install says so through `client_binary` instead.
+#[derive(Debug, Clone)]
+pub struct Artifacts {
+    pub daemon: PathBuf,
+    pub client: PathBuf,
 }
 
 /// See [`Node::rollback_plan`].
@@ -1046,9 +1103,24 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     let mut observed = observe(node).await?;
     let needs_stage = match &observed {
         Observed::Absent | Observed::OldBinary => true,
-        Observed::Reported(status) => {
-            Version::parse(&status.binary.version).map_or(true, |have| have < want)
-        }
+        Observed::Reported(status) => match Version::parse(&status.binary.version) {
+            None => true,
+            Some(have) if have < want => true,
+            // A newer control plane owns this box, client and all; nothing
+            // here may downgrade any part of it.
+            Some(have) if have > want => false,
+            // The daemon binary is already this build. The client ships in
+            // the same pass, so a box missing it — or holding one from
+            // another build — is staged again anyway.
+            Some(_) => {
+                node.client_binary().is_some()
+                    && status
+                        .client
+                        .as_ref()
+                        .and_then(|client| Version::parse(&client.version))
+                        != Some(want)
+            }
+        },
     };
     let mut staged = false;
     if needs_stage {
@@ -1232,12 +1304,21 @@ async fn observe<N: Node>(node: &N) -> Result<Observed> {
 /// refuses to open a running executable for writing (`ETXTBSY`), so writing
 /// in place is the one shape that always fails when a box is in use.
 async fn stage<N: Node>(node: &N) -> Result<()> {
-    let artifact = node.artifact().await?;
-    node.put(&artifact, "termiod.new").await?;
+    let artifacts = node.artifact().await?;
+    node.put(&artifacts.daemon, "termiod.new").await?;
     let binary = node.binary();
-    let command = format!(
+    let mut command = format!(
         "chmod +x {binary}.new && {{ [ ! -e {binary} ] || mv -f {binary} {binary}.prev; }} && mv -f {binary}.new {binary}"
     );
+    // The client lands in the same pass, with the same discipline, activated
+    // by the same shell command — the narrowest window there is for a box to
+    // hold one binary of a build without the other.
+    if let Some(client) = node.client_binary() {
+        node.put(&artifacts.client, "termio.new").await?;
+        command.push_str(&format!(
+            " && chmod +x {client}.new && {{ [ ! -e {client} ] || mv -f {client} {client}.prev; }} && mv -f {client}.new {client}"
+        ));
+    }
     let run = node.run(&command).await?;
     if run.code != 0 {
         bail!(
@@ -1249,10 +1330,50 @@ async fn stage<N: Node>(node: &N) -> Result<()> {
     Ok(())
 }
 
+/// The daemon answering as the build wanted, and the client beside it
+/// answering `--version` with the same build's stamp. The client half is
+/// skipped on a box a newer control plane owns — its client is that plane's
+/// to verify — and on a node that installs no client at all.
+async fn verify<N: Node>(node: &N, want: Version) -> Result<(DaemonHello, Version)> {
+    let (hello, version) = verify_daemon(node, want).await?;
+    if version == want {
+        verify_client(node, want).await?;
+    }
+    Ok((hello, version))
+}
+
+/// Run the installed client over the node's own shell. Existence is not the
+/// question — `stage` just put it there — but a wrong-architecture slice or a
+/// truncated copy execs and fails, and finding that out here, while `.prev` is
+/// still beside it, is the whole point of verifying before reporting.
+async fn verify_client<N: Node>(node: &N, want: Version) -> Result<()> {
+    let Some(client) = node.client_binary() else {
+        return Ok(());
+    };
+    let run = node.run(&format!("{client} --version")).await?;
+    if run.code != 0 {
+        bail!(
+            "the client at {client} does not answer --version: {}",
+            last_line(&run.stderr)
+        );
+    }
+    match run.stdout.split_whitespace().find_map(Version::parse) {
+        Some(stamp) if stamp >= want => Ok(()),
+        Some(_) => bail!(
+            "the client at {client} answers as an older build ({})",
+            last_line(&run.stdout)
+        ),
+        None => bail!(
+            "the client at {client} answers --version with no build stamp ({})",
+            last_line(&run.stdout)
+        ),
+    }
+}
+
 /// Handshake with whatever answers now — which, after a stop, is the daemon
 /// autostart brings up from the staged binary — and check it is the build
 /// wanted, or a newer one.
-async fn verify<N: Node>(node: &N, want: Version) -> Result<(DaemonHello, Version)> {
+async fn verify_daemon<N: Node>(node: &N, want: Version) -> Result<(DaemonHello, Version)> {
     let deadline = Instant::now() + SETTLE;
     let mut last_error = None;
     while Instant::now() < deadline {
@@ -1339,8 +1460,16 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan) -> Result<()> {
     if plan.restores_path {
         // The rename keeps the old inode alive for the daemon now exec'd from
         // it, while the path serves the build that worked to the next
-        // autostart.
-        let run = node.run(&format!("mv -f {source} {binary}")).await?;
+        // autostart. The client comes back with it — same pass in, same pass
+        // out — guarded because a box first deployed by this build has no
+        // previous client to restore.
+        let mut restore = format!("mv -f {source} {binary}");
+        if let Some(client) = node.client_binary() {
+            restore.push_str(&format!(
+                " && {{ [ ! -e {client}.prev ] || mv -f {client}.prev {client}; }}"
+            ));
+        }
+        let run = node.run(&restore).await?;
         if run.code != 0 {
             bail!(
                 "restoring the previous binary on {label}: {}",
@@ -1404,8 +1533,14 @@ impl Node for LocalNode {
         bail!("this machine's termiod ships inside the app; update the app to update it")
     }
 
-    async fn artifact(&self) -> Result<PathBuf> {
+    async fn artifact(&self) -> Result<Artifacts> {
         bail!("this machine's termiod ships inside the app; update the app to update it")
+    }
+
+    fn client_binary(&self) -> Option<String> {
+        // The Mac's client ships inside the app bundle and reaches PATH
+        // through the app's own support copy; the loop installs nothing here.
+        None
     }
 
     async fn hello(&self) -> Result<DaemonHello> {
@@ -1588,6 +1723,7 @@ mod tests {
         puts: RefCell<Vec<String>>,
         plan: Option<RollbackPlan>,
         preserve: Option<String>,
+        client: Option<String>,
     }
 
     impl FakeNode {
@@ -1599,11 +1735,13 @@ mod tests {
                 puts: RefCell::new(Vec::new()),
                 plan: None,
                 preserve: None,
+                client: Some("$HOME/.local/bin/termio".to_string()),
             }
         }
 
         /// The local node's shape: a stash instead of `.prev`, no path
-        /// restore, rollback attempted even unstaged.
+        /// restore, rollback attempted even unstaged, and no client to
+        /// install — the Mac's ships inside the app bundle.
         fn local_style(mut self) -> FakeNode {
             self.plan = Some(RollbackPlan {
                 source: "/state/termiod.prev".to_string(),
@@ -1612,6 +1750,7 @@ mod tests {
             });
             self.preserve =
                 Some("mkdir -p /state && cp -f $HOME/.local/bin/termiod /state/termiod.prev".to_string());
+            self.client = None;
             self
         }
     }
@@ -1638,8 +1777,14 @@ mod tests {
             self.puts.borrow_mut().push(format!("{} → {name}", local.display()));
             Ok(())
         }
-        async fn artifact(&self) -> Result<PathBuf> {
-            Ok(PathBuf::from("/bundle/termiod-aarch64-unknown-linux-musl"))
+        async fn artifact(&self) -> Result<Artifacts> {
+            Ok(Artifacts {
+                daemon: PathBuf::from("/bundle/termiod-aarch64-unknown-linux-musl"),
+                client: PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl"),
+            })
+        }
+        fn client_binary(&self) -> Option<String> {
+            self.client.clone()
         }
         async fn hello(&self) -> Result<DaemonHello> {
             self.hellos
@@ -1685,11 +1830,25 @@ mod tests {
         running: bool,
         sessions: Vec<SessionSummary>,
     ) -> String {
+        status_json_with_client(binary, Some(binary), daemon, running, sessions)
+    }
+
+    fn status_json_with_client(
+        binary: &str,
+        client: Option<&str>,
+        daemon: Option<&str>,
+        running: bool,
+        sessions: Vec<SessionSummary>,
+    ) -> String {
         serde_json::to_string(&NodeStatus {
             binary: BinaryStatus {
                 version: binary.to_string(),
                 path: "/home/u/.local/bin/termiod".to_string(),
             },
+            client: client.map(|version| BinaryStatus {
+                version: version.to_string(),
+                path: "/home/u/.local/bin/termio".to_string(),
+            }),
             daemon: DaemonStatus {
                 running,
                 version: daemon.map(str::to_string),
@@ -1745,6 +1904,11 @@ mod tests {
         failed(2, "error: unrecognized subcommand 'handoff'")
     }
 
+    /// What the freshly installed client answers `--version`.
+    fn client_answers() -> Run {
+        ok(&format!("termio {WANT} (release)"))
+    }
+
     const WANT: &str = "0.44.0+1600";
 
     /// Install from an empty box: the binary is staged, nothing is stopped, and
@@ -1754,15 +1918,25 @@ mod tests {
         let node = FakeNode::new(
             vec![
                 failed(127, "bash: /home/u/.local/bin/termiod: No such file or directory"),
-                ok(""), // chmod + mv
+                ok(""), // chmod + mv, both binaries
                 ok(&status_json(WANT, None, false)),
+                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
         let report = reconcile(&node, WANT, Options::default()).await;
         assert!(matches!(report.outcome, Outcome::Current { ref version, newer: false, .. } if version == WANT), "{report:?}");
-        assert_eq!(node.puts.borrow().len(), 1);
-        assert!(!node.commands.borrow().iter().any(|command| command.contains(" stop")));
+        // The client ships in the same pass: two uploads, one activation
+        // command carrying the rename-over discipline for both binaries.
+        let puts = node.puts.borrow();
+        assert_eq!(puts.len(), 2, "{puts:?}");
+        assert!(puts[0].ends_with("→ termiod.new"), "{puts:?}");
+        assert!(puts[1].ends_with("→ termio.new"), "{puts:?}");
+        let commands = node.commands.borrow();
+        assert!(commands[1].contains("mv -f $HOME/.local/bin/termiod.new $HOME/.local/bin/termiod"), "{}", commands[1]);
+        assert!(commands[1].contains("mv -f $HOME/.local/bin/termio.new $HOME/.local/bin/termio"), "{}", commands[1]);
+        assert!(commands.last().unwrap().ends_with("termio --version"), "{commands:?}");
+        assert!(!commands.iter().any(|command| command.contains(" stop")));
     }
 
     /// A binary too old to answer `status` is staged first and asked again with
@@ -1777,6 +1951,7 @@ mod tests {
                 ok(&status_json(WANT, None, true)), // old daemon: running, no version
                 cannot_hand_off(),
                 ok(""), // stop
+                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -1798,6 +1973,7 @@ mod tests {
                 ok(""), // chmod + mv
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(3),
+                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -1818,6 +1994,7 @@ mod tests {
                 ok(""),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(1),
+                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -1910,6 +2087,7 @@ mod tests {
                 cannot_hand_off(),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)), // still empty
                 ok(""),                                            // stop
+                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2116,6 +2294,59 @@ mod tests {
         assert!(node.puts.borrow().is_empty());
     }
 
+    /// A box whose daemon is already this build but whose client is missing —
+    /// deployed before the client shipped, or half of a copy lost — is staged
+    /// again: the client is part of the build, not an extra.
+    #[tokio::test]
+    async fn a_current_daemon_missing_its_client_is_restaged() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                ok(""), // stage: both binaries, one command
+                ok(&status_json(WANT, Some(WANT), true)),
+                client_answers(),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        assert_eq!(node.puts.borrow().len(), 2);
+        // The running daemon is already the wanted build: nothing bounces it.
+        let commands = node.commands.borrow();
+        assert!(!commands.iter().any(|command| command.contains(" stop") || command.ends_with("handoff --json")), "{commands:?}");
+    }
+
+    /// A client that does not answer `--version` fails the deploy the same way
+    /// an unhealthy daemon does: the box is rolled back, client included.
+    #[tokio::test]
+    async fn a_client_that_cannot_answer_version_rolls_the_box_back() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""), // stage
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(2),
+                failed(126, "cannot execute binary file"), // termio --version
+                ok(""),        // roll back: [ -e prev ]
+                handed_off(2), // roll back: handoff --binary prev
+                ok(""),        // roll back: mv prev back, client too
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        match &report.outcome {
+            Outcome::Unhealthy { message, rolled_back } => {
+                assert!(*rolled_back, "{report:?}");
+                assert!(message.contains("--version"), "{message}");
+            }
+            other => panic!("expected unhealthy, got {other:?}"),
+        }
+        let commands = node.commands.borrow();
+        let restore = commands.last().unwrap();
+        assert!(restore.contains("mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"), "{restore}");
+        assert!(restore.contains("mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"), "{restore}");
+    }
+
     /// ssh failing is `unreachable`, kept apart from a step that ran and failed.
     #[tokio::test]
     async fn a_transport_failure_is_unreachable() {
@@ -2133,8 +2364,11 @@ mod tests {
             async fn put(&self, _: &Path, _: &str) -> Result<()> {
                 unreachable!()
             }
-            async fn artifact(&self) -> Result<PathBuf> {
+            async fn artifact(&self) -> Result<Artifacts> {
                 unreachable!()
+            }
+            fn client_binary(&self) -> Option<String> {
+                None
             }
             async fn hello(&self) -> Result<DaemonHello> {
                 unreachable!()

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -340,9 +340,7 @@ pub async fn status() -> Result<NodeStatus> {
             .map(|path| path.display().to_string())
             .unwrap_or_default(),
     };
-    let client = tokio::task::spawn_blocking(client_beside_this_binary)
-        .await
-        .unwrap_or(None);
+    let client = client_beside_this_binary().await;
     let host_id = paths::stored_host_id();
     let mut daemon = DaemonStatus {
         running: false,
@@ -388,15 +386,32 @@ pub async fn status() -> Result<NodeStatus> {
 /// rather than stat'ed because installed means "answers `--version`": a
 /// half-copied file or a wrong-architecture slice is exactly what the deploy
 /// loop needs to read as something to replace, not something present. An
-/// unanswerable client reports with an empty version, which no build stamp
-/// parses as.
-fn client_beside_this_binary() -> Option<BinaryStatus> {
+/// unanswerable client — one that errors, exits nonzero, or hangs past the
+/// timeout — reports with an empty version, which no build stamp parses as.
+/// The timeout matters because `status` is on the path of every deploy and
+/// attach: before this probe existed, `status` executed nothing beside
+/// itself, and a wedged client must not turn it into a hang.
+async fn client_beside_this_binary() -> Option<BinaryStatus> {
     let exe = std::env::current_exe().ok()?;
     let candidate = exe.parent()?.join("termio");
     if !candidate.is_file() {
         return None;
     }
-    let (_, stamp) = binary_version(&candidate);
+    let answered = tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::process::Command::new(&candidate)
+            .arg("--version")
+            .stdin(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .output()
+            .await
+            .ok()
+    })
+    .await
+    .ok()
+    .flatten();
+    let stamp = answered
+        .filter(|output| output.status.success())
+        .and_then(|output| version_stamp(&String::from_utf8_lossy(&output.stdout)));
     Some(BinaryStatus {
         version: stamp.unwrap_or_default(),
         path: candidate.display().to_string(),
@@ -817,8 +832,11 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
 /// `None` is not a failure: it means the version check is skipped and the
 /// handoff is judged on the pid and the reconnect alone. Refusing to hand off
 /// to a binary whose `--version` this build cannot parse would be refusing on
-/// the strength of a string.
-fn binary_version(binary: &Path) -> (Option<Version>, Option<String>) {
+/// the strength of a string. A nonzero exit is `None` too: a stamp printed on
+/// the way to failing is not an answer, and `verify_client` holds the same
+/// line — a probe that accepted it would mask exactly what verification
+/// exists to catch.
+pub(crate) fn binary_version(binary: &Path) -> (Option<Version>, Option<String>) {
     let Ok(output) = std::process::Command::new(binary)
         .arg("--version")
         .stdin(std::process::Stdio::null())
@@ -826,15 +844,19 @@ fn binary_version(binary: &Path) -> (Option<Version>, Option<String>) {
     else {
         return (None, None);
     };
-    let printed = String::from_utf8_lossy(&output.stdout);
-    let stamp = printed
+    if !output.status.success() {
+        return (None, None);
+    }
+    let stamp = version_stamp(&String::from_utf8_lossy(&output.stdout));
+    (stamp.as_deref().and_then(Version::parse), stamp)
+}
+
+/// The first word of `printed` that parses as a build stamp.
+fn version_stamp(printed: &str) -> Option<String> {
+    printed
         .split_whitespace()
         .find(|word| Version::parse(word).is_some())
-        .map(str::to_string);
-    (
-        stamp.as_deref().and_then(Version::parse),
-        stamp,
-    )
+        .map(str::to_string)
 }
 
 /// `termiod handoff` — the CLI around [`handoff`].
@@ -920,14 +942,15 @@ pub trait Node {
     }
 }
 
-/// What [`Node::artifact`] stages: one build, both binaries. The client is not
-/// optional here on purpose — a deploy that shipped only half the build would
-/// recreate exactly the skew the same-pass rule exists to rule out — and a
-/// node with no client to install says so through `client_binary` instead.
+/// What [`Node::artifact`] stages: one build, both binaries. Every build of
+/// this crate produces both, so `client` is `None` only when a developer's
+/// `--bin` override points at a daemon with no client beside it — and that
+/// same override turns the node's client plane off (`client_binary` returns
+/// `None`), so the two stay consistent rather than shipping half a build.
 #[derive(Debug, Clone)]
 pub struct Artifacts {
     pub daemon: PathBuf,
-    pub client: PathBuf,
+    pub client: Option<PathBuf>,
 }
 
 /// See [`Node::rollback_plan`].
@@ -1101,32 +1124,35 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     let label = node.label();
 
     let mut observed = observe(node).await?;
-    let needs_stage = match &observed {
-        Observed::Absent | Observed::OldBinary => true,
+    let plan = match &observed {
+        Observed::Absent | Observed::OldBinary => Some(StagePlan::Full),
         Observed::Reported(status) => match Version::parse(&status.binary.version) {
-            None => true,
-            Some(have) if have < want => true,
+            None => Some(StagePlan::Full),
+            Some(have) if have < want => Some(StagePlan::Full),
             // A newer control plane owns this box, client and all; nothing
             // here may downgrade any part of it.
-            Some(have) if have > want => false,
+            Some(have) if have > want => None,
             // The daemon binary is already this build. The client ships in
             // the same pass, so a box missing it — or holding one from
-            // another build — is staged again anyway.
+            // another build — is staged again, client only: re-renaming the
+            // daemon would destroy `termiod.prev`, the box's one rollback
+            // point, to repair a file the daemon plane never lost.
             Some(_) => {
-                node.client_binary().is_some()
-                    && status
+                let client_current = node.client_binary().is_none()
+                    || status
                         .client
                         .as_ref()
                         .and_then(|client| Version::parse(&client.version))
-                        != Some(want)
+                        == Some(want);
+                (!client_current).then_some(StagePlan::ClientOnly)
             }
         },
     };
-    let mut staged = false;
-    if needs_stage {
+    let mut staged = None;
+    if let Some(plan) = plan {
         eprintln!("[deploy] installing termiod {desired} on {label}…");
-        stage(node).await?;
-        staged = true;
+        stage(node, plan).await?;
+        staged = Some(plan);
         observed = observe(node).await?;
     }
     let Observed::Reported(status) = observed else {
@@ -1244,9 +1270,9 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         }
     }
 
-    match verify(node, want).await {
+    match verify(node, want, staged.is_some()).await {
         Ok((hello, version)) => {
-            if daemon_is_stale || staged {
+            if daemon_is_stale || staged.is_some() {
                 // Best effort: a copy that fails costs the *next* upgrade its
                 // free rollback, not this one anything.
                 if let Some(preserve) = node.preserve_command() {
@@ -1262,15 +1288,31 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         }
         Err(error) => {
             let message = format!("{error:#}");
-            let plan = node.rollback_plan();
-            let rolled_back =
-                (staged || plan.even_unstaged) && roll_back(node, &plan).await.is_ok();
+            // A client-only stage touched nothing but the client, so its
+            // rollback restores nothing but the client: handing the daemon
+            // back to `.prev` here would downgrade a plane that never failed.
+            let rolled_back = match staged {
+                Some(StagePlan::ClientOnly) => roll_back_client(node).await.is_ok(),
+                _ => {
+                    let plan = node.rollback_plan();
+                    (staged.is_some() || plan.even_unstaged)
+                        && roll_back(node, &plan).await.is_ok()
+                }
+            };
             Ok(Outcome::Unhealthy {
                 message,
                 rolled_back,
             })
         }
     }
+}
+
+/// What a reconcile pass needs to put on the node: the whole build, or only
+/// the `termio` client when the daemon plane is already current.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StagePlan {
+    Full,
+    ClientOnly,
 }
 
 async fn observe<N: Node>(node: &N) -> Result<Observed> {
@@ -1303,21 +1345,37 @@ async fn observe<N: Node>(node: &N) -> Result<Observed> {
 /// it keeps the old inode until it exits, which is the handover wanted. Linux
 /// refuses to open a running executable for writing (`ETXTBSY`), so writing
 /// in place is the one shape that always fails when a box is in use.
-async fn stage<N: Node>(node: &N) -> Result<()> {
+async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<()> {
     let artifacts = node.artifact().await?;
-    node.put(&artifacts.daemon, "termiod.new").await?;
-    let binary = node.binary();
-    let mut command = format!(
-        "chmod +x {binary}.new && {{ [ ! -e {binary} ] || mv -f {binary} {binary}.prev; }} && mv -f {binary}.new {binary}"
-    );
+    let mut command = String::new();
+    if plan == StagePlan::Full {
+        node.put(&artifacts.daemon, "termiod.new").await?;
+        command = swap_command(&node.binary());
+    }
     // The client lands in the same pass, with the same discipline, activated
     // by the same shell command — the narrowest window there is for a box to
-    // hold one binary of a build without the other.
+    // hold one binary of a build without the other. When the client's half
+    // fails after the daemon's rename succeeded, the daemon is renamed back
+    // in the same command: a failed stage must leave the box as it was, not
+    // holding a new daemon beside an old client — the exact skew this loop
+    // exists to prevent — with `.prev` already spent.
     if let Some(client) = node.client_binary() {
-        node.put(&artifacts.client, "termio.new").await?;
-        command.push_str(&format!(
-            " && chmod +x {client}.new && {{ [ ! -e {client} ] || mv -f {client} {client}.prev; }} && mv -f {client}.new {client}"
-        ));
+        let Some(local) = &artifacts.client else {
+            bail!("no termio client in the build for {}", node.label());
+        };
+        node.put(local, "termio.new").await?;
+        let client_swap = swap_command(&client);
+        command = if command.is_empty() {
+            client_swap
+        } else {
+            format!(
+                "{command} && {{ {client_swap} || {{ {}; false; }}; }}",
+                restore_command(&node.binary())
+            )
+        };
+    }
+    if command.is_empty() {
+        return Ok(());
     }
     let run = node.run(&command).await?;
     if run.code != 0 {
@@ -1330,13 +1388,34 @@ async fn stage<N: Node>(node: &N) -> Result<()> {
     Ok(())
 }
 
+/// Upload-activate for one binary: rename the current file to `.prev`, the
+/// `.new` upload over the path — and if that last rename fails, put `.prev`
+/// straight back, so a partial swap never leaves the path empty. The restore
+/// is scoped inside the swap on purpose: only a `.prev` this very command
+/// created may be moved back, because a stale `.prev` from an earlier deploy
+/// moved over a healthy binary is a silent downgrade.
+fn swap_command(target: &str) -> String {
+    format!(
+        "chmod +x {target}.new && {{ [ ! -e {target} ] || mv -f {target} {target}.prev; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
+        restore_command(target)
+    )
+}
+
+/// Move `.prev` back over the path, if there is one.
+fn restore_command(target: &str) -> String {
+    format!("{{ [ ! -e {target}.prev ] || mv -f {target}.prev {target}; }}")
+}
+
 /// The daemon answering as the build wanted, and the client beside it
-/// answering `--version` with the same build's stamp. The client half is
-/// skipped on a box a newer control plane owns — its client is that plane's
-/// to verify — and on a node that installs no client at all.
-async fn verify<N: Node>(node: &N, want: Version) -> Result<(DaemonHello, Version)> {
+/// answering `--version` with at least the same build's stamp. The client
+/// half is skipped on a box a newer control plane owns — its client is that
+/// plane's to verify — and on a node that installs no client at all. Unless
+/// this run staged: what this run just put on disk is this run's to verify,
+/// whatever daemon happens to answer — a newer plane racing this one must
+/// not turn an unverified client into a reported success.
+async fn verify<N: Node>(node: &N, want: Version, staged: bool) -> Result<(DaemonHello, Version)> {
     let (hello, version) = verify_daemon(node, want).await?;
-    if version == want {
+    if version == want || staged {
         verify_client(node, want).await?;
     }
     Ok((hello, version))
@@ -1465,9 +1544,7 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan) -> Result<()> {
         // previous client to restore.
         let mut restore = format!("mv -f {source} {binary}");
         if let Some(client) = node.client_binary() {
-            restore.push_str(&format!(
-                " && {{ [ ! -e {client}.prev ] || mv -f {client}.prev {client}; }}"
-            ));
+            restore.push_str(&format!(" && {}", client_restore_command(&client)));
         }
         let run = node.run(&restore).await?;
         if run.code != 0 {
@@ -1478,6 +1555,34 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Put the previous client back — the daemon plane was never touched, so
+/// this is the whole rollback for a client-only stage.
+async fn roll_back_client<N: Node>(node: &N) -> Result<()> {
+    let Some(client) = node.client_binary() else {
+        return Ok(());
+    };
+    let label = node.label();
+    eprintln!("[deploy] rolling {label} back to the previous client…");
+    let run = node.run(&client_restore_command(&client)).await?;
+    if run.code != 0 {
+        bail!(
+            "restoring the previous client on {label}: {}",
+            last_line(&run.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// The client's way back: `.prev` over the path when there is one, and the
+/// failed install *removed* when there is not. A first-time client that
+/// failed verification has no previous build to return to, and leaving it in
+/// place would keep a broken binary leading every session's PATH while the
+/// report claims the box was restored — absent is the state the box was in,
+/// so absent is what restored means.
+fn client_restore_command(client: &str) -> String {
+    format!("if [ -e {client}.prev ]; then mv -f {client}.prev {client}; else rm -f {client}; fi")
 }
 
 /// The one line worth showing from a `handoff --json` reply, falling back to
@@ -1780,7 +1885,7 @@ mod tests {
         async fn artifact(&self) -> Result<Artifacts> {
             Ok(Artifacts {
                 daemon: PathBuf::from("/bundle/termiod-aarch64-unknown-linux-musl"),
-                client: PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl"),
+                client: Some(PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl")),
             })
         }
         fn client_binary(&self) -> Option<String> {
@@ -2296,13 +2401,15 @@ mod tests {
 
     /// A box whose daemon is already this build but whose client is missing —
     /// deployed before the client shipped, or half of a copy lost — is staged
-    /// again: the client is part of the build, not an extra.
+    /// again, client only: the repair never re-renames the daemon, so
+    /// `termiod.prev` — the box's one rollback point — survives it, and the
+    /// multi-MB daemon is not uploaded to fix a file it never lost.
     #[tokio::test]
-    async fn a_current_daemon_missing_its_client_is_restaged() {
+    async fn a_current_daemon_missing_its_client_is_restaged_client_only() {
         let node = FakeNode::new(
             vec![
                 ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
-                ok(""), // stage: both binaries, one command
+                ok(""), // stage: the client alone
                 ok(&status_json(WANT, Some(WANT), true)),
                 client_answers(),
             ],
@@ -2310,10 +2417,82 @@ mod tests {
         );
         let report = reconcile(&node, WANT, Options::default()).await;
         assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
-        assert_eq!(node.puts.borrow().len(), 2);
-        // The running daemon is already the wanted build: nothing bounces it.
+        let puts = node.puts.borrow();
+        assert_eq!(puts.len(), 1, "{puts:?}");
+        assert!(puts[0].ends_with("→ termio.new"), "{puts:?}");
+        // The daemon plane is untouched: not bounced, not renamed.
         let commands = node.commands.borrow();
         assert!(!commands.iter().any(|command| command.contains(" stop") || command.ends_with("handoff --json")), "{commands:?}");
+        assert!(!commands.iter().any(|command| command.contains("termiod.prev")), "{commands:?}");
+    }
+
+    /// A client-only stage that fails verification rolls back the client
+    /// alone — handing the daemon to `.prev` would downgrade a plane that
+    /// never failed — and a first-time client with no `.prev` is removed
+    /// rather than left broken at the head of every session's PATH.
+    #[tokio::test]
+    async fn a_failed_client_only_stage_rolls_back_only_the_client() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                ok(""), // stage: the client alone
+                ok(&status_json(WANT, Some(WANT), true)),
+                failed(126, "cannot execute binary file"), // termio --version
+                ok(""), // roll back: restore or remove the client
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        let restore = commands.last().unwrap();
+        assert!(restore.contains("termio.prev"), "{restore}");
+        assert!(restore.contains("rm -f $HOME/.local/bin/termio"), "{restore}");
+        assert!(!commands.iter().any(|command| command.contains("termiod.prev") || command.contains(" stop")), "{commands:?}");
+    }
+
+    /// This run staged the box, so the client is verified even when a newer
+    /// daemon answers — two planes racing must not turn an unverified client
+    /// into `Current { newer: true }`.
+    #[tokio::test]
+    async fn a_staged_box_verifies_its_client_even_under_a_newer_daemon() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""), // stage
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(1),
+                client_answers(), // verified despite the newer daemon answering
+            ],
+            vec![hello(Some("0.45.0+1700"))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { newer: true, .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        assert!(commands.last().unwrap().ends_with("termio --version"), "{commands:?}");
+    }
+
+    /// The activation command undoes itself: a client half that fails after
+    /// the daemon's rename must put the daemon back in the same command, so a
+    /// failed stage never leaves a new daemon beside an old client with
+    /// `.prev` already spent.
+    #[tokio::test]
+    async fn a_failed_stage_restores_the_daemon_in_the_same_command() {
+        let node = FakeNode::new(
+            vec![
+                failed(127, "bash: termiod: No such file or directory"),
+                failed(1, "mv: cannot overwrite directory"), // stage activation
+            ],
+            vec![],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Failed { .. }), "{report:?}");
+        let activation = node.commands.borrow().last().unwrap().clone();
+        // The client's failure branch restores the daemon's `.prev`.
+        assert!(
+            activation.contains("mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
+            "{activation}"
+        );
     }
 
     /// A client that does not answer `--version` fails the deploy the same way

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1081,6 +1081,11 @@ pub enum Outcome {
         version: String,
         daemon: Option<String>,
         busy: Vec<SessionSummary>,
+        /// What is wrong with the `termio` client, or what could not be learned
+        /// about it — the same note `Current` carries, under the same key, so a
+        /// reader does not have to ask which rung it is looking at.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client: Option<String>,
     },
     /// The new daemon did not verify. `rolled_back` means the previous binary is
     /// back in place and whatever it autostarts next is the build that worked.
@@ -1140,9 +1145,14 @@ impl Report {
                 version,
                 daemon,
                 busy,
+                client,
             } if busy.is_empty() => format!(
-                "{node}: termiod {version} is staged; the running daemon ({}) takes over once it is stopped",
-                daemon.as_deref().unwrap_or("no version")
+                "{node}: termiod {version} is staged; the running daemon ({}) takes over once it is stopped{}",
+                daemon.as_deref().unwrap_or("no version"),
+                match client {
+                    Some(trouble) => format!("\n{trouble}"),
+                    None => String::new(),
+                }
             ),
             Outcome::Staged { version, busy, .. } => {
                 let mut text = format!(
@@ -1295,7 +1305,14 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // attach — so an upload that fails, or an activation that does, would
             // have made a healthy box unreachable ("Couldn't set up termiod on
             // …") over the CLI inside its sessions.
-            Err(error) if plan == StagePlan::ClientOnly => {
+            Err(error)
+                if plan == StagePlan::ClientOnly
+                    // A host that dropped is unreachable, which is a state of its
+                    // own: swallowed here it came back as `Unhealthy`, after a
+                    // full settle budget spent waiting for a daemon nothing
+                    // could reach.
+                    && error.downcast_ref::<Unreachable>().is_none() =>
+            {
                 eprintln!("[deploy] {label}'s client could not be installed ({error:#}); leaving it as it is");
                 // Put off rather than written off, and with no need to work out
                 // which kind of failure this was: a host that dropped, a control
@@ -1331,10 +1348,36 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     };
 
     if options.stage_only {
+        // The client is still checked here. Stopping at the stage is about not
+        // touching the *daemon*; a client this pass just installed and never ran
+        // is one the box could be left holding broken, with nothing said about it
+        // — and running it touches no daemon at all.
+        if staged.client {
+            client_skew = match verify_client(node, want).await {
+                ClientVerdict::Good => {
+                    clear_client_repair(repair_note.as_deref());
+                    None
+                }
+                ClientVerdict::Bad(message) => {
+                    let removed = roll_back_client(node).await.is_ok();
+                    let wait = delay_client_repair(repair_note.as_deref(), desired);
+                    Some((
+                        format!(
+                            "{message}{}; installing it again in {}",
+                            if removed { "; it was taken back off the box" } else { "; it is still there" },
+                            describe_wait(wait),
+                        ),
+                        true,
+                    ))
+                }
+                ClientVerdict::Unknown(message) => Some((message, false)),
+            };
+        }
         return Ok(Outcome::Staged {
             version: status.binary.version,
             daemon: status.daemon.version,
             busy: Vec::new(),
+            client: client_skew.map(|(note, _)| note),
         });
     }
 
@@ -1372,6 +1415,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                         version: status.binary.version.clone(),
                         daemon: status.daemon.version.clone(),
                         busy: alive,
+                        client: client_skew.as_ref().map(|(note, _)| note.clone()),
                     });
                 }
                 // A daemon holding no session has nothing a stop can cost, so
@@ -1395,6 +1439,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                                 version: fresh.binary.version,
                                 daemon: fresh.daemon.version,
                                 busy: alive,
+                                client: client_skew.as_ref().map(|(note, _)| note.clone()),
                             });
                         }
                     }
@@ -1403,6 +1448,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                             version: status.binary.version.clone(),
                             daemon: status.daemon.version.clone(),
                             busy: Vec::new(),
+                            client: client_skew.as_ref().map(|(note, _)| note.clone()),
                         });
                     }
                 }
@@ -1434,6 +1480,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                         version: status.binary.version,
                         daemon: status.daemon.version,
                         busy: outcome.busy,
+                        client: client_skew.as_ref().map(|(note, _)| note.clone()),
                     });
                 }
                 _ => bail!("stopping termiod on {label}: {}", last_line(&run.stderr)),
@@ -1479,7 +1526,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // bounded one the next pass closes with a `ClientOnly` restage, and
             // no session pays for it.
             ClientVerdict::Bad(message) => {
-                let put_back = roll_back_client(node, staged.client_replaced).await.is_ok();
+                let put_back = roll_back_client(node).await.is_ok();
                 // Put off, not written off. The copy that answered wrongly may
                 // simply have arrived short — the very thing this probe exists to
                 // catch — and sending the bytes again is what fixes that, so the
@@ -1776,7 +1823,14 @@ fn swap_command(target: &str, replaced: &str) -> String {
 /// swap set: the build it renamed aside, or removal where it installed onto an
 /// empty path.
 fn shell_restore(target: &str, replaced: &str) -> String {
-    format!("if [ -n \"${replaced}\" ]; then mv -f {target}.prev {target}; else rm -f {target}; fi")
+    // Copied to a temporary name and renamed over the path, rather than moved
+    // straight back: the rename is what keeps the replacement atomic, and the
+    // copy is what leaves `.prev` where it was. Moving it back put the right
+    // daemon on the box with nothing beside it to roll back to — exactly the
+    // "`.prev` already spent" state the stage is supposed to prevent.
+    format!(
+        "if [ -n \"${replaced}\" ]; then cp -f {target}.prev {target}.undo && mv -f {target}.undo {target}; else rm -f {target}; fi"
+    )
 }
 
 /// The undo for a swap that happened in an *earlier* ssh command, where no shell
@@ -1979,13 +2033,13 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged: Staged) -> Re
 
 /// Put the previous client back — the daemon plane was never touched, so
 /// this is the whole rollback for a client-only stage.
-async fn roll_back_client<N: Node>(node: &N, replaced: bool) -> Result<()> {
+async fn roll_back_client<N: Node>(node: &N) -> Result<()> {
     let Some(client) = node.client_binary() else {
         return Ok(());
     };
     let label = node.label();
     eprintln!("[deploy] rolling {label} back to the previous client…");
-    let run = node.run(&restore_command(&client, replaced)).await?;
+    let run = node.run(&format!("rm -f {client}")).await?;
     if run.code != 0 {
         bail!(
             "restoring the previous client on {label}: {}",
@@ -3030,9 +3084,18 @@ mod tests {
         let report = reconcile(&node, WANT, Options::default()).await;
         assert!(matches!(report.outcome, Outcome::Failed { .. }), "{report:?}");
         let activation = node.commands.borrow().last().unwrap().clone();
-        // The client's failure branch restores the daemon's `.prev`.
+        // The client's failure branch puts the daemon back — by copy and rename,
+        // so the box still has a `.prev` to roll back to afterwards. Moving it
+        // back restored the right daemon and spent the only way back from it.
         assert!(
-            activation.contains("mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
+            activation.contains(
+                "cp -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod.undo \
+                 && mv -f $HOME/.local/bin/termiod.undo $HOME/.local/bin/termiod"
+            ),
+            "{activation}"
+        );
+        assert!(
+            !activation.contains("mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
             "{activation}"
         );
     }
@@ -3089,21 +3152,24 @@ mod tests {
             !commands.iter().any(|command| command == "mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
             "{commands:?}"
         );
-        // This run renamed the box's client aside, so the undo puts that one
-        // back — the one build it is certain about.
-        assert_eq!(
-            commands.last().unwrap(),
-            "mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio",
-            "{commands:?}"
-        );
+        // Taken off the box rather than swapped for the older one it replaced:
+        // the daemon here is staying on the new build, and an older client beside
+        // it is the skew §1.2 exists to rule out. A missing client is a state the
+        // next pass closes; a mismatched one is not.
+        assert_eq!(commands.last().unwrap(), "rm -f $HOME/.local/bin/termio", "{commands:?}");
     }
 
     /// The undo follows what the activation reported, not what the box's status
-    /// implied. A daemon built before this pass reports no `client` field at
-    /// all, so deriving replaced-ness from the status concluded there had been
-    /// no client and *removed* one that failed verification — instead of putting
-    /// back the `termio.prev` the same stage had just written. Every box already
-    /// in the field passes through that on its first upgrade.
+    /// implied. A daemon built before this pass reports no `client` field at all,
+    /// so deriving replaced-ness from the status concluded there had never been a
+    /// client — and a rollback then *removed* one instead of putting back the
+    /// `termio.prev` the same stage had just written. Every box already in the
+    /// field passes through that on its first upgrade.
+    ///
+    /// The rollback that asks is the daemon's: when the daemon goes back to its
+    /// previous build the client goes with it, so the pair stays one build. (A
+    /// client that fails on its own is taken off instead, because the daemon is
+    /// staying new — see above.)
     #[tokio::test]
     async fn a_client_is_put_back_even_when_the_old_daemon_never_reported_one() {
         // An older build's status: no `client` key, which `serde(default)`
@@ -3124,13 +3190,19 @@ mod tests {
                 staged_over_a_client(),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(1),
-                failed(126, "cannot execute binary file"), // termio --version
-                ok(""),                                    // put the client back
+                ok(""),        // roll back: [ -e prev ]
+                handed_off(1), // roll back: handoff --binary prev
+                ok(""),        // roll back: the daemon
+                ok(""),        // roll back: the client, with it
             ],
-            vec![hello(Some(WANT))],
+            // The daemon never comes up, so the rollback is the daemon's and the
+            // client rides along with it.
+            (0..40)
+                .map(|_| Err(anyhow::anyhow!("no protocol reply")))
+                .collect(),
         );
         let report = reconcile(&node, WANT, Options::default()).await;
-        assert!(matches!(report.outcome, Outcome::Current { client: Some(_), .. }), "{report:?}");
+        assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
         assert_eq!(
             node.commands.borrow().last().unwrap(),
             "mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"
@@ -3260,12 +3332,46 @@ mod tests {
         assert_eq!(client_repair_waiting(Some(&note), WANT), None);
     }
 
-    /// A repair that did not take is put off, never written off — and a failure
-    /// that never ran the binary is not reported as the binary's fault. ssh
-    /// dropping for a second says nothing about whether this client can live on
-    /// that box, so it costs a short wait and nothing else.
+    /// Stopping at the stage still runs the client it just installed. That is
+    /// about not touching the *daemon*, and running a client touches none — so a
+    /// box was otherwise left holding a client nothing had ever executed, with
+    /// the report saying nothing about it.
     #[tokio::test]
-    async fn a_dropped_connection_only_delays_the_next_client_repair() {
+    async fn stopping_at_the_stage_still_answers_for_the_client_it_installed() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                staged_over_a_client(),
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                failed(126, "cannot execute binary file"), // termio --version
+                ok(""),                                    // take it back off
+            ],
+            vec![],
+        );
+        let options = Options { stage_only: true, ..Options::default() };
+        let report = reconcile(&node, WANT, options).await;
+        match &report.outcome {
+            Outcome::Staged { client: Some(note), .. } => {
+                assert!(note.contains("--version"), "{note}");
+            }
+            other => panic!("expected staged naming the client trouble, got {other:?}"),
+        }
+        let commands = node.commands.borrow();
+        assert_eq!(commands.last().unwrap(), "rm -f $HOME/.local/bin/termio", "{commands:?}");
+        // The daemon is what `--stage-only` promises not to touch.
+        assert!(!commands.iter().any(|command| command.contains(" stop")), "{commands:?}");
+        assert!(
+            !commands.iter().any(|command| command.ends_with("handoff --json")),
+            "{commands:?}"
+        );
+    }
+
+    /// A host that drops mid-repair is reported as what it is. Folded into the
+    /// soft arm it came back as `Unhealthy` — after a full settle budget spent
+    /// waiting on a daemon nothing could reach — and nothing about the client is
+    /// learned either way, so no wait is recorded against it.
+    #[tokio::test]
+    async fn a_host_that_drops_mid_repair_is_reported_unreachable() {
         let note = std::path::PathBuf::from(format!(
             "/tmp/termiod-repair-{}-dropped",
             std::process::id()
@@ -3279,17 +3385,10 @@ mod tests {
         node.unreachable_put = true;
         let report = reconcile(&node, WANT, Options::default()).await;
 
-        // Usable, said out loud, and not blamed on a binary nothing ran.
-        match &report.outcome {
-            Outcome::Current { client: Some(_), client_failed, .. } => {
-                assert!(!client_failed, "{report:?}");
-            }
-            other => panic!("expected current with a client note, got {other:?}"),
-        }
-        assert_eq!(report.exit_code(), 0, "a dropped connection is not a failed deploy");
-        // Put off by the first wait, not abandoned: the same build is tried again.
-        let waiting = client_repair_waiting(Some(&note), WANT).expect("a wait");
-        assert!(waiting <= CLIENT_REPAIR_WAIT, "{waiting:?}");
+        assert!(matches!(report.outcome, Outcome::Unreachable { .. }), "{report:?}");
+        // And nothing is held against the client: the repair never got far enough
+        // to learn anything about it, so the next pass starts fresh.
+        assert_eq!(client_repair_waiting(Some(&note), WANT), None);
         let _ = std::fs::remove_file(&note);
     }
 

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1229,14 +1229,6 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             }
         },
     };
-    // What was on the node before this run staged anything, which is what says
-    // whether a `.prev` afterwards is this run's doing. Read here, from the
-    // observation already in hand, because the box cannot answer it later: a
-    // `.prev` on disk may be this run's or an older deploy's, and putting back
-    // the wrong one installs a build some earlier pass had replaced.
-    let daemon_present = !matches!(observed, Observed::Absent);
-    let client_present = matches!(&observed, Observed::Reported(status) if status.client.is_some());
-
     // What this run put on the node, per plane. Every undo below reads this and
     // nothing else: a run that staged only the client may not touch the daemon,
     // and one that staged no client may not touch the client — the box's own,
@@ -1244,8 +1236,6 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     let mut staged = Staged::default();
     if let Some(plan) = plan {
         staged = stage(node, plan).await?;
-        staged.daemon_replaced = staged.daemon && daemon_present;
-        staged.client_replaced = staged.client && client_present;
         match (staged.daemon, staged.client) {
             (true, true) => eprintln!("[deploy] installed termiod {desired} and its client on {label}"),
             (true, false) => eprintln!("[deploy] installed termiod {desired} on {label}"),
@@ -1529,6 +1519,14 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
     if command.is_empty() {
         return Ok(staged);
     }
+    // The activation reports what it renamed aside, because it is the only thing
+    // that looked. Deriving it here from the observation instead read a field
+    // (`status.client`) that only a daemon built from this pass onward reports,
+    // so on the first upgrade of a box already in the field the loop concluded
+    // there had been no client — and a client that then failed verification was
+    // removed rather than put back from the `termio.prev` this very stage had
+    // just written. Every existing box passes through that once.
+    command.push_str(&format!(" && echo \"{STAGE_REPORT} client_replaced=${{termio_replaced:-0}}\""));
     let run = node.run(&command).await?;
     if run.code != 0 {
         bail!(
@@ -1537,8 +1535,17 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
             last_line(&run.stderr)
         );
     }
+    staged.client_replaced = staged.client
+        && run
+            .stdout
+            .lines()
+            .any(|line| line.contains(STAGE_REPORT) && line.contains("client_replaced=1"));
     Ok(staged)
 }
+
+/// Marks the activation's own account of itself, so a login banner on the way
+/// through cannot be mistaken for it.
+const STAGE_REPORT: &str = "termiod-stage:";
 
 /// Which planes a stage actually put on the node. A pass that shipped no client
 /// — because this build has none — turns the client plane off for the rest of
@@ -1547,11 +1554,18 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
 struct Staged {
     daemon: bool,
     client: bool,
-    /// Whether the stage renamed a previous build aside, per plane — the fact an
-    /// undo in a later ssh command needs and cannot read off the disk. Taken
-    /// from the observation this run made before staging: a `.prev` on the box
-    /// says nothing about whose it is.
-    daemon_replaced: bool,
+    /// Whether the stage renamed a previous *client* aside — the fact an undo in
+    /// a later ssh command needs and cannot read off the disk, since a
+    /// `termio.prev` sitting there says nothing about whose it is. Reported by
+    /// the activation command itself, which is the only thing that tested the
+    /// path at the moment it mattered.
+    ///
+    /// There is deliberately no daemon twin. The daemon's `.prev` is the box's
+    /// rollback point and is kept across runs on purpose, so a failed upgrade
+    /// hands back to whatever known-good build is there rather than to nothing;
+    /// the client's is not a rollback point but a skew risk, because a client
+    /// from an earlier build beside this build's daemon is exactly what the
+    /// same-pass rule exists to prevent.
     client_replaced: bool,
 }
 
@@ -2103,6 +2117,12 @@ mod tests {
         }
     }
 
+    /// What the activation echoes when it renamed a client aside, which is what
+    /// the loop reads to know whose `termio.prev` is on the box.
+    fn staged_over_a_client() -> Run {
+        ok("termiod-stage: client_replaced=1")
+    }
+
     fn ok(stdout: &str) -> Run {
         Run {
             code: 0,
@@ -2542,7 +2562,7 @@ mod tests {
         let node = FakeNode::new(
             vec![
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
-                ok(""), // stage: chmod + mv
+                staged_over_a_client(), // stage: chmod + mv
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(3), // the daemon takes the bad image on
                 ok(""),        // roll back: [ -e prev ]
@@ -2816,7 +2836,7 @@ mod tests {
         let node = FakeNode::new(
             vec![
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
-                ok(""), // stage
+                staged_over_a_client(), // stage
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(2),
                 failed(126, "cannot execute binary file"), // termio --version
@@ -2858,6 +2878,45 @@ mod tests {
             commands.last().unwrap(),
             "mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio",
             "{commands:?}"
+        );
+    }
+
+    /// The undo follows what the activation reported, not what the box's status
+    /// implied. A daemon built before this pass reports no `client` field at
+    /// all, so deriving replaced-ness from the status concluded there had been
+    /// no client and *removed* one that failed verification — instead of putting
+    /// back the `termio.prev` the same stage had just written. Every box already
+    /// in the field passes through that on its first upgrade.
+    #[tokio::test]
+    async fn a_client_is_put_back_even_when_the_old_daemon_never_reported_one() {
+        // An older build's status: no `client` key, which `serde(default)`
+        // reads as `None` however many clients are actually on the box.
+        let older_status = serde_json::json!({
+            "binary": { "version": "0.43.0+1500", "path": "/home/u/.local/bin/termiod" },
+            "daemon": { "running": true, "version": "0.43.0+1500", "pid": 4242,
+                        "socket": "/run/user/1001/termiod/termiod.sock" },
+            "sessions": [],
+            "host_id": "h_1",
+            "supervisor": "none"
+        })
+        .to_string();
+        let node = FakeNode::new(
+            vec![
+                ok(&older_status),
+                // The activation says what it found: a client was renamed aside.
+                staged_over_a_client(),
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(1),
+                failed(126, "cannot execute binary file"), // termio --version
+                ok(""),                                    // put the client back
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { client: Some(_), .. }), "{report:?}");
+        assert_eq!(
+            node.commands.borrow().last().unwrap(),
+            "mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"
         );
     }
 

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1154,7 +1154,7 @@ impl Report {
                     None => String::new(),
                 }
             ),
-            Outcome::Staged { version, busy, .. } => {
+            Outcome::Staged { version, busy, client, .. } => {
                 let mut text = format!(
                     "{node}: termiod {version} is staged, but the daemon still running there has work in progress:"
                 );
@@ -1167,6 +1167,13 @@ impl Report {
                     ));
                 }
                 text.push_str("\nRun this again once it finishes, or pass --force to stop it now.");
+                // The client rides this rung as much as the others; destructured
+                // away, the note reached the app and the JSON but never the
+                // person reading the command's own output.
+                if let Some(trouble) = client {
+                    text.push('\n');
+                    text.push_str(trouble);
+                }
                 text
             }
             Outcome::Unhealthy {
@@ -1322,9 +1329,13 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                 // calling it the client's fault would claim — this pass never got
                 // to run it.
                 let wait = delay_client_repair(repair_note.as_deref(), desired);
+                // The same fault the next passes report: this one did the failing
+                // work and left the box on a client that is not this build, so it
+                // would be the odd one out calling that a success while every
+                // later pass that attempts nothing calls it a failure.
                 client_skew = Some((
                     format!("{error:#}; tried again in {}", describe_wait(wait)),
-                    false,
+                    true,
                 ));
                 Staged::default()
             }
@@ -1347,37 +1358,43 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         bail!("termiod was installed on {label} but does not answer `status` there");
     };
 
+    // The client this pass installed is answered for here, before any of the
+    // ways out below. It needs nothing from the daemon — it is one `--version`
+    // over ssh — and every rung that returns early was otherwise leaving a box
+    // holding a client nothing had run, already at the head of every session's
+    // PATH through the daemon's own symlink, with the report silent about it.
+    if staged.client {
+        client_skew = match verify_client(node, want).await {
+            ClientVerdict::Good => {
+                clear_client_repair(repair_note.as_deref());
+                None
+            }
+            ClientVerdict::Bad(message) => {
+                let removed = roll_back_client(node).await.is_ok();
+                let wait = delay_client_repair(repair_note.as_deref(), desired);
+                Some((
+                    format!(
+                        "{message}{}; installing it again in {}",
+                        if removed {
+                            "; it was taken back off the box"
+                        } else {
+                            "; it could not be taken back off the box"
+                        },
+                        describe_wait(wait),
+                    ),
+                    true,
+                ))
+            }
+            ClientVerdict::Unknown(message) => Some((message, false)),
+        };
+    }
+
     if options.stage_only {
-        // The client is still checked here. Stopping at the stage is about not
-        // touching the *daemon*; a client this pass just installed and never ran
-        // is one the box could be left holding broken, with nothing said about it
-        // — and running it touches no daemon at all.
-        if staged.client {
-            client_skew = match verify_client(node, want).await {
-                ClientVerdict::Good => {
-                    clear_client_repair(repair_note.as_deref());
-                    None
-                }
-                ClientVerdict::Bad(message) => {
-                    let removed = roll_back_client(node).await.is_ok();
-                    let wait = delay_client_repair(repair_note.as_deref(), desired);
-                    Some((
-                        format!(
-                            "{message}{}; installing it again in {}",
-                            if removed { "; it was taken back off the box" } else { "; it is still there" },
-                            describe_wait(wait),
-                        ),
-                        true,
-                    ))
-                }
-                ClientVerdict::Unknown(message) => Some((message, false)),
-            };
-        }
         return Ok(Outcome::Staged {
             version: status.binary.version,
             daemon: status.daemon.version,
             busy: Vec::new(),
-            client: client_skew.map(|(note, _)| note),
+            client: client_skew.as_ref().map(|(note, _)| note.clone()),
         });
     }
 
@@ -1511,48 +1528,8 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         }
     };
 
-    // Only a client this run put there is verified here. One that was already
-    // on the box answered for itself in the `status` this pass already read —
-    // that reading is an execution of the same binary, not a stat — so asking
-    // again would spend an ssh round trip, before every attach, to learn what
-    // the machine has just said.
-    let mut client_trouble = client_skew;
-    if staged.client {
-        match verify_client(node, want).await {
-            ClientVerdict::Good => clear_client_repair(repair_note.as_deref()),
-            // Undo what this run did, which for a client that failed to answer
-            // is the client. A Full stage therefore leaves a verified new daemon
-            // beside no client rather than beside a broken one: a skew, but a
-            // bounded one the next pass closes with a `ClientOnly` restage, and
-            // no session pays for it.
-            ClientVerdict::Bad(message) => {
-                let put_back = roll_back_client(node).await.is_ok();
-                // Put off, not written off. The copy that answered wrongly may
-                // simply have arrived short — the very thing this probe exists to
-                // catch — and sending the bytes again is what fixes that, so the
-                // next attempt is delayed rather than abandoned.
-                let wait = delay_client_repair(repair_note.as_deref(), desired);
-                client_trouble = Some((
-                    format!(
-                        "{message}{}; installing it again in {}",
-                        if put_back {
-                            "; the previous client is back in place"
-                        } else {
-                            "; it could not be put back"
-                        },
-                        describe_wait(wait),
-                    ),
-                    true,
-                ));
-            }
-            // Nothing was learned about the client, so nothing is undone: what
-            // this run installed stays, and the next pass asks again.
-            // Reported, never counted as a fault: nothing was learned, and a
-            // deploy that installed everything correctly must not be called
-            // failed because ssh was flaky for the length of one probe.
-            ClientVerdict::Unknown(message) => client_trouble = Some((message, false)),
-        }
-    }
+    // Settled above, before the first way out of this function.
+    let client_trouble = client_skew;
 
     if daemon_is_stale || staged.daemon {
         // Best effort: a copy that fails costs the *next* upgrade its free
@@ -2031,18 +2008,23 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged: Staged) -> Re
     Ok(())
 }
 
-/// Put the previous client back — the daemon plane was never touched, so
-/// this is the whole rollback for a client-only stage.
+/// Take a client that failed verification back off the box.
+///
+/// It is removed, not replaced by the one it displaced: the daemon here is
+/// staying on the new build, and the older client beside it is the skew §1.2
+/// exists to rule out. A machine with no `termio` is a state the next pass
+/// closes — nothing even leads its sessions' PATH with a client that is not
+/// there — and one with the wrong `termio` is not.
 async fn roll_back_client<N: Node>(node: &N) -> Result<()> {
     let Some(client) = node.client_binary() else {
         return Ok(());
     };
     let label = node.label();
-    eprintln!("[deploy] rolling {label} back to the previous client…");
+    eprintln!("[deploy] taking the client that did not verify back off {label}…");
     let run = node.run(&format!("rm -f {client}")).await?;
     if run.code != 0 {
         bail!(
-            "restoring the previous client on {label}: {}",
+            "removing the client that did not verify on {label}: {}",
             last_line(&run.stderr)
         );
     }
@@ -2299,6 +2281,12 @@ mod tests {
         repair_note: Option<PathBuf>,
         /// Makes `put` fail the way ssh does when the host drops.
         unreachable_put: bool,
+        /// What `termio --version` answers. Kept out of the scripted queue so a
+        /// test states what the client does rather than where in the sequence it
+        /// is asked — the loop is free to ask earlier or later. `None` falls
+        /// through to the queue, which is how a test makes the box unreachable
+        /// for the probe.
+        client_version: Option<Run>,
     }
 
     impl FakeNode {
@@ -2314,6 +2302,7 @@ mod tests {
                 client_artifact: Some(PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl")),
                 repair_note: None,
                 unreachable_put: false,
+                client_version: Some(client_answers()),
             }
         }
 
@@ -2346,6 +2335,11 @@ mod tests {
         }
         async fn run(&self, command: &str) -> Result<Run> {
             self.commands.borrow_mut().push(command.to_string());
+            if command.ends_with("termio --version") {
+                if let Some(answer) = self.client_version.clone() {
+                    return Ok(answer);
+                }
+            }
             self.runs
                 .borrow_mut()
                 .pop_front()
@@ -2521,7 +2515,6 @@ mod tests {
                 failed(127, "bash: /home/u/.local/bin/termiod: No such file or directory"),
                 ok(""), // chmod + mv, both binaries
                 ok(&status_json(WANT, None, false)),
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2552,7 +2545,6 @@ mod tests {
                 ok(&status_json(WANT, None, true)), // old daemon: running, no version
                 cannot_hand_off(),
                 ok(""), // stop
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2560,8 +2552,8 @@ mod tests {
         assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
         let commands = node.commands.borrow();
         assert!(commands[1].contains("termiod.prev"), "{}", commands[1]);
-        assert!(commands[3].ends_with("handoff --json"), "{}", commands[3]);
-        assert!(commands[4].ends_with("stop --json"), "{}", commands[4]);
+        assert!(commands.iter().any(|command| command.ends_with("handoff --json")), "{commands:?}");
+        assert!(commands.iter().any(|command| command.ends_with("stop --json")), "{commands:?}");
     }
 
     /// The whole point: a daemon that can take on the new binary is never
@@ -2574,7 +2566,6 @@ mod tests {
                 ok(""), // chmod + mv
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(3),
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2595,7 +2586,6 @@ mod tests {
                 ok(""),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(1),
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2688,7 +2678,6 @@ mod tests {
                 cannot_hand_off(),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)), // still empty
                 ok(""),                                            // stop
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2941,7 +2930,6 @@ mod tests {
                 ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
                 ok(""), // stage: the client alone
                 ok(&status_json(WANT, Some(WANT), true)),
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -2962,16 +2950,16 @@ mod tests {
     /// rather than left broken at the head of every session's PATH.
     #[tokio::test]
     async fn a_failed_client_only_stage_rolls_back_only_the_client() {
-        let node = FakeNode::new(
+        let mut node = FakeNode::new(
             vec![
                 ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
                 ok(""), // stage: the client alone
                 ok(&status_json(WANT, Some(WANT), true)),
-                failed(126, "cannot execute binary file"), // termio --version
                 ok(""), // roll back: restore or remove the client
             ],
             vec![hello(Some(WANT))],
         );
+        node.client_version = Some(failed(126, "cannot execute binary file"));
         let report = reconcile(&node, WANT, Options::default()).await;
         match &report.outcome {
             Outcome::Current { client: Some(_), .. } => {}
@@ -3058,14 +3046,16 @@ mod tests {
                 ok(""), // stage
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(1),
-                client_answers(), // verified despite the newer daemon answering
             ],
             vec![hello(Some("0.45.0+1700"))],
         );
         let report = reconcile(&node, WANT, Options::default()).await;
         assert!(matches!(report.outcome, Outcome::Current { newer: true, .. }), "{report:?}");
         let commands = node.commands.borrow();
-        assert!(commands.last().unwrap().ends_with("termio --version"), "{commands:?}");
+        assert!(
+            commands.iter().any(|command| command.ends_with("termio --version")),
+            "{commands:?}"
+        );
     }
 
     /// The activation command undoes itself: a client half that fails after
@@ -3113,17 +3103,17 @@ mod tests {
     /// it is still a non-zero exit for whoever ran the deploy.
     #[tokio::test]
     async fn a_client_that_cannot_answer_version_never_touches_the_daemon() {
-        let node = FakeNode::new(
+        let mut node = FakeNode::new(
             vec![
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
                 staged_over_a_client(), // stage
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(2),
-                failed(126, "cannot execute binary file"), // termio --version
                 ok(""),                                    // put the client back
             ],
             vec![hello(Some(WANT))],
         );
+        node.client_version = Some(failed(126, "cannot execute binary file"));
         let report = reconcile(&node, WANT, Options::default()).await;
         match &report.outcome {
             Outcome::Current {
@@ -3132,7 +3122,7 @@ mod tests {
                 ..
             } => {
                 assert!(trouble.contains("--version"), "{trouble}");
-                assert!(trouble.contains("back in place"), "{trouble}");
+                assert!(trouble.contains("taken back off the box"), "{trouble}");
                 assert_eq!(host_id, "h_1");
             }
             other => panic!("expected current with a client note, got {other:?}"),
@@ -3156,7 +3146,18 @@ mod tests {
         // the daemon here is staying on the new build, and an older client beside
         // it is the skew §1.2 exists to rule out. A missing client is a state the
         // next pass closes; a mismatched one is not.
-        assert_eq!(commands.last().unwrap(), "rm -f $HOME/.local/bin/termio", "{commands:?}");
+        assert!(
+            commands.iter().any(|command| command == "rm -f $HOME/.local/bin/termio"),
+            "{commands:?}"
+        );
+        // And it happened before the daemon was asked anything, which is the
+        // point of settling the client plane first: every way out of the loop
+        // after that carries what was learned about it.
+        let removed = commands
+            .iter()
+            .position(|command| command == "rm -f $HOME/.local/bin/termio");
+        let handed = commands.iter().position(|command| command.ends_with("handoff --json"));
+        assert!(removed < handed, "{commands:?}");
     }
 
     /// The undo follows what the activation reported, not what the box's status
@@ -3221,7 +3222,6 @@ mod tests {
                 failed(127, "bash: /home/u/.local/bin/termiod: No such file or directory"),
                 ok(""),
                 ok(&status_json(WANT, None, false)),
-                client_answers(),
             ],
             vec![hello(Some(WANT))],
         );
@@ -3244,7 +3244,7 @@ mod tests {
     /// retries within, which is what a network blip needs to pass.
     #[tokio::test]
     async fn an_unreachable_box_does_not_cost_the_client_it_just_installed() {
-        let node = FakeNode::new(
+        let mut node = FakeNode::new(
             vec![
                 ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
                 staged_over_a_client(),
@@ -3254,6 +3254,9 @@ mod tests {
             ],
             vec![hello(Some(WANT))],
         );
+        // Nothing answers the probe, so it falls through to the queue — which is
+        // empty, and the fake reports that as a transport failure.
+        node.client_version = None;
         let report = reconcile(&node, WANT, Options::default()).await;
         match &report.outcome {
             Outcome::Current { client: Some(note), client_failed, .. } => {
@@ -3332,22 +3335,72 @@ mod tests {
         assert_eq!(client_repair_waiting(Some(&note), WANT), None);
     }
 
+    /// A daemon too busy to be replaced does not excuse the client from being
+    /// answered for. The pass installed one, the running daemon's own symlink
+    /// already leads every session's PATH to it, and the rung that reports the
+    /// box staged used to return without ever running it — so a truncated or
+    /// wrong-architecture `termio` sat there unreported until something else
+    /// happened to look.
+    #[tokio::test]
+    async fn a_box_left_staged_still_answers_for_its_client() {
+        let busy = StopOutcome {
+            stopped: false,
+            busy: vec![SessionSummary {
+                id: "1".into(),
+                name: "claude".into(),
+                command: "claude".into(),
+                title: None,
+                status: "working".into(),
+                attached: 0,
+                running: true,
+                alive: true,
+            }],
+            message: "1 session is in use".into(),
+        };
+        let mut node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                staged_over_a_client(),
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                ok(""), // take the client that did not verify back off
+                cannot_hand_off(),
+                Run {
+                    code: EXIT_BUSY,
+                    stdout: serde_json::to_string(&busy).unwrap(),
+                    stderr: String::new(),
+                },
+            ],
+            vec![],
+        );
+        node.client_version = Some(failed(126, "cannot execute binary file"));
+        let report = reconcile(&node, WANT, Options::default()).await;
+        match &report.outcome {
+            Outcome::Staged { busy, client: Some(note), .. } => {
+                assert_eq!(busy.len(), 1);
+                assert!(note.contains("--version"), "{note}");
+            }
+            other => panic!("expected staged naming the client trouble, got {other:?}"),
+        }
+        // And the CLI's own line says it, not only the JSON.
+        assert!(report.describe().contains("--version"), "{}", report.describe());
+    }
+
     /// Stopping at the stage still runs the client it just installed. That is
     /// about not touching the *daemon*, and running a client touches none — so a
     /// box was otherwise left holding a client nothing had ever executed, with
     /// the report saying nothing about it.
     #[tokio::test]
     async fn stopping_at_the_stage_still_answers_for_the_client_it_installed() {
-        let node = FakeNode::new(
+        let mut node = FakeNode::new(
             vec![
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
                 staged_over_a_client(),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
-                failed(126, "cannot execute binary file"), // termio --version
                 ok(""),                                    // take it back off
             ],
             vec![],
         );
+        node.client_version = Some(failed(126, "cannot execute binary file"));
         let options = Options { stage_only: true, ..Options::default() };
         let report = reconcile(&node, WANT, options).await;
         match &report.outcome {
@@ -3442,10 +3495,10 @@ mod tests {
                 ok(&status_json_with_client("0.45.0+1700", None, Some("0.45.0+1700"), true, Vec::new())),
                 staged_over_a_client(),
                 ok(&status_json("0.45.0+1700", Some("0.45.0+1700"), true)),
-                ok("termio 0.45.0+1700 (release)"),
             ],
             vec![hello(Some("0.45.0+1700"))],
         );
+        newer.client_version = Some(ok("termio 0.45.0+1700 (release)"));
         newer.repair_note = Some(note.clone());
         let report = reconcile(&newer, "0.45.0+1700", Options::default()).await;
         assert!(matches!(report.outcome, Outcome::Current { client: None, .. }), "{report:?}");

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -18,7 +18,7 @@
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::UnixStream;
 
@@ -987,11 +987,13 @@ pub trait Node {
         None
     }
 
-    /// Where this control plane may note that the machine would not take a
-    /// build's client, so a repair that can only fail is not retried on every
-    /// attach. Stamped with the build that failed, so a later build gets its own
-    /// chance and a machine that starts accepting one is forgotten as soon as it
-    /// does.
+    /// Where this control plane may note that a client repair did not take, so
+    /// the next one waits instead of going again on the next attach. The wait
+    /// grows with each failure and stops at a cap, so nothing is ever written
+    /// off: a short upload, a host that dropped and a machine that refuses the
+    /// file all get another attempt, which is why none of them has to be told
+    /// apart from the others. Stamped with the build, so other bytes get their
+    /// own first chance, and forgotten as soon as a client installs.
     ///
     /// `None` turns the memory off, which is right for a node that installs no
     /// client at all — and keeps a node that is not a real machine from writing
@@ -1213,7 +1215,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // What this pass will have to say about the client even when it stages
     // nothing for it. A note that stops a doomed repair may not also stop the
     // box from reporting the skew it is carrying.
-    let mut client_skew: Option<String> = None;
+    let mut client_skew: Option<(String, bool)> = None;
     let mut observed = observe(node).await?;
     let plan = match &observed {
         Observed::Absent | Observed::OldBinary => Some(StagePlan::Full),
@@ -1246,26 +1248,32 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                         .and_then(|client| Version::parse(&client.version))
                         .is_some_and(|have| have >= want);
                 if client_current {
-                    // The note is about a client this machine would not take. It
-                    // is plainly obsolete once the machine has one.
-                    remember_client_repair(repair_note.as_deref(), None);
+                    // A delayed repair is plainly moot once the machine has the
+                    // client it was for.
+                    clear_client_repair(repair_note.as_deref());
                     None
-                } else if client_repair_refused(repair_note.as_deref(), desired) {
-                    // Installing this build's client here already failed for a
-                    // reason of the machine's own, so it is not attempted again
-                    // — but the machine is carrying a client that is not this
-                    // build, and it says so on every pass until that changes.
-                    // Silence here would report the exact skew §1.2 exists to
-                    // prevent as a clean bill of health, for good.
-                    client_skew = Some(format!(
-                        "the client on {label} is {}, not {desired}, and installing this build's \
-                         here already failed; a later build installs one again",
-                        status
-                            .client
-                            .as_ref()
-                            .map(|client| client.version.as_str())
-                            .filter(|version| !version.is_empty())
-                            .unwrap_or("missing"),
+                } else if let Some(wait) =
+                    client_repair_waiting(repair_note.as_deref(), desired)
+                {
+                    // Installing this build's client here failed recently, so it
+                    // waits rather than going again on this attach — but the
+                    // machine is carrying a client that is not this build, and it
+                    // says so every pass until that changes. Silence here would
+                    // report the exact skew §1.2 exists to prevent as a clean
+                    // bill of health.
+                    client_skew = Some((
+                        format!(
+                            "the client on {label} is {}, not {desired}; installing this build's \
+                             here failed, and it is tried again in {}",
+                            status
+                                .client
+                                .as_ref()
+                                .map(|client| client.version.as_str())
+                                .filter(|version| !version.is_empty())
+                                .unwrap_or("missing"),
+                            describe_wait(wait),
+                        ),
+                        true,
                     ));
                     None
                 } else {
@@ -1289,15 +1297,18 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // …") over the CLI inside its sessions.
             Err(error) if plan == StagePlan::ClientOnly => {
                 eprintln!("[deploy] {label}'s client could not be installed ({error:#}); leaving it as it is");
-                // Only a refusal by the machine is remembered. ssh dropping for a
-                // second says nothing about whether this client can live there,
-                // and writing it down would disable client installs on that box
-                // until the next build — the same rule the `Unknown` verdict
-                // keeps below.
-                if error.downcast_ref::<Unreachable>().is_none() {
-                    remember_client_repair(repair_note.as_deref(), Some(desired));
-                }
-                client_skew = Some(format!("{error:#}"));
+                // Put off rather than written off, and with no need to work out
+                // which kind of failure this was: a host that dropped, a control
+                // plane without the slice and a machine that refuses the file all
+                // want another attempt, just not on the next attach. And none of
+                // them establishes anything about the *binary*, which is what
+                // calling it the client's fault would claim — this pass never got
+                // to run it.
+                let wait = delay_client_repair(repair_note.as_deref(), desired);
+                client_skew = Some((
+                    format!("{error:#}; tried again in {}", describe_wait(wait)),
+                    false,
+                ));
                 Staged::default()
             }
             Err(error) => return Err(error),
@@ -1458,10 +1469,10 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // that reading is an execution of the same binary, not a stat — so asking
     // again would spend an ssh round trip, before every attach, to learn what
     // the machine has just said.
-    let mut client_trouble = client_skew.map(|note| (note, true));
+    let mut client_trouble = client_skew;
     if staged.client {
         match verify_client(node, want).await {
-            ClientVerdict::Good => remember_client_repair(repair_note.as_deref(), None),
+            ClientVerdict::Good => clear_client_repair(repair_note.as_deref()),
             // Undo what this run did, which for a client that failed to answer
             // is the client. A Full stage therefore leaves a verified new daemon
             // beside no client rather than beside a broken one: a skew, but a
@@ -1469,19 +1480,20 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // no session pays for it.
             ClientVerdict::Bad(message) => {
                 let put_back = roll_back_client(node, staged.client_replaced).await.is_ok();
-                // Written down so the next pass does not spend another upload
-                // learning the same thing. A machine that cannot take this build's
-                // client — a noexec mount, a denied exec, a full disk — was
-                // otherwise restaged on every attach, for good.
-                remember_client_repair(repair_note.as_deref(), Some(desired));
+                // Put off, not written off. The copy that answered wrongly may
+                // simply have arrived short — the very thing this probe exists to
+                // catch — and sending the bytes again is what fixes that, so the
+                // next attempt is delayed rather than abandoned.
+                let wait = delay_client_repair(repair_note.as_deref(), desired);
                 client_trouble = Some((
                     format!(
-                        "{message}{}",
+                        "{message}{}; installing it again in {}",
                         if put_back {
-                            "; the previous client is back in place, and a later build installs one again"
+                            "; the previous client is back in place"
                         } else {
-                            "; it could not be put back, and a later build installs one again"
-                        }
+                            "; it could not be put back"
+                        },
+                        describe_wait(wait),
                     ),
                     true,
                 ));
@@ -1520,27 +1532,89 @@ enum StagePlan {
     ClientOnly,
 }
 
-/// Whether this control plane already found that the machine will not take the
-/// client of build `desired`.
-fn client_repair_refused(note: Option<&Path>, desired: &str) -> bool {
-    note.and_then(|path| std::fs::read_to_string(path).ok())
-        .is_some_and(|stamp| stamp.trim() == desired)
+/// How long a client repair waits before it is tried again, and the longest that
+/// wait grows to.
+///
+/// It is a wait rather than a refusal because a repair that did not take says
+/// almost nothing about whether the next one will: a short upload, a host that
+/// dropped, a control plane without the slice, a disk that was full an hour ago.
+/// Those all want another attempt, just not on every attach. The first minute
+/// costs a blip nothing, and the cap means a machine that truly cannot take the
+/// client spends one upload every few hours instead of one each time someone
+/// reaches it.
+const CLIENT_REPAIR_WAIT: Duration = Duration::from_secs(60);
+const CLIENT_REPAIR_WAIT_CAP: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// What a note holds: the build whose client would not install, how many times
+/// it has been tried, and when it may be tried again.
+struct ClientRepairWait {
+    build: String,
+    attempts: u32,
+    after: SystemTime,
 }
 
-/// Write down that `desired`'s client would not install here, or forget it
-/// (`None`) because one just did.
-fn remember_client_repair(note: Option<&Path>, desired: Option<&str>) {
-    let Some(path) = note else { return };
-    match desired {
-        Some(stamp) => {
-            if let Some(parent) = path.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            let _ = std::fs::write(path, stamp);
+/// How much longer a client repair for `desired` should be left alone, or `None`
+/// when it is due — including because nothing is remembered, or because what is
+/// remembered is about another build and this one has not been tried yet.
+fn client_repair_waiting(note: Option<&Path>, desired: &str) -> Option<Duration> {
+    let waiting = read_client_repair(note?)?;
+    if waiting.build != desired {
+        return None;
+    }
+    waiting.after.duration_since(SystemTime::now()).ok()
+}
+
+fn read_client_repair(path: &Path) -> Option<ClientRepairWait> {
+    let written = std::fs::read_to_string(path).ok()?;
+    let mut fields = written.split_whitespace();
+    let build = fields.next()?.to_string();
+    let attempts = fields.next()?.parse().ok()?;
+    let seconds: u64 = fields.next()?.parse().ok()?;
+    Some(ClientRepairWait {
+        build,
+        attempts,
+        after: SystemTime::UNIX_EPOCH + Duration::from_secs(seconds),
+    })
+}
+
+/// Put a client repair for `desired` off for a while, longer each time it fails.
+fn delay_client_repair(note: Option<&Path>, desired: &str) -> Duration {
+    let attempts = note
+        .and_then(read_client_repair)
+        .filter(|waiting| waiting.build == desired)
+        .map_or(0, |waiting| waiting.attempts)
+        .saturating_add(1);
+    let wait = CLIENT_REPAIR_WAIT
+        .saturating_mul(1u32 << attempts.saturating_sub(1).min(16))
+        .min(CLIENT_REPAIR_WAIT_CAP);
+    if let Some(path) = note {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
         }
-        None => {
-            let _ = std::fs::remove_file(path);
-        }
+        let due = SystemTime::now() + wait;
+        let seconds = due
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_or(0, |since| since.as_secs());
+        let _ = std::fs::write(path, format!("{desired} {attempts} {seconds}"));
+    }
+    wait
+}
+
+/// Forget a delayed repair, because one just installed.
+fn clear_client_repair(note: Option<&Path>) {
+    if let Some(path) = note {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// A wait, for a sentence a person reads.
+fn describe_wait(wait: Duration) -> String {
+    let minutes = wait.as_secs() / 60;
+    match minutes {
+        0 => "shortly".to_string(),
+        1 => "a minute".to_string(),
+        2..=90 => format!("{minutes} minutes"),
+        _ => format!("{} hours", (minutes + 30) / 60),
     }
 }
 
@@ -3147,12 +3221,51 @@ mod tests {
         assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
     }
 
-    /// Only the machine refusing the client is remembered. ssh dropping for a
-    /// second says nothing about whether this client can live there, and writing
-    /// it down would disable client installs on that box until the next build —
-    /// the same rule the `Unknown` verdict keeps for the probe.
+    /// The wait grows each time and stops growing at the cap, and a due wait is
+    /// no wait at all. Nothing is remembered forever: a repair that failed for
+    /// any reason — a short upload, a host that dropped, a control plane without
+    /// the slice — is always tried again, which is why none of those has to be
+    /// told apart from a machine that truly cannot take the client.
+    #[test]
+    fn a_failed_repair_waits_longer_each_time_and_never_stops_being_retried() {
+        let note = std::path::PathBuf::from(format!(
+            "/tmp/termiod-repair-{}-backoff",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&note);
+
+        // Nothing remembered is nothing to wait for.
+        assert_eq!(client_repair_waiting(Some(&note), WANT), None);
+
+        let first = delay_client_repair(Some(&note), WANT);
+        assert_eq!(first, CLIENT_REPAIR_WAIT);
+        let second = delay_client_repair(Some(&note), WANT);
+        assert!(second > first, "{second:?} should outgrow {first:?}");
+
+        // It is a wait, and a short one: the box is tried again.
+        let waiting = client_repair_waiting(Some(&note), WANT).expect("a wait");
+        assert!(waiting <= second);
+
+        // Growing stops somewhere, so it never becomes a refusal in disguise.
+        let mut wait = second;
+        for _ in 0..32 {
+            wait = delay_client_repair(Some(&note), WANT);
+        }
+        assert_eq!(wait, CLIENT_REPAIR_WAIT_CAP);
+
+        // Another build's client is other bytes, and gets its own first chance.
+        assert_eq!(client_repair_waiting(Some(&note), "0.45.0+1700"), None);
+        // And a client that installs forgets the whole thing.
+        clear_client_repair(Some(&note));
+        assert_eq!(client_repair_waiting(Some(&note), WANT), None);
+    }
+
+    /// A repair that did not take is put off, never written off — and a failure
+    /// that never ran the binary is not reported as the binary's fault. ssh
+    /// dropping for a second says nothing about whether this client can live on
+    /// that box, so it costs a short wait and nothing else.
     #[tokio::test]
-    async fn a_dropped_connection_does_not_disable_the_client_on_a_box() {
+    async fn a_dropped_connection_only_delays_the_next_client_repair() {
         let note = std::path::PathBuf::from(format!(
             "/tmp/termiod-repair-{}-dropped",
             std::process::id()
@@ -3166,20 +3279,25 @@ mod tests {
         node.unreachable_put = true;
         let report = reconcile(&node, WANT, Options::default()).await;
 
-        // Usable, said out loud, and still worth trying again next time.
+        // Usable, said out loud, and not blamed on a binary nothing ran.
         match &report.outcome {
-            Outcome::Current { client: Some(_), .. } => {}
+            Outcome::Current { client: Some(_), client_failed, .. } => {
+                assert!(!client_failed, "{report:?}");
+            }
             other => panic!("expected current with a client note, got {other:?}"),
         }
-        assert!(!note.exists(), "a transport failure is not a verdict on the client");
+        assert_eq!(report.exit_code(), 0, "a dropped connection is not a failed deploy");
+        // Put off by the first wait, not abandoned: the same build is tried again.
+        let waiting = client_repair_waiting(Some(&note), WANT).expect("a wait");
+        assert!(waiting <= CLIENT_REPAIR_WAIT, "{waiting:?}");
         let _ = std::fs::remove_file(&note);
     }
 
-    /// And it is remembered, so the next attach does not spend another upload
+    /// And it is put off, so the next attach does not spend another upload
     /// learning the same thing. A machine that can never take this build's
     /// client was otherwise restaged on every single attach, for good.
     #[tokio::test]
-    async fn a_refused_client_repair_is_not_attempted_again_for_the_same_build() {
+    async fn a_failed_client_repair_is_not_attempted_again_right_away() {
         let note = std::path::PathBuf::from(format!(
             "/tmp/termiod-repair-{}-{}",
             std::process::id(),
@@ -3218,7 +3336,8 @@ mod tests {
         assert_eq!(report.exit_code(), 1, "a skewed box is a failed deploy");
         assert!(again.puts.borrow().is_empty(), "{:?}", again.puts.borrow());
 
-        // A later build is a fresh chance, so the note does not apply to it.
+        // A later build is a fresh chance: the wait was about the bytes that
+        // failed, and these are different ones.
         let mut newer = FakeNode::new(
             vec![
                 ok(&status_json_with_client("0.45.0+1700", None, Some("0.45.0+1700"), true, Vec::new())),

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1026,9 +1026,20 @@ pub enum Outcome {
         daemon: Option<String>,
         busy: Vec<SessionSummary>,
     },
-    /// The new daemon did not verify. `rolled_back` means the previous binary is
-    /// back in place and whatever it autostarts next is the build that worked.
-    Unhealthy { message: String, rolled_back: bool },
+    /// A plane did not verify. `rolled_back` means what this run installed there
+    /// has been put back, so whatever runs next is the build that worked.
+    ///
+    /// `client_only` says which plane: with it set the daemon answered as the
+    /// build wanted and nothing on the box was stopped — only the `termio`
+    /// client is unusable, and the next reconcile restages it. Older reports
+    /// carry no such field and are all daemon failures, which is what its
+    /// default says.
+    Unhealthy {
+        message: String,
+        rolled_back: bool,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        client_only: bool,
+    },
     /// The transport failed; nothing on the node was touched.
     Unreachable { message: String },
     /// A step failed in a way the loop could not classify.
@@ -1092,15 +1103,20 @@ impl Report {
                 text.push_str("\nRun this again once it finishes, or pass --force to stop it now.");
                 text
             }
+            // The message carries its own framing — which plane failed is not
+            // something this line may assume, now that a client can fail on a
+            // box whose daemon came up perfectly and kept every session.
             Outcome::Unhealthy {
                 message,
                 rolled_back,
+                client_only,
             } => format!(
-                "{node}: the new termiod did not come up — {message}{}",
-                if *rolled_back {
-                    "\nThe previous binary is back in place."
-                } else {
-                    ""
+                "{node}: {message}{}",
+                match (*rolled_back, *client_only) {
+                    (true, true) => "\nThe daemon is untouched, and the previous client is back in place.",
+                    (true, false) => "\nThe previous binary is back in place.",
+                    (false, true) => "\nThe daemon is untouched; the next deploy installs the client again.",
+                    (false, false) => "",
                 }
             ),
             Outcome::Unreachable { message } => format!("{node}: unreachable — {message}"),
@@ -1159,16 +1175,24 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // daemon would destroy `termiod.prev`, the box's one rollback
             // point, to repair a file the daemon plane never lost.
             Some(_) => {
+                // `>=`, the same line `verify_client` holds: a client newer than
+                // this build is one a newer plane installed, and restaging would
+                // downgrade what verification would have accepted. Reachable
+                // whenever a rollback put the daemon back without its client.
                 let client_current = node.client_binary().is_none()
                     || status
                         .client
                         .as_ref()
                         .and_then(|client| Version::parse(&client.version))
-                        == Some(want);
+                        .is_some_and(|have| have >= want);
                 (!client_current).then_some(StagePlan::ClientOnly)
             }
         },
     };
+    // Whether this run has a client to answer for at all. Off when the node
+    // installs none (this Mac), and off when the build carries none, so a
+    // daemon-only deploy is never failed against a client nobody sent.
+    let mut client_plane = node.client_binary().is_some();
     let mut staged = None;
     if let Some(plan) = plan {
         match plan {
@@ -1179,8 +1203,9 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                 eprintln!("[deploy] installing the termio {desired} client on {label}…")
             }
         }
-        stage(node, plan).await?;
-        staged = Some(plan);
+        let shipped = stage(node, plan).await?;
+        client_plane = client_plane && shipped.client;
+        staged = shipped.anything().then_some(plan);
         observed = observe(node).await?;
     }
     let Observed::Reported(status) = observed else {
@@ -1298,41 +1323,59 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         }
     }
 
-    match verify(node, want, staged.is_some()).await {
-        Ok((hello, version)) => {
-            if daemon_is_stale || staged.is_some() {
-                // Best effort: a copy that fails costs the *next* upgrade its
-                // free rollback, not this one anything.
-                if let Some(preserve) = node.preserve_command() {
-                    let _ = node.run(&preserve).await;
-                }
-            }
-            Ok(Outcome::Current {
-                version: hello.version.unwrap_or_default(),
-                host_id: hello.host_id,
-                proto: Some(hello.proto),
-                newer: version > want,
-            })
-        }
+    // The two planes are verified — and answered for — separately. Folding the
+    // client's verdict into the daemon's put a box's every live session at the
+    // mercy of one artifact the daemon does not depend on: a truncated `termio`
+    // drove the daemon rollback, whose fallback is `stop --force`, and SIGTERMed
+    // every agent on a box whose daemon had verified perfectly.
+    let (hello, version) = match verify_daemon(node, want).await {
+        Ok(answered) => answered,
         Err(error) => {
-            let message = format!("{error:#}");
-            // A client-only stage touched nothing but the client, so its
-            // rollback restores nothing but the client: handing the daemon
-            // back to `.prev` here would downgrade a plane that never failed.
-            let rolled_back = match staged {
-                Some(StagePlan::ClientOnly) => roll_back_client(node).await.is_ok(),
-                _ => {
-                    let plan = node.rollback_plan();
-                    (staged.is_some() || plan.even_unstaged)
-                        && roll_back(node, &plan).await.is_ok()
-                }
-            };
-            Ok(Outcome::Unhealthy {
+            let message = format!("the new termiod did not come up — {error:#}");
+            let plan = node.rollback_plan();
+            let rolled_back =
+                (staged.is_some() || plan.even_unstaged) && roll_back(node, &plan).await.is_ok();
+            return Ok(Outcome::Unhealthy {
                 message,
                 rolled_back,
-            })
+                client_only: false,
+            });
+        }
+    };
+
+    // The client half is skipped on a box a newer control plane owns — its
+    // client is that plane's to verify — unless this run staged, because what
+    // this run put on disk is this run's to answer for whatever daemon replies.
+    if client_plane && (version == want || staged.is_some()) {
+        if let Err(error) = verify_client(node, want).await {
+            // Undo only what this run did, which for a client that failed to
+            // answer is the client: its own `.prev`, or removal where this run
+            // installed it fresh. A Full stage therefore leaves a verified new
+            // daemon beside no client rather than beside a broken one — a skew,
+            // but a bounded one the next pass closes with a `ClientOnly`
+            // restage, and no session pays for it.
+            let restored = staged.is_some() && roll_back_client(node).await.is_ok();
+            return Ok(Outcome::Unhealthy {
+                message: format!("{error:#}"),
+                rolled_back: restored,
+                client_only: true,
+            });
         }
     }
+
+    if daemon_is_stale || staged.is_some() {
+        // Best effort: a copy that fails costs the *next* upgrade its free
+        // rollback, not this one anything.
+        if let Some(preserve) = node.preserve_command() {
+            let _ = node.run(&preserve).await;
+        }
+    }
+    Ok(Outcome::Current {
+        version: hello.version.unwrap_or_default(),
+        host_id: hello.host_id,
+        proto: Some(hello.proto),
+        newer: version > want,
+    })
 }
 
 /// What a reconcile pass needs to put on the node: the whole build, or only
@@ -1373,12 +1416,17 @@ async fn observe<N: Node>(node: &N) -> Result<Observed> {
 /// it keeps the old inode until it exits, which is the handover wanted. Linux
 /// refuses to open a running executable for writing (`ETXTBSY`), so writing
 /// in place is the one shape that always fails when a box is in use.
-async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<()> {
+async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
     let artifacts = node.artifact().await?;
+    let mut staged = Staged {
+        daemon: false,
+        client: false,
+    };
     let mut command = String::new();
     if plan == StagePlan::Full {
         node.put(&artifacts.daemon, "termiod.new").await?;
         command = swap_command(&node.binary());
+        staged.daemon = true;
     }
     // The client lands in the same pass, with the same discipline, activated
     // by the same shell command — the narrowest window there is for a box to
@@ -1387,23 +1435,34 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<()> {
     // in the same command: a failed stage must leave the box as it was, not
     // holding a new daemon beside an old client — the exact skew this loop
     // exists to prevent — with `.prev` already spent.
+    // A build with no client in it deploys the daemon alone rather than failing:
+    // `cargo build --bin termiod` in a checkout produces exactly that, and a
+    // deploy that worked before this pass must not become one that cannot be
+    // done. Only a real bundle's missing Linux slice is an error, and
+    // `Node::artifact` is where that is refused.
     if let Some(client) = node.client_binary() {
-        let Some(local) = &artifacts.client else {
-            bail!("no termio client in the build for {}", node.label());
-        };
-        node.put(local, "termio.new").await?;
-        let client_swap = swap_command(&client);
-        command = if command.is_empty() {
-            client_swap
-        } else {
-            format!(
-                "{command} && {{ {client_swap} || {{ {}; false; }}; }}",
-                restore_command(&node.binary())
-            )
-        };
+        match &artifacts.client {
+            Some(local) => {
+                node.put(local, "termio.new").await?;
+                let client_swap = swap_command(&client);
+                command = if command.is_empty() {
+                    client_swap
+                } else {
+                    format!(
+                        "{command} && {{ {client_swap} || {{ {}; false; }}; }}",
+                        restore_command(&node.binary())
+                    )
+                };
+                staged.client = true;
+            }
+            None => eprintln!(
+                "[deploy] this build carries no termio client; {} keeps the client it has",
+                node.label()
+            ),
+        }
     }
     if command.is_empty() {
-        return Ok(());
+        return Ok(staged);
     }
     let run = node.run(&command).await?;
     if run.code != 0 {
@@ -1413,44 +1472,55 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<()> {
             last_line(&run.stderr)
         );
     }
-    Ok(())
+    Ok(staged)
 }
 
-/// Upload-activate for one binary: rename the current file to `.prev`, the
-/// `.new` upload over the path — and if that last rename fails, undo it, so a
-/// partial swap never leaves the path empty.
+/// Which planes a stage actually put on the node. A pass that shipped no client
+/// — because this build has none — turns the client plane off for the rest of
+/// the run, so nothing is verified against a client that was never sent.
+#[derive(Debug, Clone, Copy)]
+struct Staged {
+    daemon: bool,
+    client: bool,
+}
+
+impl Staged {
+    fn anything(&self) -> bool {
+        self.daemon || self.client
+    }
+}
+
+/// Upload-activate for one binary: clear any older `.prev`, rename the current
+/// file aside as the new one, put the `.new` upload over the path — and if that
+/// last rename fails, undo it, so a partial swap never leaves the path empty.
+///
+/// Clearing first is what makes `.prev` mean *this* run: after it, the file
+/// exists only where this swap renamed something aside, which is the fact
+/// [`restore_command`] needs and cannot otherwise learn. It runs in a separate
+/// ssh command later, so a shell variable could not carry it; the file's own
+/// presence does. The `.prev` an operator reaches for with `handoff --binary`
+/// still means the same thing — the build the last stage replaced — because a
+/// stage that replaces something always writes it again immediately.
 fn swap_command(target: &str) -> String {
     format!(
-        "chmod +x {target}.new && {{ [ ! -e {target} ] || mv -f {target} {target}.prev; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
+        "rm -f {target}.prev && chmod +x {target}.new && {{ [ ! -e {target} ] || mv -f {target} {target}.prev; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
         restore_command(target)
     )
 }
 
-/// Put a path back the way this run found it: the previous build over it when
-/// there is one, and *gone* when there is not.
+/// Put a path back the way *this run* found it: the build this run renamed
+/// aside, and *gone* when it renamed nothing.
 ///
-/// The removal half is what makes "a failed stage leaves the box as it was"
-/// true on a first install. There, the swap renamed nothing aside (the path
-/// held nothing to rename), so a restore that only knew how to move `.prev`
-/// back was a no-op and the box kept a binary from a stage that had failed —
-/// reported as `Failed` while the new build sat on disk.
+/// Both halves are load-bearing, and both were bugs. The removal is what makes
+/// "a failed stage leaves the box as it was" true on a first install, where the
+/// swap had nothing to rename aside and a restore that only knew `.prev` left
+/// the box holding a binary from a stage that failed. And the restore is scoped
+/// to this run by [`swap_command`] clearing `.prev` first: restoring whatever
+/// `.prev` happened to be on the box would install the build some *earlier*
+/// deploy replaced — a 0.43 client beside a 0.44 daemon, reported as a
+/// successful rollback, which is the skew this whole pass exists to rule out.
 fn restore_command(target: &str) -> String {
     format!("if [ -e {target}.prev ]; then mv -f {target}.prev {target}; else rm -f {target}; fi")
-}
-
-/// The daemon answering as the build wanted, and the client beside it
-/// answering `--version` with at least the same build's stamp. The client
-/// half is skipped on a box a newer control plane owns — its client is that
-/// plane's to verify — and on a node that installs no client at all. Unless
-/// this run staged: what this run just put on disk is this run's to verify,
-/// whatever daemon happens to answer — a newer plane racing this one must
-/// not turn an unverified client into a reported success.
-async fn verify<N: Node>(node: &N, want: Version, staged: bool) -> Result<(DaemonHello, Version)> {
-    let (hello, version) = verify_daemon(node, want).await?;
-    if version == want || staged {
-        verify_client(node, want).await?;
-    }
-    Ok((hello, version))
 }
 
 /// Run the installed client over the node's own shell. Existence is not the
@@ -1860,6 +1930,8 @@ mod tests {
         plan: Option<RollbackPlan>,
         preserve: Option<String>,
         client: Option<String>,
+        /// The client this build would ship. `None` is a daemon-only build.
+        client_artifact: Option<PathBuf>,
     }
 
     impl FakeNode {
@@ -1872,6 +1944,7 @@ mod tests {
                 plan: None,
                 preserve: None,
                 client: Some("$HOME/.local/bin/termio".to_string()),
+                client_artifact: Some(PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl")),
             }
         }
 
@@ -1916,7 +1989,7 @@ mod tests {
         async fn artifact(&self) -> Result<Artifacts> {
             Ok(Artifacts {
                 daemon: PathBuf::from("/bundle/termiod-aarch64-unknown-linux-musl"),
-                client: Some(PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl")),
+                client: self.client_artifact.clone(),
             })
         }
         fn client_binary(&self) -> Option<String> {
@@ -2560,10 +2633,14 @@ mod tests {
         );
     }
 
-    /// A client that does not answer `--version` fails the deploy the same way
-    /// an unhealthy daemon does: the box is rolled back, client included.
+    /// A client that does not answer `--version` is reported and put back, and
+    /// costs the box nothing else. The daemon verified as the build wanted, so
+    /// it is not handed back, not stopped, and not downgraded: the previous
+    /// shape drove the daemon's own rollback from this failure, whose fallback
+    /// is `stop --force`, and spent every live session on the box over one
+    /// artifact the daemon does not depend on.
     #[tokio::test]
-    async fn a_client_that_cannot_answer_version_rolls_the_box_back() {
+    async fn a_client_that_cannot_answer_version_never_touches_the_daemon() {
         let node = FakeNode::new(
             vec![
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
@@ -2571,24 +2648,34 @@ mod tests {
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
                 handed_off(2),
                 failed(126, "cannot execute binary file"), // termio --version
-                ok(""),        // roll back: [ -e prev ]
-                handed_off(2), // roll back: handoff --binary prev
-                ok(""),        // roll back: the daemon
-                ok(""),        // roll back: the client
+                ok(""),                                    // put the client back
             ],
             vec![hello(Some(WANT))],
         );
         let report = reconcile(&node, WANT, Options::default()).await;
         match &report.outcome {
-            Outcome::Unhealthy { message, rolled_back } => {
+            Outcome::Unhealthy {
+                message,
+                rolled_back,
+                client_only,
+            } => {
+                assert!(*client_only, "{report:?}");
                 assert!(*rolled_back, "{report:?}");
                 assert!(message.contains("--version"), "{message}");
             }
             other => panic!("expected unhealthy, got {other:?}"),
         }
         let commands = node.commands.borrow();
+        assert!(!commands.iter().any(|command| command.contains(" stop")), "{commands:?}");
         assert!(
-            commands.iter().any(|command| command == "mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
+            !commands.iter().any(|command| command.contains("handoff --binary")),
+            "{commands:?}"
+        );
+        // The daemon's own restore is a command of its own; `termiod.prev`
+        // inside the stage's activation is the swap keeping a rollback point,
+        // which is not a rollback.
+        assert!(
+            !commands.iter().any(|command| command == "mv -f $HOME/.local/bin/termiod.prev $HOME/.local/bin/termiod"),
             "{commands:?}"
         );
         // The client's restore names the removal too: a first-time client has
@@ -2596,6 +2683,31 @@ mod tests {
         let client = commands.last().unwrap();
         assert!(client.contains("mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"), "{client}");
         assert!(client.contains("rm -f $HOME/.local/bin/termio"), "{client}");
+    }
+
+    /// A build with no client in it deploys the daemon alone: nothing is put
+    /// there for the client, and nothing is verified against one. A control
+    /// plane run out of a checkout (`cargo build --bin termiod`) is this, and
+    /// failing it would turn a Mac→Mac deploy that worked into one that cannot
+    /// be done.
+    #[tokio::test]
+    async fn a_build_carrying_no_client_deploys_the_daemon_alone() {
+        let mut node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        node.client_artifact = None;
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        assert!(node.puts.borrow().is_empty(), "{:?}", node.puts.borrow());
+        let commands = node.commands.borrow();
+        assert!(
+            !commands.iter().any(|command| command.contains("termio --version")),
+            "{commands:?}"
+        );
     }
 
     /// ssh failing is `unreachable`, kept apart from a step that ran and failed.

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -246,6 +246,28 @@ pub struct NodeStatus {
     /// running daemon: it is a file beside the socket.
     pub host_id: Option<String>,
     pub supervisor: Supervisor,
+    /// The machine's operating system, as the binary answering knows it
+    /// (`macos`, `linux`). Absent from a build too old to report it.
+    ///
+    /// It is here so the control plane can decide what a machine needs without
+    /// asking it a second question: `uname -sm` is a round trip on every deploy
+    /// and every attach, and the machine has already answered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os: Option<String>,
+}
+
+impl NodeStatus {
+    /// Whether this machine takes a `termio` client from a deploy.
+    ///
+    /// The same rule `remote::target_takes_a_client` applies to a detected
+    /// target, answered from the machine's own report instead: a Mac links its
+    /// own client from its app bundle and is sent none. A build too old to name
+    /// its OS is treated as a box, which is what every machine this loop had
+    /// deployed to before Macs were reachable was — and the first upgrade makes
+    /// it answer for itself.
+    pub fn takes_a_client(&self) -> bool {
+        self.os.as_deref() != Some("macos")
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -379,6 +401,7 @@ pub async fn status() -> Result<NodeStatus> {
         sessions,
         host_id,
         supervisor: detect_supervisor().await,
+        os: Some(std::env::consts::OS.to_string()),
     })
 }
 
@@ -1177,11 +1200,17 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // daemon would destroy `termiod.prev`, the box's one rollback
             // point, to repair a file the daemon plane never lost.
             Some(_) => {
+                // A machine that takes no client — a Mac, which links its own
+                // from its app bundle — is current by having none. Asked only of
+                // the node's own report, never of the network: planning a client
+                // pass for one meant a `uname` round trip on every deploy and
+                // every attach, to stage nothing and say so wrongly.
+                let takes_client = node.client_binary().is_some() && status.takes_a_client();
                 // `>=`, the same line `verify_client` holds: a client newer than
                 // this build is one a newer plane installed, and restaging would
                 // downgrade what verification would have accepted. Reachable
                 // whenever a rollback put the daemon back without its client.
-                let client_current = node.client_binary().is_none()
+                let client_current = !takes_client
                     || status
                         .client
                         .as_ref()
@@ -1191,10 +1220,6 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             }
         },
     };
-    // Whether this run has a client to answer for at all. Off when the node
-    // installs none (this Mac), and off when the build carries none, so a
-    // daemon-only deploy is never failed against a client nobody sent.
-    let mut client_plane = node.client_binary().is_some();
     // What this run put on the node, per plane. Every undo below reads this and
     // nothing else: a run that staged only the client may not touch the daemon,
     // and one that staged no client may not touch the client — the box's own,
@@ -1205,7 +1230,6 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     };
     if let Some(plan) = plan {
         staged = stage(node, plan).await?;
-        client_plane = client_plane && staged.client;
         match (staged.daemon, staged.client) {
             (true, true) => eprintln!("[deploy] installed termiod {desired} and its client on {label}"),
             (true, false) => eprintln!("[deploy] installed termiod {desired} on {label}"),
@@ -1357,25 +1381,26 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         }
     };
 
-    // The client half is skipped on a box a newer control plane owns — its
-    // client is that plane's to verify — unless this run staged, because what
-    // this run put on disk is this run's to answer for whatever daemon replies.
+    // Only a client this run put there is verified here. One that was already
+    // on the box answered for itself in the `status` this pass already read —
+    // that reading is an execution of the same binary, not a stat — so asking
+    // again would spend an ssh round trip, before every attach, to learn what
+    // the machine has just said.
     let mut client_trouble = None;
-    if client_plane && (version == want || staged.anything()) {
+    if staged.client {
         if let Err(error) = verify_client(node, want).await {
-            // Undo only what this run did, which for a client that failed to
-            // answer is the client — and only where this run installed one. A
-            // Full stage therefore leaves a verified new daemon beside no
-            // client rather than beside a broken one: a skew, but a bounded one
-            // the next pass closes with a `ClientOnly` restage, and no session
-            // pays for it.
-            let put_back = staged.client && roll_back_client(node).await.is_ok();
+            // Undo what this run did, which for a client that failed to answer
+            // is the client. A Full stage therefore leaves a verified new daemon
+            // beside no client rather than beside a broken one: a skew, but a
+            // bounded one the next pass closes with a `ClientOnly` restage, and
+            // no session pays for it.
+            let put_back = roll_back_client(node).await.is_ok();
             client_trouble = Some(format!(
                 "{error:#}{}",
-                match (staged.client, put_back) {
-                    (false, _) => "; it was already there, and is left as it is",
-                    (true, true) => "; the previous client is back in place, and the next deploy installs this build's again",
-                    (true, false) => "; it could not be put back, and the next deploy installs this build's again",
+                if put_back {
+                    "; the previous client is back in place, and the next deploy installs this build's again"
+                } else {
+                    "; it could not be put back, and the next deploy installs this build's again"
                 }
             ));
         }
@@ -1454,31 +1479,25 @@ async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
     // in the same command: a failed stage must leave the box as it was, not
     // holding a new daemon beside an old client — the exact skew this loop
     // exists to prevent — with `.prev` already spent.
-    // A build with no client in it deploys the daemon alone rather than failing:
-    // `cargo build --bin termiod` in a checkout produces exactly that, and a
-    // deploy that worked before this pass must not become one that cannot be
-    // done. Only a real bundle's missing Linux slice is an error, and
-    // `Node::artifact` is where that is refused.
-    if let Some(client) = node.client_binary() {
-        match &artifacts.client {
-            Some(local) => {
-                node.put(local, "termio.new").await?;
-                let client_swap = swap_command(&client);
-                command = if command.is_empty() {
-                    client_swap
-                } else {
-                    format!(
-                        "{command} && {{ {client_swap} || {{ {}; false; }}; }}",
-                        restore_command(&node.binary())
-                    )
-                };
-                staged.client = true;
-            }
-            None => eprintln!(
-                "[deploy] this build carries no termio client; {} keeps the client it has",
-                node.label()
-            ),
-        }
+    // A build with no client for this node deploys the daemon alone rather than
+    // failing: a Mac is sent none by design, and `cargo build --bin termiod` in
+    // a checkout produces none at all — a deploy that worked before this pass
+    // must not become one that cannot be done. Only a real bundle's missing
+    // Linux slice is an error, and `Node::artifact` is where that is refused.
+    // Silent here because neither case is a degradation this step discovered:
+    // the artifact source names the one that is.
+    if let (Some(local), Some(client)) = (&artifacts.client, node.client_binary()) {
+        node.put(local, "termio.new").await?;
+        let client_swap = swap_command(&client);
+        command = if command.is_empty() {
+            client_swap
+        } else {
+            format!(
+                "{command} && {{ {client_swap} || {{ {}; false; }}; }}",
+                restore_command(&node.binary())
+            )
+        };
+        staged.client = true;
     }
     if command.is_empty() {
         return Ok(staged);
@@ -1509,20 +1528,26 @@ impl Staged {
     }
 }
 
-/// Upload-activate for one binary: clear any older `.prev`, rename the current
-/// file aside as the new one, put the `.new` upload over the path — and if that
-/// last rename fails, undo it, so a partial swap never leaves the path empty.
+/// Upload-activate for one binary: rename the current file aside as `.prev`,
+/// put the `.new` upload over the path — and if that last rename fails, undo it,
+/// so a partial swap never leaves the path empty.
 ///
-/// Clearing first is what makes `.prev` mean *this* run: after it, the file
-/// exists only where this swap renamed something aside, which is the fact
-/// [`restore_command`] needs and cannot otherwise learn. It runs in a separate
-/// ssh command later, so a shell variable could not carry it; the file's own
-/// presence does. The `.prev` an operator reaches for with `handoff --binary`
-/// still means the same thing — the build the last stage replaced — because a
-/// stage that replaces something always writes it again immediately.
+/// The rename-aside is also what makes `.prev` mean *this* run: it either moves
+/// this run's replaced build there, or, where there was nothing to replace,
+/// clears whatever an older run left. That is the fact [`restore_command`] needs
+/// and cannot otherwise learn — it runs in a separate ssh command later, so a
+/// shell variable could not carry it, but the file's own presence can. The
+/// `.prev` an operator reaches for with `handoff --binary` still means what it
+/// always did: the build the last stage replaced.
+///
+/// Both halves sit in the *same* step on purpose. Clearing `.prev` in a step of
+/// its own ran before anything could put one back, so a stage that then failed
+/// at `chmod` — a short upload, a noexec mount — short-circuited the `&&` chain
+/// with no restore, and left a box running its old daemon with no rollback point
+/// for the next upgrade to hand back to.
 fn swap_command(target: &str) -> String {
     format!(
-        "rm -f {target}.prev && chmod +x {target}.new && {{ [ ! -e {target} ] || mv -f {target} {target}.prev; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
+        "chmod +x {target}.new && {{ if [ -e {target} ]; then mv -f {target} {target}.prev; else rm -f {target}.prev; fi; }} && {{ mv -f {target}.new {target} || {{ {}; false; }}; }}",
         restore_command(target)
     )
 }
@@ -2093,8 +2118,19 @@ mod tests {
             sessions,
             host_id: Some("h_1".to_string()),
             supervisor: Supervisor::None,
+            os: Some("linux".to_string()),
         })
         .expect("status serializes")
+    }
+
+    /// What a Mac reachable over ssh reports: it links its own client from its
+    /// app bundle, so it is sent none and is not missing one.
+    fn status_json_from_a_mac(binary: &str, daemon: Option<&str>) -> String {
+        let mut status: serde_json::Value =
+            serde_json::from_str(&status_json_with_client(binary, None, daemon, true, Vec::new()))
+                .expect("status parses");
+        status["os"] = "macos".into();
+        status.to_string()
     }
 
     /// A shell at its prompt with someone attached: alive, not busy — exactly
@@ -2778,6 +2814,44 @@ mod tests {
         let client = commands.last().unwrap();
         assert!(client.contains("mv -f $HOME/.local/bin/termio.prev $HOME/.local/bin/termio"), "{client}");
         assert!(client.contains("rm -f $HOME/.local/bin/termio"), "{client}");
+    }
+
+    /// A Mac reachable over ssh is current with no client of the deploy's: it
+    /// links its own from its app bundle. Nothing is staged, and — the point —
+    /// nothing is *asked*: planning a client pass for it meant a `uname` round
+    /// trip on every deploy and every attach, to ship nothing and say so
+    /// wrongly.
+    #[tokio::test]
+    async fn a_mac_box_is_current_without_a_client_and_without_asking() {
+        let node = FakeNode::new(
+            vec![ok(&status_json_from_a_mac(WANT, Some(WANT)))],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { client: None, .. }), "{report:?}");
+        assert!(node.puts.borrow().is_empty(), "{:?}", node.puts.borrow());
+        // One command: the status read. No artifact resolution, no client probe.
+        let commands = node.commands.borrow();
+        assert_eq!(commands.len(), 1, "{commands:?}");
+        assert!(commands[0].ends_with("status --json"), "{commands:?}");
+    }
+
+    /// A client already on the box answered for itself in the `status` this pass
+    /// read — that reading executes it — so nothing re-asks it over ssh before
+    /// every attach.
+    #[tokio::test]
+    async fn a_client_already_in_place_is_not_probed_again() {
+        let node = FakeNode::new(
+            vec![ok(&status_json(WANT, Some(WANT), true))],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { client: None, .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        assert!(
+            !commands.iter().any(|command| command.ends_with("termio --version")),
+            "{commands:?}"
+        );
     }
 
     /// A build with no client in it deploys the daemon alone: nothing is put

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -416,21 +416,7 @@ pub async fn status() -> Result<NodeStatus> {
 /// itself, and a wedged client must not turn it into a hang.
 async fn client_beside_this_binary() -> Option<BinaryStatus> {
     let candidate = paired_client()?;
-    let answered = tokio::time::timeout(Duration::from_secs(5), async {
-        tokio::process::Command::new(&candidate)
-            .arg("--version")
-            .stdin(std::process::Stdio::null())
-            .kill_on_drop(true)
-            .output()
-            .await
-            .ok()
-    })
-    .await
-    .ok()
-    .flatten();
-    let stamp = answered
-        .filter(|output| output.status.success())
-        .and_then(|output| version_stamp(&String::from_utf8_lossy(&output.stdout)));
+    let (_, stamp) = binary_version(&candidate).await;
     Some(BinaryStatus {
         version: stamp.unwrap_or_default(),
         path: candidate.display().to_string(),
@@ -739,7 +725,7 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
     // explicit `--binary` naming an older compatible build is a legitimate
     // request — a rollback — and checking it against this CLI's own stamp would
     // report a handoff that worked as one that failed.
-    let (want, want_text) = binary_version(&binary);
+    let (want, want_text) = binary_version(&binary).await;
 
     let socket = paths::socket_path()?;
     let Some(mut stream) = connect_existing(&socket).await else {
@@ -880,18 +866,25 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
 /// the way to failing is not an answer, and `verify_client` holds the same
 /// line — a probe that accepted it would mask exactly what verification
 /// exists to catch.
-pub(crate) fn binary_version(binary: &Path) -> (Option<Version>, Option<String>) {
-    let Ok(output) = std::process::Command::new(binary)
-        .arg("--version")
-        .stdin(std::process::Stdio::null())
-        .output()
-    else {
-        return (None, None);
-    };
-    if !output.status.success() {
-        return (None, None);
-    }
-    let stamp = version_stamp(&String::from_utf8_lossy(&output.stdout));
+/// Bounded, because a binary that blocks on `--version` is one of the things
+/// this is looking for: a wrapper waiting on the network, a wedged home
+/// directory. Unbounded, it hung the command that asked with nothing on screen.
+pub(crate) async fn binary_version(binary: &Path) -> (Option<Version>, Option<String>) {
+    let answered = tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::process::Command::new(binary)
+            .arg("--version")
+            .stdin(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .output()
+            .await
+            .ok()
+    })
+    .await
+    .ok()
+    .flatten();
+    let stamp = answered
+        .filter(|output| output.status.success())
+        .and_then(|output| version_stamp(&String::from_utf8_lossy(&output.stdout)));
     (stamp.as_deref().and_then(Version::parse), stamp)
 }
 
@@ -991,6 +984,21 @@ pub trait Node {
     /// expects to find it, run after an upgrade verifies. `None` where staging
     /// already left `.prev` behind.
     fn preserve_command(&self) -> Option<String> {
+        None
+    }
+
+    /// Where this control plane may note that the machine would not take a
+    /// build's client, so a repair that can only fail is not retried on every
+    /// attach. Stamped with the build that failed, so a later build gets its own
+    /// chance and a machine that starts accepting one is forgotten as soon as it
+    /// does.
+    ///
+    /// `None` turns the memory off, which is right for a node that installs no
+    /// client at all — and keeps a node that is not a real machine from writing
+    /// anywhere. Only a client-*only* pass consults it: a daemon upgrade is
+    /// sending a build to the machine regardless, and the client rides along for
+    /// almost nothing.
+    fn client_repair_note(&self) -> Option<PathBuf> {
         None
     }
 }
@@ -1225,7 +1233,9 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                         .as_ref()
                         .and_then(|client| Version::parse(&client.version))
                         .is_some_and(|have| have >= want);
-                (!client_current).then_some(StagePlan::ClientOnly)
+                (!client_current
+                    && !client_repair_refused(node.client_repair_note().as_deref(), desired))
+                    .then_some(StagePlan::ClientOnly)
             }
         },
     };
@@ -1233,9 +1243,23 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // nothing else: a run that staged only the client may not touch the daemon,
     // and one that staged no client may not touch the client — the box's own,
     // which it has been using all along, is not this run's to restore or remove.
+    let repair_note = node.client_repair_note();
     let mut staged = Staged::default();
     if let Some(plan) = plan {
-        staged = stage(node, plan).await?;
+        staged = match stage(node, plan).await {
+            Ok(staged) => staged,
+            // A client-only pass may not fail the reconcile. It repairs a machine
+            // whose daemon is already the build wanted, and it runs before every
+            // attach — so an upload that fails, or an activation that does, would
+            // have made a healthy box unreachable ("Couldn't set up termiod on
+            // …") over the CLI inside its sessions.
+            Err(error) if plan == StagePlan::ClientOnly => {
+                eprintln!("[deploy] {label}'s client could not be installed ({error:#}); leaving it as it is");
+                remember_client_repair(repair_note.as_deref(), Some(desired));
+                Staged::default()
+            }
+            Err(error) => return Err(error),
+        };
         match (staged.daemon, staged.client) {
             (true, true) => eprintln!("[deploy] installed termiod {desired} and its client on {label}"),
             (true, false) => eprintln!("[deploy] installed termiod {desired} on {label}"),
@@ -1394,21 +1418,32 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // the machine has just said.
     let mut client_trouble = None;
     if staged.client {
-        if let Err(error) = verify_client(node, want).await {
+        match verify_client(node, want).await {
+            ClientVerdict::Good => remember_client_repair(repair_note.as_deref(), None),
             // Undo what this run did, which for a client that failed to answer
             // is the client. A Full stage therefore leaves a verified new daemon
             // beside no client rather than beside a broken one: a skew, but a
             // bounded one the next pass closes with a `ClientOnly` restage, and
             // no session pays for it.
-            let put_back = roll_back_client(node, staged.client_replaced).await.is_ok();
-            client_trouble = Some(format!(
-                "{error:#}{}",
-                if put_back {
-                    "; the previous client is back in place, and the next deploy installs this build's again"
-                } else {
-                    "; it could not be put back, and the next deploy installs this build's again"
-                }
-            ));
+            ClientVerdict::Bad(message) => {
+                let put_back = roll_back_client(node, staged.client_replaced).await.is_ok();
+                // Written down so the next pass does not spend another upload
+                // learning the same thing. A machine that cannot take this build's
+                // client — a noexec mount, a denied exec, a full disk — was
+                // otherwise restaged on every attach, for good.
+                remember_client_repair(repair_note.as_deref(), Some(desired));
+                client_trouble = Some(format!(
+                    "{message}{}",
+                    if put_back {
+                        "; the previous client is back in place, and a later build installs one again"
+                    } else {
+                        "; it could not be put back, and a later build installs one again"
+                    }
+                ));
+            }
+            // Nothing was learned about the client, so nothing is undone: what
+            // this run installed stays, and the next pass asks again.
+            ClientVerdict::Unknown(message) => client_trouble = Some(message),
         }
     }
 
@@ -1434,6 +1469,30 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
 enum StagePlan {
     Full,
     ClientOnly,
+}
+
+/// Whether this control plane already found that the machine will not take the
+/// client of build `desired`.
+fn client_repair_refused(note: Option<&Path>, desired: &str) -> bool {
+    note.and_then(|path| std::fs::read_to_string(path).ok())
+        .is_some_and(|stamp| stamp.trim() == desired)
+}
+
+/// Write down that `desired`'s client would not install here, or forget it
+/// (`None`) because one just did.
+fn remember_client_repair(note: Option<&Path>, desired: Option<&str>) {
+    let Some(path) = note else { return };
+    match desired {
+        Some(stamp) => {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(path, stamp);
+        }
+        None => {
+            let _ = std::fs::remove_file(path);
+        }
+    }
 }
 
 async fn observe<N: Node>(node: &N) -> Result<Observed> {
@@ -1467,19 +1526,11 @@ async fn observe<N: Node>(node: &N) -> Result<Observed> {
 /// refuses to open a running executable for writing (`ETXTBSY`), so writing
 /// in place is the one shape that always fails when a box is in use.
 async fn stage<N: Node>(node: &N, plan: StagePlan) -> Result<Staged> {
-    let client_only = plan == StagePlan::ClientOnly;
-    let artifacts = match node.artifact(client_only).await {
-        Ok(artifacts) => artifacts,
-        // A client-only pass repairs a machine whose daemon is already the
-        // build wanted, and it runs before every attach. A control plane that
-        // cannot produce the client leaves it alone rather than failing the
-        // reconcile — the alternative made attaching to a healthy box an error.
-        Err(error) if client_only => {
-            eprintln!("[deploy] {}; leaving {}'s client alone", format!("{error:#}"), node.label());
-            return Ok(Staged::default());
-        }
-        Err(error) => return Err(error),
-    };
+    // Every failure here is the caller's to judge: a client-only pass is allowed
+    // to fail without failing the reconcile, and that holds for the artifact it
+    // cannot produce, the upload that does not land, and the activation that does
+    // not run — not only the first of the three.
+    let artifacts = node.artifact(plan == StagePlan::ClientOnly).await?;
     let mut staged = Staged::default();
     let mut command = String::new();
     if plan == StagePlan::Full {
@@ -1625,28 +1676,59 @@ fn restore_command(target: &str, replaced: bool) -> String {
 /// question — `stage` just put it there — but a wrong-architecture slice or a
 /// truncated copy execs and fails, and finding that out here, while `.prev` is
 /// still beside it, is the whole point of verifying before reporting.
-async fn verify_client<N: Node>(node: &N, want: Version) -> Result<()> {
+async fn verify_client<N: Node>(node: &N, want: Version) -> ClientVerdict {
     let Some(client) = node.client_binary() else {
-        return Ok(());
+        return ClientVerdict::Good;
     };
-    let run = node.run(&format!("{client} --version")).await?;
-    if run.code != 0 {
-        bail!(
-            "the client at {client} does not answer --version: {}",
-            last_line(&run.stderr)
-        );
+    // Retried within the same budget the daemon probe uses, and for the same
+    // reason: ssh failing is not the client answering. Taken as a verdict, a
+    // dropped connection during the probe had the loop delete the very client it
+    // had just correctly installed.
+    let deadline = Instant::now() + SETTLE;
+    let mut unreachable = String::new();
+    loop {
+        match node.run(&format!("{client} --version")).await {
+            Ok(run) if run.code != 0 => {
+                return ClientVerdict::Bad(format!(
+                    "the client at {client} does not answer --version: {}",
+                    last_line(&run.stderr)
+                ))
+            }
+            Ok(run) => {
+                return match run.stdout.split_whitespace().find_map(Version::parse) {
+                    Some(stamp) if stamp >= want => ClientVerdict::Good,
+                    Some(_) => ClientVerdict::Bad(format!(
+                        "the client at {client} answers as an older build ({})",
+                        last_line(&run.stdout)
+                    )),
+                    None => ClientVerdict::Bad(format!(
+                        "the client at {client} answers --version with no build stamp ({})",
+                        last_line(&run.stdout)
+                    )),
+                }
+            }
+            Err(error) => unreachable = format!("{error:#}"),
+        }
+        if Instant::now() >= deadline {
+            return ClientVerdict::Unknown(format!(
+                "could not reach {} to check the client at {client}: {unreachable}",
+                node.label()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    match run.stdout.split_whitespace().find_map(Version::parse) {
-        Some(stamp) if stamp >= want => Ok(()),
-        Some(_) => bail!(
-            "the client at {client} answers as an older build ({})",
-            last_line(&run.stdout)
-        ),
-        None => bail!(
-            "the client at {client} answers --version with no build stamp ({})",
-            last_line(&run.stdout)
-        ),
-    }
+}
+
+/// What a probe of the installed client established.
+enum ClientVerdict {
+    /// It answered as the build wanted, or newer.
+    Good,
+    /// It answered, and the answer is the client's own fault.
+    Bad(String),
+    /// The machine could not be asked, so nothing about the client is known.
+    /// Never grounds for undoing an install: a dropped connection is not a
+    /// verdict on a binary, and the next pass asks again.
+    Unknown(String),
 }
 
 /// Handshake with whatever answers now — which, after a stop, is the daemon
@@ -2036,6 +2118,8 @@ mod tests {
         client: Option<String>,
         /// The client this build would ship. `None` is a daemon-only build.
         client_artifact: Option<PathBuf>,
+        /// Where a refused client repair is remembered, when a test cares.
+        repair_note: Option<PathBuf>,
     }
 
     impl FakeNode {
@@ -2049,6 +2133,7 @@ mod tests {
                 preserve: None,
                 client: Some("$HOME/.local/bin/termio".to_string()),
                 client_artifact: Some(PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl")),
+                repair_note: None,
             }
         }
 
@@ -2114,6 +2199,9 @@ mod tests {
         }
         fn preserve_command(&self) -> Option<String> {
             self.preserve.clone()
+        }
+        fn client_repair_note(&self) -> Option<PathBuf> {
+            self.repair_note.clone()
         }
     }
 
@@ -2944,6 +3032,109 @@ mod tests {
         // It records what it renamed aside, which is what the undo reads.
         assert!(activation.contains("termiod_replaced=1"), "{activation}");
         assert!(activation.contains("termio_replaced=1"), "{activation}");
+    }
+
+    /// ssh failing during the client probe is not the client answering. Taken as
+    /// a verdict it deleted the very client the same pass had just correctly
+    /// installed, so an unreachable machine leaves the install alone and says it
+    /// could not tell — the next pass asks again.
+    ///
+    /// Slow on purpose: it waits out the same `SETTLE` budget the daemon probe
+    /// retries within, which is what a network blip needs to pass.
+    #[tokio::test]
+    async fn an_unreachable_box_does_not_cost_the_client_it_just_installed() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                staged_over_a_client(),
+                ok(&status_json(WANT, Some(WANT), true)),
+                // Every `termio --version` attempt after this finds no scripted
+                // answer, which the fake reports as a transport error.
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        match &report.outcome {
+            Outcome::Current { client: Some(note), .. } => {
+                assert!(note.contains("could not reach"), "{note}");
+            }
+            other => panic!("expected current with an unknown-client note, got {other:?}"),
+        }
+        // The client it installed is still there: nothing restored, nothing removed.
+        let commands = node.commands.borrow();
+        let client_restore = restore_command("$HOME/.local/bin/termio", false);
+        let client_revert = restore_command("$HOME/.local/bin/termio", true);
+        assert!(
+            !commands.iter().any(|command| command == &client_restore || command == &client_revert),
+            "{commands:?}"
+        );
+    }
+
+    /// A client-only pass whose upload or activation fails leaves the machine
+    /// attachable. Its daemon is the build wanted and every session on it is
+    /// running; failing the reconcile turned reaching a healthy box into
+    /// "Couldn't set up termiod on …" over the CLI inside its sessions.
+    #[tokio::test]
+    async fn a_client_repair_that_will_not_install_still_leaves_the_box_usable() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                failed(1, "mv: cannot move: Read-only file system"), // activation
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+    }
+
+    /// And it is remembered, so the next attach does not spend another upload
+    /// learning the same thing. A machine that can never take this build's
+    /// client was otherwise restaged on every single attach, for good.
+    #[tokio::test]
+    async fn a_refused_client_repair_is_not_attempted_again_for_the_same_build() {
+        let note = std::path::PathBuf::from(format!(
+            "/tmp/termiod-repair-{}-{}",
+            std::process::id(),
+            "refused"
+        ));
+        let _ = std::fs::remove_file(&note);
+        let mut node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                failed(1, "mv: cannot move: Read-only file system"),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        node.repair_note = Some(note.clone());
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+
+        // The next pass: the same box, the same build, and nothing sent.
+        let mut again = FakeNode::new(
+            vec![ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new()))],
+            vec![hello(Some(WANT))],
+        );
+        again.repair_note = Some(note.clone());
+        let report = reconcile(&again, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        assert!(again.puts.borrow().is_empty(), "{:?}", again.puts.borrow());
+
+        // A later build is a fresh chance, so the note does not apply to it.
+        let mut newer = FakeNode::new(
+            vec![
+                ok(&status_json_with_client("0.45.0+1700", None, Some("0.45.0+1700"), true, Vec::new())),
+                staged_over_a_client(),
+                ok(&status_json("0.45.0+1700", Some("0.45.0+1700"), true)),
+                ok("termio 0.45.0+1700 (release)"),
+            ],
+            vec![hello(Some("0.45.0+1700"))],
+        );
+        newer.repair_note = Some(note.clone());
+        let report = reconcile(&newer, "0.45.0+1700", Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { client: None, .. }), "{report:?}");
+        assert_eq!(newer.puts.borrow().len(), 1);
+
+        let _ = std::fs::remove_file(&note);
     }
 
     /// A client-only pass on a control plane that cannot produce a client leaves

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1018,6 +1018,14 @@ pub enum Outcome {
         proto: Option<u32>,
         /// Another control plane put a newer build here. Left alone.
         newer: bool,
+        /// What went wrong with the `termio` client beside the daemon, when
+        /// something did. The daemon is still the build wanted and the machine
+        /// is still usable — that is why this rides `Current` rather than a
+        /// failure: a report that could not name the host would have every
+        /// reader treat a healthy box as unusable. The next reconcile restages
+        /// the client on its own.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client: Option<String>,
     },
     /// The binary is in place and the daemon still running is the old one.
     /// `busy` is why it was not stopped — empty when stopping was not asked for.
@@ -1026,20 +1034,11 @@ pub enum Outcome {
         daemon: Option<String>,
         busy: Vec<SessionSummary>,
     },
-    /// A plane did not verify. `rolled_back` means what this run installed there
-    /// has been put back, so whatever runs next is the build that worked.
-    ///
-    /// `client_only` says which plane: with it set the daemon answered as the
-    /// build wanted and nothing on the box was stopped — only the `termio`
-    /// client is unusable, and the next reconcile restages it. Older reports
-    /// carry no such field and are all daemon failures, which is what its
-    /// default says.
-    Unhealthy {
-        message: String,
-        rolled_back: bool,
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-        client_only: bool,
-    },
+    /// The new daemon did not verify. `rolled_back` means the previous binary is
+    /// back in place and whatever it autostarts next is the build that worked.
+    /// Only ever the daemon: a client that fails verification leaves the machine
+    /// running and is reported on `Current`.
+    Unhealthy { message: String, rolled_back: bool },
     /// The transport failed; nothing on the node was touched.
     Unreachable { message: String },
     /// A step failed in a way the loop could not classify.
@@ -1057,6 +1056,9 @@ pub struct Report {
 impl Report {
     pub fn exit_code(&self) -> i32 {
         match self.outcome {
+            // A client that did not verify is still a failed deploy for whoever
+            // ran one, even though the machine came out of it working.
+            Outcome::Current { client: Some(_), .. } => 1,
             Outcome::Current { .. } => 0,
             Outcome::Staged { .. } => EXIT_BUSY,
             _ => 1,
@@ -1071,13 +1073,18 @@ impl Report {
                 version,
                 host_id,
                 newer,
+                client,
                 ..
             } => format!(
-                "{node}: termiod {version} is running (host {host_id}){}",
+                "{node}: termiod {version} is running (host {host_id}){}{}",
                 if *newer {
                     " — newer than this build, left alone"
                 } else {
                     ""
+                },
+                match client {
+                    Some(trouble) => format!("\n{trouble}"),
+                    None => String::new(),
                 }
             ),
             Outcome::Staged {
@@ -1103,20 +1110,15 @@ impl Report {
                 text.push_str("\nRun this again once it finishes, or pass --force to stop it now.");
                 text
             }
-            // The message carries its own framing — which plane failed is not
-            // something this line may assume, now that a client can fail on a
-            // box whose daemon came up perfectly and kept every session.
             Outcome::Unhealthy {
                 message,
                 rolled_back,
-                client_only,
             } => format!(
-                "{node}: {message}{}",
-                match (*rolled_back, *client_only) {
-                    (true, true) => "\nThe daemon is untouched, and the previous client is back in place.",
-                    (true, false) => "\nThe previous binary is back in place.",
-                    (false, true) => "\nThe daemon is untouched; the next deploy installs the client again.",
-                    (false, false) => "",
+                "{node}: the new termiod did not come up — {message}{}",
+                if *rolled_back {
+                    "\nThe previous binary is back in place."
+                } else {
+                    ""
                 }
             ),
             Outcome::Unreachable { message } => format!("{node}: unreachable — {message}"),
@@ -1193,20 +1195,29 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // installs none (this Mac), and off when the build carries none, so a
     // daemon-only deploy is never failed against a client nobody sent.
     let mut client_plane = node.client_binary().is_some();
-    let mut staged = None;
+    // What this run put on the node, per plane. Every undo below reads this and
+    // nothing else: a run that staged only the client may not touch the daemon,
+    // and one that staged no client may not touch the client — the box's own,
+    // which it has been using all along, is not this run's to restore or remove.
+    let mut staged = Staged {
+        daemon: false,
+        client: false,
+    };
     if let Some(plan) = plan {
-        match plan {
-            StagePlan::Full => eprintln!("[deploy] installing termiod {desired} on {label}…"),
-            // The daemon is deliberately untouched on this pass; saying it is
-            // being installed would describe the one plan that does not.
-            StagePlan::ClientOnly => {
-                eprintln!("[deploy] installing the termio {desired} client on {label}…")
-            }
+        staged = stage(node, plan).await?;
+        client_plane = client_plane && staged.client;
+        match (staged.daemon, staged.client) {
+            (true, true) => eprintln!("[deploy] installed termiod {desired} and its client on {label}"),
+            (true, false) => eprintln!("[deploy] installed termiod {desired} on {label}"),
+            (false, true) => eprintln!("[deploy] installed the termio {desired} client on {label}"),
+            // Nothing reached the node, so nothing is announced; whatever
+            // declined to ship a client said why.
+            (false, false) => {}
         }
-        let shipped = stage(node, plan).await?;
-        client_plane = client_plane && shipped.client;
-        staged = shipped.anything().then_some(plan);
-        observed = observe(node).await?;
+        // Only a node something landed on can have a new answer.
+        if staged.anything() {
+            observed = observe(node).await?;
+        }
     }
     let Observed::Reported(status) = observed else {
         bail!("termiod was installed on {label} but does not answer `status` there");
@@ -1331,14 +1342,17 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     let (hello, version) = match verify_daemon(node, want).await {
         Ok(answered) => answered,
         Err(error) => {
-            let message = format!("the new termiod did not come up — {error:#}");
+            let message = format!("{error:#}");
             let plan = node.rollback_plan();
-            let rolled_back =
-                (staged.is_some() || plan.even_unstaged) && roll_back(node, &plan).await.is_ok();
+            // Only a run that staged a *daemon* may undo one. A client-only
+            // pass that trips this arm would otherwise move `termiod.prev` over
+            // a daemon binary it never wrote — downgrading the box and spending
+            // its one rollback point over an artifact it never touched.
+            let rolled_back = (staged.daemon || plan.even_unstaged)
+                && roll_back(node, &plan, staged.client).await.is_ok();
             return Ok(Outcome::Unhealthy {
                 message,
                 rolled_back,
-                client_only: false,
             });
         }
     };
@@ -1346,24 +1360,28 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // The client half is skipped on a box a newer control plane owns — its
     // client is that plane's to verify — unless this run staged, because what
     // this run put on disk is this run's to answer for whatever daemon replies.
-    if client_plane && (version == want || staged.is_some()) {
+    let mut client_trouble = None;
+    if client_plane && (version == want || staged.anything()) {
         if let Err(error) = verify_client(node, want).await {
             // Undo only what this run did, which for a client that failed to
-            // answer is the client: its own `.prev`, or removal where this run
-            // installed it fresh. A Full stage therefore leaves a verified new
-            // daemon beside no client rather than beside a broken one — a skew,
-            // but a bounded one the next pass closes with a `ClientOnly`
-            // restage, and no session pays for it.
-            let restored = staged.is_some() && roll_back_client(node).await.is_ok();
-            return Ok(Outcome::Unhealthy {
-                message: format!("{error:#}"),
-                rolled_back: restored,
-                client_only: true,
-            });
+            // answer is the client — and only where this run installed one. A
+            // Full stage therefore leaves a verified new daemon beside no
+            // client rather than beside a broken one: a skew, but a bounded one
+            // the next pass closes with a `ClientOnly` restage, and no session
+            // pays for it.
+            let put_back = staged.client && roll_back_client(node).await.is_ok();
+            client_trouble = Some(format!(
+                "{error:#}{}",
+                match (staged.client, put_back) {
+                    (false, _) => "; it was already there, and is left as it is",
+                    (true, true) => "; the previous client is back in place, and the next deploy installs this build's again",
+                    (true, false) => "; it could not be put back, and the next deploy installs this build's again",
+                }
+            ));
         }
     }
 
-    if daemon_is_stale || staged.is_some() {
+    if daemon_is_stale || staged.daemon {
         // Best effort: a copy that fails costs the *next* upgrade its free
         // rollback, not this one anything.
         if let Some(preserve) = node.preserve_command() {
@@ -1375,6 +1393,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         host_id: hello.host_id,
         proto: Some(hello.proto),
         newer: version > want,
+        client: client_trouble,
     })
 }
 
@@ -1593,7 +1612,7 @@ async fn verify_daemon<N: Node>(node: &N, want: Version) -> Result<(DaemonHello,
 /// the same pid keeps every PTY — and stopping only when that also fails, so
 /// an image that turned out bad costs the sessions only when there is no
 /// non-destructive way back.
-async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan) -> Result<()> {
+async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan, staged_client: bool) -> Result<()> {
     let binary = node.binary();
     let label = node.label();
     let source = &plan.source;
@@ -1649,19 +1668,25 @@ async fn roll_back<N: Node>(node: &N, plan: &RollbackPlan) -> Result<()> {
                 last_line(&run.stderr)
             );
         }
-        // The client comes back in its own command, and its failure is a note
-        // rather than the rollback's. Chained onto the daemon's restore and
-        // judged by one exit code, a client that would not move back reported
-        // the whole rollback as failed — telling an operator the box was left
-        // on the build that broke it, while the daemon had in fact already
-        // been put back, and inviting recovery the box did not need.
-        if let Some(client) = node.client_binary() {
-            let restored = node.run(&restore_command(&client)).await;
-            if !matches!(&restored, Ok(run) if run.code == 0) {
-                eprintln!(
-                    "[deploy] {label} is back on the previous daemon, but its client could not be \
-                     restored; the next deploy replaces it"
-                );
+        // The client comes back only where this run replaced one, and its
+        // failure is a note rather than the rollback's.
+        //
+        // Both halves were bugs. Restoring on `client_binary().is_some()` alone
+        // ran `rm -f` over a client this run never staged — a working client,
+        // deleted because a *daemon* failed to verify, on any node whose build
+        // ships no client of its own. And chaining it onto the daemon's restore
+        // under one exit code reported the whole rollback as failed when only
+        // the client would not move, telling an operator the box was left on
+        // the build that broke it while the daemon had already been put back.
+        if staged_client {
+            if let Some(client) = node.client_binary() {
+                let restored = node.run(&restore_command(&client)).await;
+                if !matches!(&restored, Ok(run) if run.code == 0) {
+                    eprintln!(
+                        "[deploy] {label} is back on the previous daemon, but its client could not be \
+                         restored; the next deploy replaces it"
+                    );
+                }
             }
         }
     }
@@ -2581,12 +2606,75 @@ mod tests {
             vec![hello(Some(WANT))],
         );
         let report = reconcile(&node, WANT, Options::default()).await;
-        assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
+        match &report.outcome {
+            Outcome::Current { client: Some(_), .. } => {}
+            other => panic!("expected current with a client note, got {other:?}"),
+        }
         let commands = node.commands.borrow();
         let restore = commands.last().unwrap();
         assert!(restore.contains("termio.prev"), "{restore}");
         assert!(restore.contains("rm -f $HOME/.local/bin/termio"), "{restore}");
+        // The daemon plane is untouched. A client-only pass may not reach the
+        // daemon's rollback: `termiod.prev` is the box's one way back to the
+        // build before this one, and moving it would downgrade a plane that
+        // never failed and never staged.
         assert!(!commands.iter().any(|command| command.contains("termiod.prev") || command.contains(" stop")), "{commands:?}");
+    }
+
+    /// A client-only pass whose *daemon* stops answering leaves the daemon
+    /// alone: this run staged no daemon, so it has none to undo, and moving
+    /// `termiod.prev` over the binary would downgrade the box over a client.
+    #[tokio::test]
+    async fn a_client_only_pass_never_arms_the_daemon_rollback() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new())),
+                ok(""), // stage: the client alone
+                ok(&status_json(WANT, Some(WANT), true)),
+            ],
+            (0..40)
+                .map(|_| Err(anyhow::anyhow!("no protocol reply")))
+                .collect(),
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(
+            matches!(report.outcome, Outcome::Unhealthy { rolled_back: false, .. }),
+            "{report:?}"
+        );
+        let commands = node.commands.borrow();
+        assert!(!commands.iter().any(|command| command.contains("termiod.prev")), "{commands:?}");
+        assert!(!commands.iter().any(|command| command.contains("handoff --binary")), "{commands:?}");
+        assert!(!commands.iter().any(|command| command.contains(" stop")), "{commands:?}");
+    }
+
+    /// A daemon rollback restores only what the run staged. Where the build
+    /// shipped no client, the box's own — installed by something else, and
+    /// working — must survive: the restore command's other half is `rm -f`.
+    #[tokio::test]
+    async fn a_daemon_rollback_leaves_a_client_this_run_never_staged() {
+        let mut node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""), // stage: the daemon alone
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(1),
+                ok(""),        // roll back: [ -e prev ]
+                handed_off(1), // roll back: handoff --binary prev
+                ok(""),        // roll back: the daemon
+            ],
+            (0..40)
+                .map(|_| Err(anyhow::anyhow!("no protocol reply")))
+                .collect(),
+        );
+        node.client_artifact = None;
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        // The client's own restore — whose other half deletes — never runs.
+        // Matched whole, because `termiod`'s commands contain `termio`'s as a
+        // prefix and a substring test would pass on the daemon's own removal.
+        let client_restore = restore_command("$HOME/.local/bin/termio");
+        assert!(!commands.iter().any(|command| command == &client_restore), "{commands:?}");
     }
 
     /// This run staged the box, so the client is verified even when a newer
@@ -2633,12 +2721,17 @@ mod tests {
         );
     }
 
-    /// A client that does not answer `--version` is reported and put back, and
-    /// costs the box nothing else. The daemon verified as the build wanted, so
-    /// it is not handed back, not stopped, and not downgraded: the previous
-    /// shape drove the daemon's own rollback from this failure, whose fallback
-    /// is `stop --force`, and spent every live session on the box over one
-    /// artifact the daemon does not depend on.
+    /// A client that does not answer `--version` is reported on an otherwise
+    /// healthy machine and put back, and costs the box nothing else. The daemon
+    /// verified as the build wanted, so it is not handed back, not stopped, and
+    /// not downgraded: the previous shape drove the daemon's own rollback from
+    /// this failure, whose fallback is `stop --force`, and spent every live
+    /// session on the box over one artifact the daemon does not depend on.
+    ///
+    /// It rides `Current` because the machine is usable and every reader needs
+    /// to be told which machine it is — a report that could not say would have
+    /// the app refuse to register a box whose daemon is perfectly healthy — and
+    /// it is still a non-zero exit for whoever ran the deploy.
     #[tokio::test]
     async fn a_client_that_cannot_answer_version_never_touches_the_daemon() {
         let node = FakeNode::new(
@@ -2654,17 +2747,19 @@ mod tests {
         );
         let report = reconcile(&node, WANT, Options::default()).await;
         match &report.outcome {
-            Outcome::Unhealthy {
-                message,
-                rolled_back,
-                client_only,
+            Outcome::Current {
+                client: Some(trouble),
+                host_id,
+                ..
             } => {
-                assert!(*client_only, "{report:?}");
-                assert!(*rolled_back, "{report:?}");
-                assert!(message.contains("--version"), "{message}");
+                assert!(trouble.contains("--version"), "{trouble}");
+                assert!(trouble.contains("back in place"), "{trouble}");
+                assert_eq!(host_id, "h_1");
             }
-            other => panic!("expected unhealthy, got {other:?}"),
+            other => panic!("expected current with a client note, got {other:?}"),
         }
+        // Still a failed deploy for whoever ran one.
+        assert_eq!(report.exit_code(), 1);
         let commands = node.commands.borrow();
         assert!(!commands.iter().any(|command| command.contains(" stop")), "{commands:?}");
         assert!(
@@ -2708,6 +2803,49 @@ mod tests {
             !commands.iter().any(|command| command.contains("termio --version")),
             "{commands:?}"
         );
+    }
+
+    /// The keys the app decodes (`Termiod.LifecycleReport`, camel-cased from
+    /// these by `convertFromSnakeCase`). A client that failed rides `current`
+    /// with the host named, because the app registers a machine from that state
+    /// and only that state — reporting it as a failure left the app telling the
+    /// user a healthy daemon had not answered, and refusing the box.
+    #[test]
+    fn a_client_failure_reports_as_a_usable_machine() {
+        let report = Report {
+            node: "box".to_string(),
+            desired: WANT.to_string(),
+            outcome: Outcome::Current {
+                version: WANT.to_string(),
+                host_id: "h_1".to_string(),
+                proto: Some(1),
+                newer: false,
+                client: Some("the client at ~/.local/bin/termio does not answer --version".into()),
+            },
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(json["state"], "current");
+        assert_eq!(json["host_id"], "h_1");
+        assert_eq!(json["version"], WANT);
+        assert!(json["client"].as_str().unwrap().contains("--version"));
+
+        // And a healthy one carries no such key at all, so nothing downstream
+        // has to tell "absent" from "empty".
+        let healthy = Report {
+            node: "box".to_string(),
+            desired: WANT.to_string(),
+            outcome: Outcome::Current {
+                version: WANT.to_string(),
+                host_id: "h_1".to_string(),
+                proto: Some(1),
+                newer: false,
+                client: None,
+            },
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&healthy).unwrap()).unwrap();
+        assert!(json.get("client").is_none(), "{json}");
     }
 
     /// ssh failing is `unreachable`, kept apart from a step that ran and failed.

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1058,14 +1058,20 @@ pub enum Outcome {
         proto: Option<u32>,
         /// Another control plane put a newer build here. Left alone.
         newer: bool,
-        /// What went wrong with the `termio` client beside the daemon, when
-        /// something did. The daemon is still the build wanted and the machine
-        /// is still usable — that is why this rides `Current` rather than a
-        /// failure: a report that could not name the host would have every
-        /// reader treat a healthy box as unusable. The next reconcile restages
-        /// the client on its own.
+        /// What is wrong with the `termio` client beside the daemon, or what
+        /// could not be learned about it. The daemon is still the build wanted
+        /// and the machine is still usable — that is why this rides `Current`
+        /// rather than a failure: a report that could not name the host would
+        /// have every reader treat a healthy box as unusable.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         client: Option<String>,
+        /// Whether that note is the client's own fault rather than something
+        /// this pass could not find out. Only a fault fails the deploy: ssh
+        /// being flaky for the seconds of a `--version` probe is not a reason
+        /// to call an otherwise perfect deploy failed, and it must still be
+        /// *said*, which is why it is a separate question from `client`.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        client_failed: bool,
     },
     /// The binary is in place and the daemon still running is the old one.
     /// `busy` is why it was not stopped — empty when stopping was not asked for.
@@ -1096,9 +1102,10 @@ pub struct Report {
 impl Report {
     pub fn exit_code(&self) -> i32 {
         match self.outcome {
-            // A client that did not verify is still a failed deploy for whoever
-            // ran one, even though the machine came out of it working.
-            Outcome::Current { client: Some(_), .. } => 1,
+            // A client at fault is still a failed deploy for whoever ran one,
+            // even though the machine came out of it working. One this pass
+            // merely could not reach is not.
+            Outcome::Current { client_failed: true, .. } => 1,
             Outcome::Current { .. } => 0,
             Outcome::Staged { .. } => EXIT_BUSY,
             _ => 1,
@@ -1202,6 +1209,11 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         .with_context(|| format!("desired version {desired:?} is not a build stamp"))?;
     let label = node.label();
 
+    let repair_note = node.client_repair_note();
+    // What this pass will have to say about the client even when it stages
+    // nothing for it. A note that stops a doomed repair may not also stop the
+    // box from reporting the skew it is carrying.
+    let mut client_skew: Option<String> = None;
     let mut observed = observe(node).await?;
     let plan = match &observed {
         Observed::Absent | Observed::OldBinary => Some(StagePlan::Full),
@@ -1233,9 +1245,32 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                         .as_ref()
                         .and_then(|client| Version::parse(&client.version))
                         .is_some_and(|have| have >= want);
-                (!client_current
-                    && !client_repair_refused(node.client_repair_note().as_deref(), desired))
-                    .then_some(StagePlan::ClientOnly)
+                if client_current {
+                    // The note is about a client this machine would not take. It
+                    // is plainly obsolete once the machine has one.
+                    remember_client_repair(repair_note.as_deref(), None);
+                    None
+                } else if client_repair_refused(repair_note.as_deref(), desired) {
+                    // Installing this build's client here already failed for a
+                    // reason of the machine's own, so it is not attempted again
+                    // — but the machine is carrying a client that is not this
+                    // build, and it says so on every pass until that changes.
+                    // Silence here would report the exact skew §1.2 exists to
+                    // prevent as a clean bill of health, for good.
+                    client_skew = Some(format!(
+                        "the client on {label} is {}, not {desired}, and installing this build's \
+                         here already failed; a later build installs one again",
+                        status
+                            .client
+                            .as_ref()
+                            .map(|client| client.version.as_str())
+                            .filter(|version| !version.is_empty())
+                            .unwrap_or("missing"),
+                    ));
+                    None
+                } else {
+                    Some(StagePlan::ClientOnly)
+                }
             }
         },
     };
@@ -1243,7 +1278,6 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // nothing else: a run that staged only the client may not touch the daemon,
     // and one that staged no client may not touch the client — the box's own,
     // which it has been using all along, is not this run's to restore or remove.
-    let repair_note = node.client_repair_note();
     let mut staged = Staged::default();
     if let Some(plan) = plan {
         staged = match stage(node, plan).await {
@@ -1255,7 +1289,15 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             // …") over the CLI inside its sessions.
             Err(error) if plan == StagePlan::ClientOnly => {
                 eprintln!("[deploy] {label}'s client could not be installed ({error:#}); leaving it as it is");
-                remember_client_repair(repair_note.as_deref(), Some(desired));
+                // Only a refusal by the machine is remembered. ssh dropping for a
+                // second says nothing about whether this client can live there,
+                // and writing it down would disable client installs on that box
+                // until the next build — the same rule the `Unknown` verdict
+                // keeps below.
+                if error.downcast_ref::<Unreachable>().is_none() {
+                    remember_client_repair(repair_note.as_deref(), Some(desired));
+                }
+                client_skew = Some(format!("{error:#}"));
                 Staged::default()
             }
             Err(error) => return Err(error),
@@ -1416,7 +1458,7 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
     // that reading is an execution of the same binary, not a stat — so asking
     // again would spend an ssh round trip, before every attach, to learn what
     // the machine has just said.
-    let mut client_trouble = None;
+    let mut client_trouble = client_skew.map(|note| (note, true));
     if staged.client {
         match verify_client(node, want).await {
             ClientVerdict::Good => remember_client_repair(repair_note.as_deref(), None),
@@ -1432,18 +1474,24 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
                 // client — a noexec mount, a denied exec, a full disk — was
                 // otherwise restaged on every attach, for good.
                 remember_client_repair(repair_note.as_deref(), Some(desired));
-                client_trouble = Some(format!(
-                    "{message}{}",
-                    if put_back {
-                        "; the previous client is back in place, and a later build installs one again"
-                    } else {
-                        "; it could not be put back, and a later build installs one again"
-                    }
+                client_trouble = Some((
+                    format!(
+                        "{message}{}",
+                        if put_back {
+                            "; the previous client is back in place, and a later build installs one again"
+                        } else {
+                            "; it could not be put back, and a later build installs one again"
+                        }
+                    ),
+                    true,
                 ));
             }
             // Nothing was learned about the client, so nothing is undone: what
             // this run installed stays, and the next pass asks again.
-            ClientVerdict::Unknown(message) => client_trouble = Some(message),
+            // Reported, never counted as a fault: nothing was learned, and a
+            // deploy that installed everything correctly must not be called
+            // failed because ssh was flaky for the length of one probe.
+            ClientVerdict::Unknown(message) => client_trouble = Some((message, false)),
         }
     }
 
@@ -1459,7 +1507,8 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
         host_id: hello.host_id,
         proto: Some(hello.proto),
         newer: version > want,
-        client: client_trouble,
+        client: client_trouble.as_ref().map(|(note, _)| note.clone()),
+        client_failed: client_trouble.is_some_and(|(_, fault)| fault),
     })
 }
 
@@ -2120,6 +2169,8 @@ mod tests {
         client_artifact: Option<PathBuf>,
         /// Where a refused client repair is remembered, when a test cares.
         repair_note: Option<PathBuf>,
+        /// Makes `put` fail the way ssh does when the host drops.
+        unreachable_put: bool,
     }
 
     impl FakeNode {
@@ -2134,6 +2185,7 @@ mod tests {
                 client: Some("$HOME/.local/bin/termio".to_string()),
                 client_artifact: Some(PathBuf::from("/bundle/termio-aarch64-unknown-linux-musl")),
                 repair_note: None,
+                unreachable_put: false,
             }
         }
 
@@ -2172,6 +2224,9 @@ mod tests {
                 .ok_or_else(|| anyhow::anyhow!("unscripted command: {command}"))
         }
         async fn put(&self, local: &Path, name: &str) -> Result<()> {
+            if self.unreachable_put {
+                return Err(Unreachable("ssh: connect to host box port 22: Broken pipe".into()).into());
+            }
             self.puts.borrow_mut().push(format!("{} → {name}", local.display()));
             Ok(())
         }
@@ -3055,11 +3110,16 @@ mod tests {
         );
         let report = reconcile(&node, WANT, Options::default()).await;
         match &report.outcome {
-            Outcome::Current { client: Some(note), .. } => {
+            Outcome::Current { client: Some(note), client_failed, .. } => {
                 assert!(note.contains("could not reach"), "{note}");
+                // Said, but not counted against the deploy: everything installed
+                // correctly and the daemon verified, and ssh being flaky for the
+                // seconds of one probe is not the client's fault.
+                assert!(!client_failed, "{note}");
             }
             other => panic!("expected current with an unknown-client note, got {other:?}"),
         }
+        assert_eq!(report.exit_code(), 0);
         // The client it installed is still there: nothing restored, nothing removed.
         let commands = node.commands.borrow();
         let client_restore = restore_command("$HOME/.local/bin/termio", false);
@@ -3087,6 +3147,34 @@ mod tests {
         assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
     }
 
+    /// Only the machine refusing the client is remembered. ssh dropping for a
+    /// second says nothing about whether this client can live there, and writing
+    /// it down would disable client installs on that box until the next build —
+    /// the same rule the `Unknown` verdict keeps for the probe.
+    #[tokio::test]
+    async fn a_dropped_connection_does_not_disable_the_client_on_a_box() {
+        let note = std::path::PathBuf::from(format!(
+            "/tmp/termiod-repair-{}-dropped",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&note);
+        let mut node = FakeNode::new(
+            vec![ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new()))],
+            vec![hello(Some(WANT))],
+        );
+        node.repair_note = Some(note.clone());
+        node.unreachable_put = true;
+        let report = reconcile(&node, WANT, Options::default()).await;
+
+        // Usable, said out loud, and still worth trying again next time.
+        match &report.outcome {
+            Outcome::Current { client: Some(_), .. } => {}
+            other => panic!("expected current with a client note, got {other:?}"),
+        }
+        assert!(!note.exists(), "a transport failure is not a verdict on the client");
+        let _ = std::fs::remove_file(&note);
+    }
+
     /// And it is remembered, so the next attach does not spend another upload
     /// learning the same thing. A machine that can never take this build's
     /// client was otherwise restaged on every single attach, for good.
@@ -3109,14 +3197,25 @@ mod tests {
         let report = reconcile(&node, WANT, Options::default()).await;
         assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
 
-        // The next pass: the same box, the same build, and nothing sent.
+        // The next pass: the same box, the same build, and nothing sent — but
+        // the box is carrying a client that is not this build, and a note that
+        // stops a doomed repair may not also stop it saying so. Silence here
+        // would report the very skew §1.2 exists to prevent as a clean bill of
+        // health, on every pass, for good.
         let mut again = FakeNode::new(
-            vec![ok(&status_json_with_client(WANT, None, Some(WANT), true, Vec::new()))],
+            vec![ok(&status_json_with_client(WANT, Some("0.43.0+1500"), Some(WANT), true, Vec::new()))],
             vec![hello(Some(WANT))],
         );
         again.repair_note = Some(note.clone());
         let report = reconcile(&again, WANT, Options::default()).await;
-        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        match &report.outcome {
+            Outcome::Current { client: Some(note), .. } => {
+                assert!(note.contains("0.43.0+1500"), "{note}");
+                assert!(note.contains(WANT), "{note}");
+            }
+            other => panic!("expected current naming the skew, got {other:?}"),
+        }
+        assert_eq!(report.exit_code(), 1, "a skewed box is a failed deploy");
         assert!(again.puts.borrow().is_empty(), "{:?}", again.puts.borrow());
 
         // A later build is a fresh chance, so the note does not apply to it.
@@ -3170,7 +3269,14 @@ mod tests {
             }
         }
         let report = reconcile(&NoClientBuild, WANT, Options::default()).await;
-        assert!(matches!(report.outcome, Outcome::Current { client: None, .. }), "{report:?}");
+        // Usable, and honest about it: the machine is reachable and its daemon
+        // is the build wanted, while the client it is missing is still named.
+        match &report.outcome {
+            Outcome::Current { client: Some(note), .. } => {
+                assert!(note.contains("no bundled client"), "{note}")
+            }
+            other => panic!("expected current with a client note, got {other:?}"),
+        }
     }
 
     /// A Mac reachable over ssh is current with no client of the deploy's: it
@@ -3252,6 +3358,7 @@ mod tests {
                 proto: Some(1),
                 newer: false,
                 client: Some("the client at ~/.local/bin/termio does not answer --version".into()),
+                client_failed: true,
             },
         };
         let json: serde_json::Value =
@@ -3260,6 +3367,9 @@ mod tests {
         assert_eq!(json["host_id"], "h_1");
         assert_eq!(json["version"], WANT);
         assert!(json["client"].as_str().unwrap().contains("--version"));
+        // The app reads this to tell a client at fault from one it could not
+        // check, and says a different sentence for each.
+        assert_eq!(json["client_failed"], true);
 
         // And a healthy one carries no such key at all, so nothing downstream
         // has to tell "absent" from "empty".
@@ -3272,11 +3382,13 @@ mod tests {
                 proto: Some(1),
                 newer: false,
                 client: None,
+                client_failed: false,
             },
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&healthy).unwrap()).unwrap();
         assert!(json.get("client").is_none(), "{json}");
+        assert!(json.get("client_failed").is_none(), "{json}");
     }
 
     /// ssh failing is `unreachable`, kept apart from a step that ran and failed.

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -30,19 +30,31 @@ pub fn remote_bin() -> String {
 /// Where the `termio` client is installed on the remote host: beside the
 /// daemon, under the name a person types (docker-lessons RFC §1.2 — the
 /// client ships everywhere the daemon does). `TERMIOD_REMOTE_BIN` moves both.
-pub fn remote_client_bin() -> String {
+/// `None` when the override renamed the daemon, which pairs with no client.
+pub fn remote_client_bin() -> Option<String> {
     client_bin_beside(&remote_bin())
 }
 
-fn client_bin_beside(daemon: &str) -> String {
-    match daemon.rsplit_once('/') {
-        Some((directory, _)) if !directory.is_empty() => format!("{directory}/termio"),
+/// The client that belongs to a daemon at `daemon`, or `None` when nothing on
+/// the box does.
+///
+/// The daemon's *basename* decides, not just its directory. `TERMIOD_REMOTE_BIN`
+/// is the knob for a custom install path and for pointing tests at a binary of
+/// their own, so `/usr/local/bin/termiod-test` is a shape someone will use —
+/// and deriving the client from the directory alone would have that deploy
+/// rename `/usr/local/bin/termio`, the box's real client, out from under
+/// everything using it. A daemon that is not named `termiod` is a daemon this
+/// loop installs alone.
+fn client_bin_beside(daemon: &str) -> Option<String> {
+    let (directory, name) = match daemon.rsplit_once('/') {
+        Some((directory, name)) if !directory.is_empty() => (directory, name),
         // A bare daemon name still installs into `$HOME/.local/bin` (see
         // `install_directory`), so the client is named by that path: its
         // activation and verification must reach the file scp put there, not
         // whatever a non-login shell's PATH happens to resolve.
-        _ => "$HOME/.local/bin/termio".to_string(),
-    }
+        _ => ("$HOME/.local/bin", daemon),
+    };
+    (name == "termiod").then(|| format!("{directory}/termio"))
 }
 
 /// SSH options shared by every outbound connection.
@@ -577,7 +589,7 @@ impl Node for SshNode {
         if self.prebuilt.is_some() && self.prebuilt_client.is_none() {
             return None;
         }
-        Some(remote_client_bin())
+        remote_client_bin()
     }
 
     async fn hello(&self) -> Result<DaemonHello> {
@@ -922,9 +934,25 @@ mod tests {
     /// default install directory, where scp actually puts the file.
     #[test]
     fn the_client_installs_beside_the_daemon() {
-        assert_eq!(client_bin_beside("$HOME/.local/bin/termiod"), "$HOME/.local/bin/termio");
-        assert_eq!(client_bin_beside("/usr/local/bin/termiod"), "/usr/local/bin/termio");
-        assert_eq!(client_bin_beside("termiod"), "$HOME/.local/bin/termio");
+        assert_eq!(
+            client_bin_beside("$HOME/.local/bin/termiod").as_deref(),
+            Some("$HOME/.local/bin/termio")
+        );
+        assert_eq!(
+            client_bin_beside("/usr/local/bin/termiod").as_deref(),
+            Some("/usr/local/bin/termio")
+        );
+        assert_eq!(client_bin_beside("termiod").as_deref(), Some("$HOME/.local/bin/termio"));
+    }
+
+    /// A daemon the override renamed pairs with no client: deploying one would
+    /// rename the box's real `termio` aside to install a build under a name
+    /// that was never asked for.
+    #[test]
+    fn a_renamed_daemon_deploys_without_touching_the_boxs_client() {
+        assert_eq!(client_bin_beside("/usr/local/bin/termiod-test"), None);
+        assert_eq!(client_bin_beside("$HOME/builds/termiod.debug"), None);
+        assert_eq!(client_bin_beside("termiod-test"), None);
     }
 
     /// What `uname -sm` actually prints on the machines Termio is pointed at.

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -216,8 +216,15 @@ pub async fn run(cmd: RemoteCmd) -> Result<()> {
                 // that is a note rather than a stop.
                 let report = reconcile(&SshNode::new(host.clone()), Options::default()).await;
                 match report.outcome {
+                    // A client that did not verify leaves the box attachable, so
+                    // it is a note here rather than a refusal — but a note it
+                    // must be: the same outcome exits non-zero for `deploy` and
+                    // is logged as an error by the app, and someone reaching a
+                    // box this way would otherwise get no word that the `termio`
+                    // inside its sessions is broken.
+                    lifecycle::Outcome::Current { client: Some(_), .. }
+                    | lifecycle::Outcome::Staged { .. } => eprintln!("{}", report.describe()),
                     lifecycle::Outcome::Current { .. } => {}
-                    lifecycle::Outcome::Staged { .. } => eprintln!("{}", report.describe()),
                     _ => bail!("{}", report.describe()),
                 }
             }
@@ -558,6 +565,18 @@ impl Node for SshNode {
     }
 
     async fn artifact(&self) -> Result<Artifacts> {
+        // `--bin` answers before anything is asked of the host. It is the escape
+        // hatch for a machine `uname -sm` does not map to a target — an armv7
+        // board, a BSD — so making it wait on target detection took the one path
+        // that worked without detection and failed it with "pass --target
+        // explicitly", and charged every other `--bin` deploy a round trip.
+        if let Some(prebuilt) = &self.prebuilt {
+            let ships_client = self.target.as_deref().is_none_or(target_takes_a_client);
+            return Ok(Artifacts {
+                daemon: prebuilt.clone(),
+                client: ships_client.then(|| self.prebuilt_client.clone()).flatten(),
+            });
+        }
         let target = match &self.target {
             Some(target) => target.clone(),
             None => {
@@ -569,12 +588,6 @@ impl Node for SshNode {
             }
         };
         let ships_client = target_takes_a_client(&target);
-        if let Some(prebuilt) = &self.prebuilt {
-            return Ok(Artifacts {
-                daemon: prebuilt.clone(),
-                client: ships_client.then(|| self.prebuilt_client.clone()).flatten(),
-            });
-        }
         if let Some(path) = shipped_binary(&target) {
             eprintln!("[deploy] using the bundled {target} binaries");
             let daemon = PathBuf::from(path);
@@ -956,6 +969,32 @@ mod tests {
             Some("/usr/local/bin/termio")
         );
         assert_eq!(client_bin_beside("termiod").as_deref(), Some("$HOME/.local/bin/termio"));
+    }
+
+    /// `--bin` answers without asking the host anything. It is the escape hatch
+    /// for a machine whose `uname -sm` maps to no target, so resolving one first
+    /// failed exactly the deploys it exists for.
+    #[tokio::test]
+    async fn a_prebuilt_binary_deploys_without_resolving_a_target() {
+        let mut node = SshNode::new("unrecognized-board".into());
+        node.prebuilt = Some(PathBuf::from("/builds/termiod"));
+        node.prebuilt_client = Some(PathBuf::from("/builds/termio"));
+        // No `run`, so any ssh this reached for would fail the test rather than
+        // quietly cost a round trip.
+        let artifacts = node.artifact().await.expect("a prebuilt needs no target");
+        assert_eq!(artifacts.daemon, PathBuf::from("/builds/termiod"));
+        assert_eq!(artifacts.client, Some(PathBuf::from("/builds/termio")));
+    }
+
+    /// …and an explicit `--target` still decides whether the client goes.
+    #[tokio::test]
+    async fn a_prebuilt_binary_sends_no_client_to_a_named_mac() {
+        let mut node = SshNode::new("mac".into());
+        node.prebuilt = Some(PathBuf::from("/builds/termiod"));
+        node.prebuilt_client = Some(PathBuf::from("/builds/termio"));
+        node.target = Some("aarch64-apple-darwin".into());
+        let artifacts = node.artifact().await.expect("a prebuilt needs no uname");
+        assert_eq!(artifacts.client, None);
     }
 
     /// A Linux box gets its client from the deploy; a Mac never does, whichever

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -187,7 +187,7 @@ pub async fn run(cmd: RemoteCmd) -> Result<()> {
                     // Resolved before anything is sent: a stale pair is caught by
                     // a local `--version`, not by a failed verify and a daemon
                     // bounce on the box.
-                    node.prebuilt_client = client_beside(&daemon)?;
+                    node.prebuilt_client = client_beside(&daemon).await?;
                 } else if target.is_none() {
                     eprintln!(
                         "[deploy] deploying the daemon only; name the machine with --target to \
@@ -638,6 +638,29 @@ impl Node for SshNode {
         remote_client_bin()
     }
 
+    fn client_repair_note(&self) -> Option<PathBuf> {
+        // One file per host, named after the alias the user reaches it by. Kept
+        // in this machine's own durable state: it is this control plane's note
+        // about a box, not state the box should carry.
+        let named: String = self
+            .host
+            .chars()
+            .map(|character| match character {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '-' | '_' => character,
+                _ => '_',
+            })
+            .collect();
+        if named.is_empty() {
+            return None;
+        }
+        Some(
+            crate::paths::durable_state_dir()
+                .ok()?
+                .join("client-repair")
+                .join(named),
+        )
+    }
+
     async fn hello(&self) -> Result<DaemonHello> {
         let mut child = self
             .ssh()
@@ -771,7 +794,7 @@ fn shipped_client(target: &str, daemon: &Path) -> Result<PathBuf> {
 /// daemon over a skew a local check already saw. A pair that cannot answer
 /// locally — cross-built for another machine — ships as found, and the box's
 /// own verify judges it.
-fn client_beside(daemon: &Path) -> Result<Option<PathBuf>> {
+async fn client_beside(daemon: &Path) -> Result<Option<PathBuf>> {
     let candidate = daemon
         .parent()
         .map(|directory| directory.join("termio"))
@@ -783,8 +806,8 @@ fn client_beside(daemon: &Path) -> Result<Option<PathBuf>> {
         );
         return Ok(None);
     };
-    let (daemon_stamp, daemon_text) = lifecycle::binary_version(daemon);
-    let (client_stamp, client_text) = lifecycle::binary_version(&client);
+    let (daemon_stamp, daemon_text) = lifecycle::binary_version(daemon).await;
+    let (client_stamp, client_text) = lifecycle::binary_version(&client).await;
     if let (Some(daemon_stamp), Some(client_stamp)) = (daemon_stamp, client_stamp) {
         if daemon_stamp != client_stamp {
             bail!(

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -177,10 +177,23 @@ pub async fn run(cmd: RemoteCmd) -> Result<()> {
             let mut node = SshNode::new(host);
             if let Some(bin) = bin {
                 let daemon = PathBuf::from(bin);
-                // Resolved before anything is sent: a stale pair is caught by
-                // a local `--version`, not by a failed verify and a daemon
-                // bounce on the box.
-                node.prebuilt_client = client_beside(&daemon)?;
+                // Only a machine that takes a client is paired with one, and
+                // only when this deploy named it: `artifact` sends none
+                // otherwise. Pairing first meant a daemon/client build mismatch
+                // refused the whole deploy over an artifact that was never going
+                // to ship — a `--target aarch64-apple-darwin` run, say, where a
+                // Mac must be sent no client at all.
+                if target.as_deref().is_some_and(target_takes_a_client) {
+                    // Resolved before anything is sent: a stale pair is caught by
+                    // a local `--version`, not by a failed verify and a daemon
+                    // bounce on the box.
+                    node.prebuilt_client = client_beside(&daemon)?;
+                } else if target.is_none() {
+                    eprintln!(
+                        "[deploy] deploying the daemon only; name the machine with --target to \
+                         send the client beside it too"
+                    );
+                }
                 node.prebuilt = Some(daemon);
             }
             node.target = target;
@@ -576,12 +589,6 @@ impl Node for SshNode {
             // on a Mac that manages its own — shadowing the app's copy with one
             // frozen at this build, which no later pass refreshes or removes.
             let ships_client = self.target.as_deref().is_some_and(target_takes_a_client);
-            if !ships_client && self.prebuilt_client.is_some() && self.target.is_none() {
-                eprintln!(
-                    "[deploy] deploying the daemon only; name the machine with --target to send \
-                     the client beside it too"
-                );
-            }
             return Ok(Artifacts {
                 daemon: prebuilt.clone(),
                 client: ships_client.then(|| self.prebuilt_client.clone()).flatten(),

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -564,14 +564,24 @@ impl Node for SshNode {
         Ok(())
     }
 
-    async fn artifact(&self) -> Result<Artifacts> {
+    async fn artifact(&self, client_only: bool) -> Result<Artifacts> {
         // `--bin` answers before anything is asked of the host. It is the escape
         // hatch for a machine `uname -sm` does not map to a target — an armv7
         // board, a BSD — so making it wait on target detection took the one path
         // that worked without detection and failed it with "pass --target
         // explicitly", and charged every other `--bin` deploy a round trip.
         if let Some(prebuilt) = &self.prebuilt {
-            let ships_client = self.target.as_deref().is_none_or(target_takes_a_client);
+            // Unknown means no client. The host is not asked what it is on this
+            // path, and guessing "it takes one" plants a `~/.local/bin/termio`
+            // on a Mac that manages its own — shadowing the app's copy with one
+            // frozen at this build, which no later pass refreshes or removes.
+            let ships_client = self.target.as_deref().is_some_and(target_takes_a_client);
+            if !ships_client && self.prebuilt_client.is_some() && self.target.is_none() {
+                eprintln!(
+                    "[deploy] deploying the daemon only; name the machine with --target to send \
+                     the client beside it too"
+                );
+            }
             return Ok(Artifacts {
                 daemon: prebuilt.clone(),
                 client: ships_client.then(|| self.prebuilt_client.clone()).flatten(),
@@ -596,6 +606,18 @@ impl Node for SshNode {
                 false => None,
             };
             return Ok(Artifacts { daemon, client });
+        }
+        if client_only {
+            // Repairing a client is not worth building a daemon for. A control
+            // plane run out of a checkout reaches this on every attach to a box
+            // whose client is missing, and cross-compiling there needs a
+            // toolchain it may not have — which turned an attach to a healthy
+            // machine into a failure. `stage` reads this as "leave the client
+            // alone" rather than as a failed deploy.
+            bail!(
+                "no bundled {target} client to repair {} with; a client-only pass does not build one",
+                self.host
+            );
         }
         tokio::task::spawn_blocking(move || cross_compile(&target)).await?
     }
@@ -981,19 +1003,22 @@ mod tests {
         node.prebuilt_client = Some(PathBuf::from("/builds/termio"));
         // No `run`, so any ssh this reached for would fail the test rather than
         // quietly cost a round trip.
-        let artifacts = node.artifact().await.expect("a prebuilt needs no target");
+        let artifacts = node.artifact(false).await.expect("a prebuilt needs no target");
         assert_eq!(artifacts.daemon, PathBuf::from("/builds/termiod"));
-        assert_eq!(artifacts.client, Some(PathBuf::from("/builds/termio")));
+        // And no client, because nothing here knows what the machine is: sending
+        // one to a Mac plants a copy that shadows the app's own for good. Naming
+        // the target with `--target` is what asks for it.
+        assert_eq!(artifacts.client, None);
     }
 
-    /// …and an explicit `--target` still decides whether the client goes.
+    /// …and an explicit `--target` decides it, either way.
     #[tokio::test]
     async fn a_prebuilt_binary_sends_no_client_to_a_named_mac() {
         let mut node = SshNode::new("mac".into());
         node.prebuilt = Some(PathBuf::from("/builds/termiod"));
         node.prebuilt_client = Some(PathBuf::from("/builds/termio"));
         node.target = Some("aarch64-apple-darwin".into());
-        let artifacts = node.artifact().await.expect("a prebuilt needs no uname");
+        let artifacts = node.artifact(false).await.expect("a prebuilt needs no uname");
         assert_eq!(artifacts.client, None);
     }
 

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -558,12 +558,6 @@ impl Node for SshNode {
     }
 
     async fn artifact(&self) -> Result<Artifacts> {
-        if let Some(prebuilt) = &self.prebuilt {
-            return Ok(Artifacts {
-                daemon: prebuilt.clone(),
-                client: self.prebuilt_client.clone(),
-            });
-        }
         let target = match &self.target {
             Some(target) => target.clone(),
             None => {
@@ -574,10 +568,20 @@ impl Node for SshNode {
                 target_for_uname(uname.stdout.trim())?
             }
         };
+        let ships_client = target_takes_a_client(&target);
+        if let Some(prebuilt) = &self.prebuilt {
+            return Ok(Artifacts {
+                daemon: prebuilt.clone(),
+                client: ships_client.then(|| self.prebuilt_client.clone()).flatten(),
+            });
+        }
         if let Some(path) = shipped_binary(&target) {
             eprintln!("[deploy] using the bundled {target} binaries");
             let daemon = PathBuf::from(path);
-            let client = shipped_client(&target, &daemon)?;
+            let client = match ships_client {
+                true => Some(shipped_client(&target, &daemon)?),
+                false => None,
+            };
             return Ok(Artifacts { daemon, client });
         }
         tokio::task::spawn_blocking(move || cross_compile(&target)).await?
@@ -679,37 +683,31 @@ fn shipped_binary(target: &str) -> Option<String> {
         .then(|| candidate.to_string_lossy().into_owned())
 }
 
-/// The `termio` client that ships beside this executable for `target`,
-/// mirroring [`shipped_binary`]. For a Mac it is the client in the daemon's
-/// own directory — the app bundle's Resources, or a cargo target directory; a
-/// dev bundle names its copy `termio-dev`, and either lands on the box as
-/// `termio`, because argv[0] is what binds a channel and a box has only the
-/// one.
+/// Whether a machine of this target takes a `termio` client from a deploy.
 ///
-/// A missing Linux slice is an error: those exist only because
-/// `scripts/build-app.sh` put them in a bundle's Resources, so absence means a
-/// broken bundle, and shipping half a build from one would recreate the skew
-/// §1.2 rules out. A missing Mac client is not, because `shipped_binary` hands
-/// back `current_exe` for every Darwin target — including a daemon run straight
-/// out of a checkout, where `cargo build --bin termiod` legitimately produced
-/// no client. Failing there would turn a Mac→Mac deploy that worked before this
-/// pass into one that cannot be done at all; it degrades to daemon-only with a
-/// note, exactly as the `--bin` override does.
-fn shipped_client(target: &str, daemon: &Path) -> Result<Option<PathBuf>> {
+/// Every Linux box does: nothing else puts one there. No Mac does. A Mac owns
+/// its client already — its app bundle links one into `/usr/local/bin` — and
+/// `session::client_path_directory` returns `None` on macOS, so a copy planted
+/// in `~/.local/bin` would never be reached deliberately. It would only shadow
+/// the app's own wherever `~/.local/bin` comes first on `PATH`, frozen at
+/// whatever build this deploy left while that Mac's own client moves on with
+/// its app.
+fn target_takes_a_client(target: &str) -> bool {
+    !target.contains("apple-darwin")
+}
+
+/// The `termio` client that ships beside this executable for `target`,
+/// mirroring [`shipped_binary`]. Only ever asked for a target that takes one,
+/// which is every Linux box and no Mac (see [`SshNode::artifact`]).
+///
+/// Missing is an error rather than a smaller deploy: these slices exist only
+/// because `scripts/build-app.sh` put them in a bundle's Resources, so absence
+/// means a broken bundle, and shipping half a build from one would recreate the
+/// skew §1.2 rules out.
+fn shipped_client(target: &str, daemon: &Path) -> Result<PathBuf> {
     let directory = daemon
         .parent()
         .with_context(|| format!("{} has no directory", daemon.display()))?;
-    if target.contains("apple-darwin") {
-        let candidates = [directory.join("termio"), directory.join("termio-dev")];
-        let found = candidates.iter().find(|candidate| candidate.is_file()).cloned();
-        if found.is_none() {
-            eprintln!(
-                "[deploy] no termio client beside {}; deploying the daemon only",
-                daemon.display()
-            );
-        }
-        return Ok(found);
-    }
     let candidate = directory.join(format!("termio-{target}"));
     if !candidate.is_file() {
         bail!(
@@ -717,7 +715,7 @@ fn shipped_client(target: &str, daemon: &Path) -> Result<Option<PathBuf>> {
             candidate.display()
         );
     }
-    Ok(Some(candidate))
+    Ok(candidate)
 }
 
 /// The client that pairs with a developer-supplied `--bin` daemon: the
@@ -958,6 +956,16 @@ mod tests {
             Some("/usr/local/bin/termio")
         );
         assert_eq!(client_bin_beside("termiod").as_deref(), Some("$HOME/.local/bin/termio"));
+    }
+
+    /// A Linux box gets its client from the deploy; a Mac never does, whichever
+    /// way its target was arrived at.
+    #[test]
+    fn only_a_box_that_owns_no_client_is_sent_one() {
+        assert!(target_takes_a_client("x86_64-unknown-linux-musl"));
+        assert!(target_takes_a_client("aarch64-unknown-linux-musl"));
+        assert!(!target_takes_a_client("aarch64-apple-darwin"));
+        assert!(!target_takes_a_client("x86_64-apple-darwin"));
     }
 
     /// A daemon the override renamed pairs with no client: deploying one would

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -18,13 +18,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use crate::lifecycle::{self, DaemonHello, Node, Options, Report, Run, Unreachable};
+use crate::lifecycle::{self, Artifacts, DaemonHello, Node, Options, Report, Run, Unreachable};
 
 /// Where the binary is installed on the remote host. `$HOME` is expanded by
 /// the remote shell. Overridable with `TERMIOD_REMOTE_BIN` for custom install
 /// paths (and to point tests at a local binary).
 pub fn remote_bin() -> String {
     std::env::var("TERMIOD_REMOTE_BIN").unwrap_or_else(|_| "$HOME/.local/bin/termiod".to_string())
+}
+
+/// Where the `termio` client is installed on the remote host: beside the
+/// daemon, under the name a person types (docker-lessons RFC §1.2 — the
+/// client ships everywhere the daemon does). `TERMIOD_REMOTE_BIN` moves both.
+pub fn remote_client_bin() -> String {
+    client_bin_beside(&remote_bin())
+}
+
+fn client_bin_beside(daemon: &str) -> String {
+    match daemon.rsplit_once('/') {
+        Some((directory, _)) if !directory.is_empty() => format!("{directory}/termio"),
+        // A bare `termiod` resolves on the remote PATH; so does its client.
+        _ => "termio".to_string(),
+    }
 }
 
 /// SSH options shared by every outbound connection.
@@ -515,9 +530,12 @@ impl Node for SshNode {
         Ok(())
     }
 
-    async fn artifact(&self) -> Result<PathBuf> {
+    async fn artifact(&self) -> Result<Artifacts> {
         if let Some(prebuilt) = &self.prebuilt {
-            return Ok(prebuilt.clone());
+            return Ok(Artifacts {
+                daemon: prebuilt.clone(),
+                client: client_beside(prebuilt)?,
+            });
         }
         let target = match &self.target {
             Some(target) => target.clone(),
@@ -530,11 +548,16 @@ impl Node for SshNode {
             }
         };
         if let Some(path) = shipped_binary(&target) {
-            eprintln!("[deploy] using the bundled {target} binary");
-            return Ok(PathBuf::from(path));
+            eprintln!("[deploy] using the bundled {target} binaries");
+            let daemon = PathBuf::from(path);
+            let client = shipped_client(&target, &daemon)?;
+            return Ok(Artifacts { daemon, client });
         }
-        let built = tokio::task::spawn_blocking(move || cross_compile(&target)).await??;
-        Ok(PathBuf::from(built))
+        tokio::task::spawn_blocking(move || cross_compile(&target)).await?
+    }
+
+    fn client_binary(&self) -> Option<String> {
+        Some(remote_client_bin())
     }
 
     async fn hello(&self) -> Result<DaemonHello> {
@@ -624,6 +647,48 @@ fn shipped_binary(target: &str) -> Option<String> {
         .then(|| candidate.to_string_lossy().into_owned())
 }
 
+/// The `termio` client that ships beside this executable for `target`,
+/// mirroring [`shipped_binary`]. For a Mac it is the client in the daemon's
+/// own directory — the app bundle's Resources, or a cargo target directory; a
+/// dev bundle names its copy `termio-dev`, and either lands on the box as
+/// `termio`, because argv[0] is what binds a channel and a box has only the
+/// one. Missing is an error rather than a smaller deploy: a bundle built from
+/// this code always carries both, so absence means a broken bundle, and
+/// shipping half a build would recreate the skew §1.2 rules out.
+fn shipped_client(target: &str, daemon: &Path) -> Result<PathBuf> {
+    let directory = daemon
+        .parent()
+        .with_context(|| format!("{} has no directory", daemon.display()))?;
+    let candidates = if target.contains("apple-darwin") {
+        vec![directory.join("termio"), directory.join("termio-dev")]
+    } else {
+        vec![directory.join(format!("termio-{target}"))]
+    };
+    match candidates.iter().find(|candidate| candidate.is_file()) {
+        Some(found) => Ok(found.clone()),
+        None => bail!(
+            "the bundled daemon has no termio client beside it ({}); the client deploys with the daemon",
+            candidates[0].display()
+        ),
+    }
+}
+
+/// The client that pairs with a developer-supplied `--bin` daemon: the
+/// `termio` beside it, which a `cargo build` of this crate always produces.
+fn client_beside(daemon: &Path) -> Result<PathBuf> {
+    let candidate = daemon
+        .parent()
+        .map(|directory| directory.join("termio"))
+        .filter(|path| path.is_file());
+    match candidate {
+        Some(path) => Ok(path),
+        None => bail!(
+            "no termio client beside {}; the client deploys with the daemon (a `cargo build` produces both)",
+            daemon.display()
+        ),
+    }
+}
+
 /// The `uname -sm` half of target detection, split out so the mapping can be
 /// checked without a machine to ask.
 ///
@@ -679,9 +744,9 @@ fn find_tool(directories: &[String], binary: &str) -> Option<String> {
     })
 }
 
-/// `cargo build --release --target <triple>` for this crate; returns the
-/// binary path. Falls back to a clear message if the cross-linker is missing.
-fn cross_compile(target: &str) -> Result<String> {
+/// `cargo build --release --target <triple>` for this crate; returns both
+/// built binaries. Falls back to a clear message if the cross-linker is missing.
+fn cross_compile(target: &str) -> Result<Artifacts> {
     let manifest = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
     let path = toolchain_path();
     let Some(cargo) = find_tool(&path, "cargo") else {
@@ -734,12 +799,17 @@ fn cross_compile(target: &str) -> Result<String> {
         );
     }
     let dir = env!("CARGO_MANIFEST_DIR");
-    // With a workspace-less crate, target/ sits next to Cargo.toml.
-    let bin = format!("{dir}/target/{target}/release/termiod");
-    if !std::path::Path::new(&bin).exists() {
-        bail!("expected built binary at {bin} but it is missing");
+    // With a workspace-less crate, target/ sits next to Cargo.toml. One build
+    // produces both binaries — the crate declares both `[[bin]]`s — so the
+    // client costs the cross-compile nothing extra.
+    let daemon = PathBuf::from(format!("{dir}/target/{target}/release/termiod"));
+    let client = PathBuf::from(format!("{dir}/target/{target}/release/termio"));
+    for binary in [&daemon, &client] {
+        if !binary.exists() {
+            bail!("expected built binary at {} but it is missing", binary.display());
+        }
     }
-    Ok(bin)
+    Ok(Artifacts { daemon, client })
 }
 
 /// Run an interactive/remote command over SSH. `tty` requests a PTY (`-t`),
@@ -801,6 +871,15 @@ fn shell_quote(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The client installs beside the daemon, wherever the daemon goes — a
+    /// `TERMIOD_REMOTE_BIN` override moves both, and a bare name stays bare.
+    #[test]
+    fn the_client_installs_beside_the_daemon() {
+        assert_eq!(client_bin_beside("$HOME/.local/bin/termiod"), "$HOME/.local/bin/termio");
+        assert_eq!(client_bin_beside("/usr/local/bin/termiod"), "/usr/local/bin/termio");
+        assert_eq!(client_bin_beside("termiod"), "termio");
+    }
 
     /// What `uname -sm` actually prints on the machines Termio is pointed at.
     #[test]

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -37,8 +37,11 @@ pub fn remote_client_bin() -> String {
 fn client_bin_beside(daemon: &str) -> String {
     match daemon.rsplit_once('/') {
         Some((directory, _)) if !directory.is_empty() => format!("{directory}/termio"),
-        // A bare `termiod` resolves on the remote PATH; so does its client.
-        _ => "termio".to_string(),
+        // A bare daemon name still installs into `$HOME/.local/bin` (see
+        // `install_directory`), so the client is named by that path: its
+        // activation and verification must reach the file scp put there, not
+        // whatever a non-login shell's PATH happens to resolve.
+        _ => "$HOME/.local/bin/termio".to_string(),
     }
 }
 
@@ -160,7 +163,14 @@ pub async fn run(cmd: RemoteCmd) -> Result<()> {
             json,
         } => {
             let mut node = SshNode::new(host);
-            node.prebuilt = bin.map(PathBuf::from);
+            if let Some(bin) = bin {
+                let daemon = PathBuf::from(bin);
+                // Resolved before anything is sent: a stale pair is caught by
+                // a local `--version`, not by a failed verify and a daemon
+                // bounce on the box.
+                node.prebuilt_client = client_beside(&daemon)?;
+                node.prebuilt = Some(daemon);
+            }
             node.target = target;
             let report = reconcile(
                 &node,
@@ -433,6 +443,10 @@ pub struct SshNode {
     pub host: String,
     /// A binary to install instead of choosing one — the developer override.
     pub prebuilt: Option<PathBuf>,
+    /// The client paired with `prebuilt`, validated by [`client_beside`].
+    /// `None` alongside a `prebuilt` daemon means a daemon-only deploy: the
+    /// client plane is off for this node rather than half-staged.
+    pub prebuilt_client: Option<PathBuf>,
     /// A Rust target triple instead of asking `uname`.
     pub target: Option<String>,
 }
@@ -442,6 +456,7 @@ impl SshNode {
         SshNode {
             host,
             prebuilt: None,
+            prebuilt_client: None,
             target: None,
         }
     }
@@ -534,7 +549,7 @@ impl Node for SshNode {
         if let Some(prebuilt) = &self.prebuilt {
             return Ok(Artifacts {
                 daemon: prebuilt.clone(),
-                client: client_beside(prebuilt)?,
+                client: self.prebuilt_client.clone(),
             });
         }
         let target = match &self.target {
@@ -550,13 +565,18 @@ impl Node for SshNode {
         if let Some(path) = shipped_binary(&target) {
             eprintln!("[deploy] using the bundled {target} binaries");
             let daemon = PathBuf::from(path);
-            let client = shipped_client(&target, &daemon)?;
+            let client = Some(shipped_client(&target, &daemon)?);
             return Ok(Artifacts { daemon, client });
         }
         tokio::task::spawn_blocking(move || cross_compile(&target)).await?
     }
 
     fn client_binary(&self) -> Option<String> {
+        // A `--bin` override with no client beside it deploys the daemon
+        // alone; every other artifact source carries both binaries.
+        if self.prebuilt.is_some() && self.prebuilt_client.is_none() {
+            return None;
+        }
         Some(remote_client_bin())
     }
 
@@ -674,19 +694,41 @@ fn shipped_client(target: &str, daemon: &Path) -> Result<PathBuf> {
 }
 
 /// The client that pairs with a developer-supplied `--bin` daemon: the
-/// `termio` beside it, which a `cargo build` of this crate always produces.
-fn client_beside(daemon: &Path) -> Result<PathBuf> {
+/// `termio` beside it, when there is one of the same build.
+///
+/// `None` — a daemon-only deploy, with a note — rather than an error when
+/// the file is absent: `cargo build --bin termiod` legitimately produces no
+/// client, and the box keeps whatever client it has. But a client that *is*
+/// there and answers `--version` as another build is refused here, before a
+/// byte ships: sending it would fail verification on the box and bounce the
+/// daemon over a skew a local check already saw. A pair that cannot answer
+/// locally — cross-built for another machine — ships as found, and the box's
+/// own verify judges it.
+fn client_beside(daemon: &Path) -> Result<Option<PathBuf>> {
     let candidate = daemon
         .parent()
         .map(|directory| directory.join("termio"))
         .filter(|path| path.is_file());
-    match candidate {
-        Some(path) => Ok(path),
-        None => bail!(
-            "no termio client beside {}; the client deploys with the daemon (a `cargo build` produces both)",
+    let Some(client) = candidate else {
+        eprintln!(
+            "[deploy] no termio client beside {}; deploying the daemon only",
             daemon.display()
-        ),
+        );
+        return Ok(None);
+    };
+    let (daemon_stamp, daemon_text) = lifecycle::binary_version(daemon);
+    let (client_stamp, client_text) = lifecycle::binary_version(&client);
+    if let (Some(daemon_stamp), Some(client_stamp)) = (daemon_stamp, client_stamp) {
+        if daemon_stamp != client_stamp {
+            bail!(
+                "the termio beside {} is another build ({} where the daemon is {}); rebuild so the pair matches",
+                daemon.display(),
+                client_text.as_deref().unwrap_or("unstamped"),
+                daemon_text.as_deref().unwrap_or("unstamped")
+            );
+        }
     }
+    Ok(Some(client))
 }
 
 /// The `uname -sm` half of target detection, split out so the mapping can be
@@ -809,7 +851,10 @@ fn cross_compile(target: &str) -> Result<Artifacts> {
             bail!("expected built binary at {} but it is missing", binary.display());
         }
     }
-    Ok(Artifacts { daemon, client })
+    Ok(Artifacts {
+        daemon,
+        client: Some(client),
+    })
 }
 
 /// Run an interactive/remote command over SSH. `tty` requests a PTY (`-t`),
@@ -873,12 +918,13 @@ mod tests {
     use super::*;
 
     /// The client installs beside the daemon, wherever the daemon goes — a
-    /// `TERMIOD_REMOTE_BIN` override moves both, and a bare name stays bare.
+    /// `TERMIOD_REMOTE_BIN` override moves both, and a bare name means the
+    /// default install directory, where scp actually puts the file.
     #[test]
     fn the_client_installs_beside_the_daemon() {
         assert_eq!(client_bin_beside("$HOME/.local/bin/termiod"), "$HOME/.local/bin/termio");
         assert_eq!(client_bin_beside("/usr/local/bin/termiod"), "/usr/local/bin/termio");
-        assert_eq!(client_bin_beside("termiod"), "termio");
+        assert_eq!(client_bin_beside("termiod"), "$HOME/.local/bin/termio");
     }
 
     /// What `uname -sm` actually prints on the machines Termio is pointed at.

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -577,7 +577,7 @@ impl Node for SshNode {
         if let Some(path) = shipped_binary(&target) {
             eprintln!("[deploy] using the bundled {target} binaries");
             let daemon = PathBuf::from(path);
-            let client = Some(shipped_client(&target, &daemon)?);
+            let client = shipped_client(&target, &daemon)?;
             return Ok(Artifacts { daemon, client });
         }
         tokio::task::spawn_blocking(move || cross_compile(&target)).await?
@@ -684,25 +684,40 @@ fn shipped_binary(target: &str) -> Option<String> {
 /// own directory — the app bundle's Resources, or a cargo target directory; a
 /// dev bundle names its copy `termio-dev`, and either lands on the box as
 /// `termio`, because argv[0] is what binds a channel and a box has only the
-/// one. Missing is an error rather than a smaller deploy: a bundle built from
-/// this code always carries both, so absence means a broken bundle, and
-/// shipping half a build would recreate the skew §1.2 rules out.
-fn shipped_client(target: &str, daemon: &Path) -> Result<PathBuf> {
+/// one.
+///
+/// A missing Linux slice is an error: those exist only because
+/// `scripts/build-app.sh` put them in a bundle's Resources, so absence means a
+/// broken bundle, and shipping half a build from one would recreate the skew
+/// §1.2 rules out. A missing Mac client is not, because `shipped_binary` hands
+/// back `current_exe` for every Darwin target — including a daemon run straight
+/// out of a checkout, where `cargo build --bin termiod` legitimately produced
+/// no client. Failing there would turn a Mac→Mac deploy that worked before this
+/// pass into one that cannot be done at all; it degrades to daemon-only with a
+/// note, exactly as the `--bin` override does.
+fn shipped_client(target: &str, daemon: &Path) -> Result<Option<PathBuf>> {
     let directory = daemon
         .parent()
         .with_context(|| format!("{} has no directory", daemon.display()))?;
-    let candidates = if target.contains("apple-darwin") {
-        vec![directory.join("termio"), directory.join("termio-dev")]
-    } else {
-        vec![directory.join(format!("termio-{target}"))]
-    };
-    match candidates.iter().find(|candidate| candidate.is_file()) {
-        Some(found) => Ok(found.clone()),
-        None => bail!(
-            "the bundled daemon has no termio client beside it ({}); the client deploys with the daemon",
-            candidates[0].display()
-        ),
+    if target.contains("apple-darwin") {
+        let candidates = [directory.join("termio"), directory.join("termio-dev")];
+        let found = candidates.iter().find(|candidate| candidate.is_file()).cloned();
+        if found.is_none() {
+            eprintln!(
+                "[deploy] no termio client beside {}; deploying the daemon only",
+                daemon.display()
+            );
+        }
+        return Ok(found);
     }
+    let candidate = directory.join(format!("termio-{target}"));
+    if !candidate.is_file() {
+        bail!(
+            "the bundled daemon has no termio client beside it ({}); the client deploys with the daemon",
+            candidate.display()
+        );
+    }
+    Ok(Some(candidate))
 }
 
 /// The client that pairs with a developer-supplied `--bin` daemon: the

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1604,12 +1604,13 @@ fn daemon_owned_env(id: &SessionId, mut env: Vec<(String, String)>) -> Vec<(Stri
         // which is right whenever this daemon is on the default path too.
         Err(err) => eprintln!("termiod: could not resolve socket path for session env: {err}"),
     }
-    // The daemon's own directory leads the session's PATH, so every terminal
-    // opened through termio finds the `termio` the deploy loop installed
-    // beside this daemon — with no dotfile written, the same principle as
-    // never overriding `~/.ssh/config` (docker-lessons RFC §1.2). A bare SSH
-    // login outside termio keeps whatever the box's own profile does.
-    if let Some(directory) = own_binary_directory() {
+    // A directory holding just the paired `termio` leads the session's PATH,
+    // so every terminal opened through termio finds the client the deploy loop
+    // installed beside this daemon — with no dotfile written, the same
+    // principle as never overriding `~/.ssh/config` (docker-lessons RFC §1.2).
+    // A bare SSH login outside termio keeps whatever the box's own profile
+    // does.
+    if let Some(directory) = client_path_directory() {
         lead_path_with(&directory, &mut env);
     }
     env
@@ -1627,9 +1628,17 @@ fn lead_path_with(directory: &str, env: &mut Vec<(String, String)>) {
     }
 }
 
-/// The directory this daemon's binary lives in — `~/.local/bin` on a box —
-/// which is where the deploy loop puts the `termio` that matches this
-/// daemon's build.
+/// A daemon-owned directory holding one symlink — `termio`, pointing at the
+/// client installed beside this daemon — for a session's PATH to lead with.
+///
+/// The client's own directory is deliberately *not* what leads the PATH. It
+/// works only where the daemon is installed somewhere private; where it is
+/// shared (`TERMIOD_REMOTE_BIN=/usr/local/bin/termiod`, or a `/usr/bin`
+/// install) leading with it would put that whole directory ahead of the user's
+/// own PATH, so every session would resolve `node`, `python` and `git` from
+/// there while a plain ssh login resolved them normally. A directory with
+/// exactly one thing in it can be led with safely, and nothing else on the box
+/// changes meaning.
 ///
 /// `None` on a Mac, always. The Mac's client reaches sessions through the
 /// app's own support copy, never through this prepend, and the directory the
@@ -1638,12 +1647,35 @@ fn lead_path_with(directory: &str, env: &mut Vec<(String, String)>) {
 /// `termio` (the cross-channel skew the `termio-dev` naming exists to
 /// prevent), and after a Sparkle update the still-serving old daemon's
 /// bundle path names a client from a build it is not.
-pub(crate) fn own_binary_directory() -> Option<String> {
+///
+/// `None` too when there is no client to point at — a box the deploy loop has
+/// not reached yet — because a prepend that guarantees nothing is only a way
+/// to change a PATH for no reason.
+pub(crate) fn client_path_directory() -> Option<String> {
     if cfg!(target_os = "macos") {
         return None;
     }
-    let exe = std::env::current_exe().ok()?;
-    Some(exe.parent()?.display().to_string())
+    let client = crate::lifecycle::paired_client()?;
+    let directory = crate::paths::durable_state_dir().ok()?.join("bin");
+    if let Err(error) = std::fs::create_dir_all(&directory) {
+        eprintln!("termiod: could not create {}: {error}", directory.display());
+        return None;
+    }
+    let link = directory.join("termio");
+    // Re-pointed rather than trusted: a client-only redeploy can move the
+    // client under a daemon that keeps running, and a link left pointing at
+    // the old path would hand sessions a build the box no longer has.
+    match std::fs::read_link(&link) {
+        Ok(existing) if existing == client => {}
+        _ => {
+            let _ = std::fs::remove_file(&link);
+            if let Err(error) = std::os::unix::fs::symlink(&client, &link) {
+                eprintln!("termiod: could not link {}: {error}", link.display());
+                return None;
+            }
+        }
+    }
+    Some(directory.display().to_string())
 }
 
 /// `directory` put at the front of `path`, or `None` when there is nothing to
@@ -2950,7 +2982,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn a_mac_daemon_never_leads_the_sessions_path() {
-        assert_eq!(super::own_binary_directory(), None);
+        assert_eq!(super::client_path_directory(), None);
     }
 
     /// The write token as a plain str, so the assertions read as they did

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1610,23 +1610,38 @@ fn daemon_owned_env(id: &SessionId, mut env: Vec<(String, String)>) -> Vec<(Stri
     // never overriding `~/.ssh/config` (docker-lessons RFC §1.2). A bare SSH
     // login outside termio keeps whatever the box's own profile does.
     if let Some(directory) = own_binary_directory() {
-        let inherited = env
-            .iter()
-            .rev()
-            .find(|(key, _)| key == "PATH")
-            .map(|(_, value)| value.clone())
-            .or_else(|| std::env::var("PATH").ok());
-        if let Some(path) = path_led_by(&directory, inherited.as_deref()) {
-            env.push(("PATH".to_string(), path));
-        }
+        lead_path_with(&directory, &mut env);
     }
     env
 }
 
-/// The directory this daemon's binary lives in — `~/.local/bin` on a box, the
-/// app bundle's Resources on a Mac — which is where the deploy loop puts the
-/// `termio` that matches this daemon's build.
-fn own_binary_directory() -> Option<String> {
+fn lead_path_with(directory: &str, env: &mut Vec<(String, String)>) {
+    let inherited = env
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "PATH")
+        .map(|(_, value)| value.clone())
+        .or_else(|| std::env::var("PATH").ok());
+    if let Some(path) = path_led_by(directory, inherited.as_deref()) {
+        env.push(("PATH".to_string(), path));
+    }
+}
+
+/// The directory this daemon's binary lives in — `~/.local/bin` on a box —
+/// which is where the deploy loop puts the `termio` that matches this
+/// daemon's build.
+///
+/// `None` on a Mac, always. The Mac's client reaches sessions through the
+/// app's own support copy, never through this prepend, and the directory the
+/// daemon runs from there is actively wrong to advertise: a checkout-run
+/// daemon's `target/release` holds cargo's unsuffixed release-channel
+/// `termio` (the cross-channel skew the `termio-dev` naming exists to
+/// prevent), and after a Sparkle update the still-serving old daemon's
+/// bundle path names a client from a build it is not.
+pub(crate) fn own_binary_directory() -> Option<String> {
+    if cfg!(target_os = "macos") {
+        return None;
+    }
     let exe = std::env::current_exe().ok()?;
     Some(exe.parent()?.display().to_string())
 }
@@ -2916,17 +2931,26 @@ mod tests {
     /// is layered after it and extends it rather than replacing it.
     #[test]
     fn a_client_supplied_path_is_extended_not_replaced() {
-        let env = daemon_owned_env(
-            &SessionId::new("s"),
-            vec![("PATH".to_string(), "/only/what/the/client/sent".to_string())],
-        );
+        let mut env = vec![("PATH".to_string(), "/only/what/the/client/sent".to_string())];
+        super::lead_path_with("/home/u/.local/bin", &mut env);
         let path = env
             .iter()
             .rev()
             .find(|(key, _)| key == "PATH")
             .map(|(_, value)| value.as_str())
             .expect("a PATH entry");
-        assert!(path.ends_with(":/only/what/the/client/sent"), "{path}");
+        assert_eq!(path, "/home/u/.local/bin:/only/what/the/client/sent");
+    }
+
+    /// The prepend is for boxes the deploy loop installed. On a Mac the
+    /// client reaches sessions through the app's own support copy, and the
+    /// daemon's directory — a bundle Sparkle may have replaced, or a cargo
+    /// checkout holding another channel's `termio` — must never lead a
+    /// session's PATH.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_mac_daemon_never_leads_the_sessions_path() {
+        assert_eq!(super::own_binary_directory(), None);
     }
 
     /// The write token as a plain str, so the assertions read as they did

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1604,7 +1604,48 @@ fn daemon_owned_env(id: &SessionId, mut env: Vec<(String, String)>) -> Vec<(Stri
         // which is right whenever this daemon is on the default path too.
         Err(err) => eprintln!("termiod: could not resolve socket path for session env: {err}"),
     }
+    // The daemon's own directory leads the session's PATH, so every terminal
+    // opened through termio finds the `termio` the deploy loop installed
+    // beside this daemon — with no dotfile written, the same principle as
+    // never overriding `~/.ssh/config` (docker-lessons RFC §1.2). A bare SSH
+    // login outside termio keeps whatever the box's own profile does.
+    if let Some(directory) = own_binary_directory() {
+        let inherited = env
+            .iter()
+            .rev()
+            .find(|(key, _)| key == "PATH")
+            .map(|(_, value)| value.clone())
+            .or_else(|| std::env::var("PATH").ok());
+        if let Some(path) = path_led_by(&directory, inherited.as_deref()) {
+            env.push(("PATH".to_string(), path));
+        }
+    }
     env
+}
+
+/// The directory this daemon's binary lives in — `~/.local/bin` on a box, the
+/// app bundle's Resources on a Mac — which is where the deploy loop puts the
+/// `termio` that matches this daemon's build.
+fn own_binary_directory() -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    Some(exe.parent()?.display().to_string())
+}
+
+/// `directory` put at the front of `path`, or `None` when there is nothing to
+/// do. Prepended even when the directory already appears further back: an
+/// older `termio` earlier on the PATH would otherwise shadow the one shipped
+/// beside this daemon, which is exactly the skew the same-pass deploy exists
+/// to rule out. No PATH at all is left alone — a PATH invented from one
+/// directory would cost the child every standard tool.
+fn path_led_by(directory: &str, path: Option<&str>) -> Option<String> {
+    let path = path?;
+    if path.is_empty() {
+        return Some(directory.to_string());
+    }
+    if path.split(':').next() == Some(directory) {
+        return None;
+    }
+    Some(format!("{directory}:{path}"))
 }
 
 /// Everything a session actor hands over when its daemon is about to `execve`
@@ -2796,7 +2837,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
 #[cfg(test)]
 mod tests {
     use super::{
-        daemon_owned_env, handle_msg, should_emit_keyframe, spawn_sidecar, ClientBacklog,
+        daemon_owned_env, handle_msg, path_led_by, should_emit_keyframe, spawn_sidecar, ClientBacklog,
         ClientDelivery, ClientEntry, ClientEvent, ClientPlane, ClientRole, Session, SessionHandle,
         SessionMsg, Sidecar, SidecarCommand, SidecarQueue, SidecarResult, Vt,
     };
@@ -2844,6 +2885,48 @@ mod tests {
                 .map(|(_, value)| value.as_str()),
             Some("real")
         );
+    }
+
+    /// §1.2 of the docker-lessons RFC: every session this daemon spawns finds
+    /// the `termio` installed beside it, because the daemon's own directory
+    /// leads the session's PATH — and no dotfile is ever written for it.
+    #[test]
+    fn the_daemons_directory_leads_the_sessions_path() {
+        assert_eq!(
+            path_led_by("/home/u/.local/bin", Some("/usr/bin:/bin")),
+            Some("/home/u/.local/bin:/usr/bin:/bin".to_string())
+        );
+        // Already leading: nothing to change.
+        assert_eq!(path_led_by("/home/u/.local/bin", Some("/home/u/.local/bin:/usr/bin")), None);
+        // Present but shadowed: still prepended, so the client shipped beside
+        // this daemon wins over a stray older install.
+        assert_eq!(
+            path_led_by("/home/u/.local/bin", Some("/opt/stale:/home/u/.local/bin")),
+            Some("/home/u/.local/bin:/opt/stale:/home/u/.local/bin".to_string())
+        );
+        // No PATH to prepend to is not a PATH to invent.
+        assert_eq!(path_led_by("/home/u/.local/bin", None), None);
+        assert_eq!(
+            path_led_by("/home/u/.local/bin", Some("")),
+            Some("/home/u/.local/bin".to_string())
+        );
+    }
+
+    /// A client-supplied PATH is the base, not a casualty: the daemon's entry
+    /// is layered after it and extends it rather than replacing it.
+    #[test]
+    fn a_client_supplied_path_is_extended_not_replaced() {
+        let env = daemon_owned_env(
+            &SessionId::new("s"),
+            vec![("PATH".to_string(), "/only/what/the/client/sent".to_string())],
+        );
+        let path = env
+            .iter()
+            .rev()
+            .find(|(key, _)| key == "PATH")
+            .map(|(_, value)| value.as_str())
+            .expect("a PATH entry");
+        assert!(path.ends_with(":/only/what/the/client/sent"), "{path}");
     }
 
     /// The write token as a plain str, so the assertions read as they did

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1661,21 +1661,56 @@ pub(crate) fn client_path_directory() -> Option<String> {
         eprintln!("termiod: could not create {}: {error}", directory.display());
         return None;
     }
-    let link = directory.join("termio");
-    // Re-pointed rather than trusted: a client-only redeploy can move the
-    // client under a daemon that keeps running, and a link left pointing at
-    // the old path would hand sessions a build the box no longer has.
-    match std::fs::read_link(&link) {
-        Ok(existing) if existing == client => {}
-        _ => {
-            let _ = std::fs::remove_file(&link);
-            if let Err(error) = std::os::unix::fs::symlink(&client, &link) {
-                eprintln!("termiod: could not link {}: {error}", link.display());
-                return None;
-            }
+    match place_client_link(&directory, &client) {
+        Ok(()) => Some(directory.display().to_string()),
+        Err(error) => {
+            eprintln!(
+                "termiod: could not point {}/termio at {}: {error}",
+                directory.display(),
+                client.display()
+            );
+            None
         }
     }
-    Some(directory.display().to_string())
+}
+
+/// Distinguishes the staging names two spawns in this process may need at the
+/// same instant — the pid alone does not, and both would then write one path.
+static LINK_ATTEMPT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Point `<directory>/termio` at `client`, replacing whatever is there.
+///
+/// Re-pointed rather than trusted: a client-only redeploy can move the client
+/// under a daemon that keeps running, and a link left pointing at the old path
+/// would hand sessions a build the box no longer has.
+///
+/// Replaced by rename, never by remove-then-create. Two sessions spawning at
+/// once both take this path on the first spawn after a daemon starts, and
+/// unlinking first gave them a window where the link was missing — a child
+/// exec'ing at that instant finding nothing, and the loser of the race failing
+/// `EEXIST` and handing its session no `PATH` entry at all. `rename` is atomic:
+/// every reader sees the old link or the new one, and concurrent placements
+/// all succeed.
+fn place_client_link(
+    directory: &std::path::Path,
+    client: &std::path::Path,
+) -> std::io::Result<()> {
+    let link = directory.join("termio");
+    if std::fs::read_link(&link).ok().as_deref() == Some(client) {
+        return Ok(());
+    }
+    let staging = directory.join(format!(
+        "termio.{}.{}",
+        std::process::id(),
+        LINK_ATTEMPT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_file(&staging);
+    std::os::unix::fs::symlink(client, &staging)?;
+    if let Err(error) = std::fs::rename(&staging, &link) {
+        let _ = std::fs::remove_file(&staging);
+        return Err(error);
+    }
+    Ok(())
 }
 
 /// `directory` put at the front of `path`, or `None` when there is nothing to
@@ -2983,6 +3018,74 @@ mod tests {
     #[test]
     fn a_mac_daemon_never_leads_the_sessions_path() {
         assert_eq!(super::client_path_directory(), None);
+    }
+
+    /// Sessions spawning at once all get a usable link. Removing the old link
+    /// before creating the new one failed both halves of that: the loser of the
+    /// race got `EEXIST` and its session no `PATH` entry at all, and until the
+    /// winner finished there was an instant with no link for a child to exec.
+    #[test]
+    fn concurrent_spawns_all_get_the_client_link() {
+        let root = std::path::PathBuf::from(format!(
+            "/tmp/termiod-link-{}-{}",
+            std::process::id(),
+            "concurrent"
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("test directory");
+        let client = root.join("termio-real");
+        std::fs::write(&client, b"#!/bin/sh\n").expect("client");
+        let directory = root.join("bin");
+        std::fs::create_dir_all(&directory).expect("link directory");
+        // A stale link, so every caller takes the replacing path rather than
+        // the read-link fast path.
+        std::os::unix::fs::symlink(root.join("termio-old"), directory.join("termio"))
+            .expect("stale link");
+
+        let failures = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let absent = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let directory = directory.clone();
+                let client = client.clone();
+                let failures = std::sync::Arc::clone(&failures);
+                scope.spawn(move || {
+                    if super::place_client_link(&directory, &client).is_err() {
+                        failures.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                });
+            }
+            // A reader standing in for a child about to exec. What it must never
+            // see is the link *gone*, which is what unlinking first produced;
+            // `rename` leaves the name occupied throughout.
+            let link = directory.join("termio");
+            let absent = std::sync::Arc::clone(&absent);
+            scope.spawn(move || {
+                for _ in 0..2_000 {
+                    if matches!(
+                        std::fs::read_link(&link),
+                        Err(ref error) if error.kind() == std::io::ErrorKind::NotFound
+                    ) {
+                        absent.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+            });
+        });
+
+        assert_eq!(failures.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(absent.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(
+            std::fs::read_link(directory.join("termio")).expect("a link"),
+            client
+        );
+        // Nothing is left behind but the link itself.
+        let entries: Vec<_> = std::fs::read_dir(&directory)
+            .expect("read")
+            .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+            .collect();
+        assert_eq!(entries.len(), 1, "{entries:?}");
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The write token as a plain str, so the assertions read as they did


### PR DESCRIPTION
Items 1 and 2 of #628, per the amended §1.2 of the docker-lessons RFC.

**The deploy ships the client.** The reconcile loop installs `~/.local/bin/termio` beside `termiod` in the same pass — two uploads, one activation command carrying the same copy-beside-rename-over discipline for both binaries — so a box's client and daemon are always the same build. `termiod status` now reports the client beside the binary (executed, not stat'ed: installed means "answers `--version`"), a box whose daemon is current but whose client is missing or from another build is staged again, deploy verification requires the installed client to answer `--version` with the new build's stamp, and a rollback restores the previous client along with the previous daemon. A box a newer control plane owns is still left alone, client included. `build-app.sh` ships the Linux client slices next to the daemon slices the bundle already carried — the same cargo build produces both, so it is only a copy.

**The daemon leads sessions' PATH.** `termiod` keeps a directory holding one symlink to the paired `termio` and leads every spawned session's PATH with it — a directory of its own rather than the daemon's, so a daemon installed in a shared `bin` never puts the rest of that directory ahead of the user's own PATH. The entry is injected next to the existing `TERMIOD_SESSION_ID` entry and layered after the client's env, so it extends the session's PATH rather than replacing it. A session started with a command — every agent — re-asserts the entry on the login shell's own command line, after the startup files have run, which is where Debian's `/etc/profile` would otherwise reassign PATH out from under it. A plain terminal has no such command line to hang the re-assertion on (wrapping it in a second shell would consume the OSC 133 shim `Pty::spawn` routes exactly one zsh startup through, trading resize reflow for a PATH entry), so there it resolves `termio` only if the install directory is on the PATH the profile builds — `~/.local/bin` is, for the shells that read `~/.profile`. `DEPLOY.md` states this boundary. No dotfile is written, and a bare SSH login outside termio is untouched.

Out of scope, per the ship order in #628: box-side verb routing (item 3, rides the Stage 10 verb ladder in #555) and the DEPLOY.md teaching flip (item 5) beyond the two paragraphs these mechanisms make true.

Validation: `cargo build` and `cargo test` in `termiod/` (343 lib tests + integration suites green). New coverage: the same-pass stage payload and command, restaging a current daemon with a missing client, failing verification and rolling back on a client that cannot answer `--version`, client-path derivation under `TERMIOD_REMOTE_BIN`, and the PATH-prepend rules (leads, extends a client-supplied PATH, no PATH invented, a shadowed install still loses to the paired one).

Release Notes:
- Deploying to a box now installs the `termio` client beside `termiod`, verified as the same build, and agent sessions the daemon spawns find it on their PATH without any dotfile edits.

Closes nothing; #628 stays open for items 3–5.
