### PR TITLE
Show the live git branch for sessions on other machines

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -2729,8 +2729,13 @@ private struct BranchPickerToolbarView: View {
     }
 
     private var branch: String? {
-        // No local branch for a remote SSH session — its $HOME launch dir isn't the repo.
-        guard store.selectedSessionID.flatMap(store.session)?.sshHost == nil else { return nil }
+        // A checkout on another machine gets its label from that machine's own
+        // daemon (the `head:` resource) — the local model cannot see it, and a
+        // local path that merely spells the same would be the wrong repo. A box
+        // with no daemon simply never answers, and the chip stays hidden.
+        if let checkout = store.inspectorCheckout, checkout.isOnAnotherDevice {
+            return store.deviceBranch(forCheckout: checkout)
+        }
         guard let folder, let branch = store.branch(forFolder: folder), !branch.isEmpty else { return nil }
         return branch
     }

--- a/Sources/termio/Git/DeviceBranchModel.swift
+++ b/Sources/termio/Git/DeviceBranchModel.swift
@@ -1,0 +1,179 @@
+import TermioShared
+import Foundation
+import Combine
+
+/// Keeps a live branch label for checkouts on other machines — `BranchModel`'s
+/// device-side twin, with the read and the watch relocated across the wire. The
+/// daemon rides the workspace watch it already runs and re-reads `HEAD`
+/// in-process (`termiod/src/git.rs` `read_head`, the `head:` resource), so a
+/// `git checkout` on the box updates the label here the way a local one does —
+/// without the per-event `git status` the Changes pane's `git:` subscription
+/// costs, which is what makes it affordable while the checkout is merely on
+/// screen.
+///
+/// Batches are full state, never deltas: applying one is a replacement. A box
+/// without a daemon, or with one too old to know `head:`, simply never answers,
+/// and the label stays hidden — exactly what those sessions showed before.
+///
+/// Identity is the checkout — the machine *and* the root — because a remote
+/// path can spell exactly like a local one (`~/repo` here and on the box), and
+/// a label keyed by bare path would show one machine's branch beside the
+/// other's name.
+@MainActor
+final class DeviceBranchModel: ObservableObject {
+    struct Key: Hashable {
+        /// `Checkout.deviceIdentity`: the `host_id` once a handshake has
+        /// revealed one, the alias until then.
+        let device: String
+        let root: String
+    }
+
+    /// Checkout → branch label (the branch name, or a short commit hash when
+    /// the checkout is in a detached HEAD). Absent while the device has not
+    /// answered — or answered "not a repo" — so callers hide the chip.
+    @Published private(set) var branches: [Key: String] = [:]
+    @Published private(set) var detachedCheckouts: Set<Key> = []
+
+    /// One armed `head:` subscription. The subscription object *is* the
+    /// interest — releasing the last reference retires the watch on the device
+    /// — so holding it here is what keeps the label live, and dropping the
+    /// entry is the whole unsubscribe.
+    private final class Watch {
+        var subscription: Termiod.ResourceSubscription?
+        /// A handshake is in flight. What keeps a `setWatched` re-poke and the
+        /// interruption retry from opening a second subscription over the one
+        /// still being negotiated.
+        var arming = false
+        /// The last applied cursor, so two batches hopping to the main actor as
+        /// separate tasks cannot land out of order and roll the label back.
+        /// Reset when the watch re-arms: a resubscribe is served full state at
+        /// whatever cursor the device is at, including a lower one after a
+        /// daemon restart.
+        var lastSeq: UInt64 = 0
+    }
+
+    private var watches: [Key: Watch] = [:]
+
+    func branch(for checkout: Checkout) -> String? {
+        Self.key(for: checkout).flatMap { branches[$0] }
+    }
+
+    func isDetached(_ checkout: Checkout) -> Bool {
+        guard let key = Self.key(for: checkout) else { return false }
+        return detachedCheckouts.contains(key)
+    }
+
+    /// Reconciles the watched set: arms any newly wanted checkout and drops any
+    /// that has gone, forgetting its label. Idempotent, so the store can call it
+    /// on every selection change. Checkouts on this Mac are ignored — they are
+    /// `BranchModel`'s to watch.
+    func setWatched(_ checkouts: [Checkout]) {
+        var wanted: [Key: TermiodRoute] = [:]
+        for checkout in checkouts {
+            guard let key = Self.key(for: checkout) else { continue }
+            wanted[key] = checkout.device.route
+        }
+        for key in watches.keys where wanted[key] == nil {
+            watches[key] = nil
+            if branches[key] != nil { branches[key] = nil }
+            detachedCheckouts.remove(key)
+        }
+        for (key, route) in wanted {
+            if let existing = watches[key] {
+                // A watch whose handshake failed (the box was asleep, say) sits
+                // here unarmed; the next reconcile — a selection change, the app
+                // becoming active — is its retry.
+                if existing.subscription == nil, !existing.arming {
+                    arm(key, route: route, watch: existing)
+                }
+                continue
+            }
+            let watch = Watch()
+            watches[key] = watch
+            arm(key, route: route, watch: watch)
+        }
+    }
+
+    private static func key(for checkout: Checkout) -> Key? {
+        guard checkout.isOnAnotherDevice, let root = checkout.root else { return nil }
+        return Key(device: checkout.deviceIdentity, root: root)
+    }
+
+    /// Opens the subscription for one checkout. Every completion is guarded by
+    /// the `Watch`'s identity: a handshake or batch that outlives the interest
+    /// that asked for it finds a different (or no) entry under its key and
+    /// stands down — releasing the orphaned subscription, which retires the
+    /// device's watch.
+    private func arm(_ key: Key, route: TermiodRoute, watch: Watch) {
+        watch.lastSeq = 0
+        watch.arming = true
+        // The wire closures are `@Sendable` and must not carry the main-actor
+        // `Watch`; they carry its identity instead, and every hop back resolves
+        // the *current* entry under the key and compares — a delivery that
+        // outlives the interest that asked for it finds a different (or no)
+        // watch and stands down.
+        let token = ObjectIdentifier(watch)
+        Task { [weak self] in
+            defer {
+                if let self, let current = self.watches[key],
+                   ObjectIdentifier(current) == token {
+                    current.arming = false
+                }
+            }
+            do {
+                let (subscription, _, _) = try await Termiod.watchHead(
+                    route: route,
+                    root: key.root,
+                    onBatch: { [weak self] batch in
+                        Task { @MainActor [weak self] in
+                            guard let self, let current = self.watches[key],
+                                  ObjectIdentifier(current) == token else { return }
+                            self.apply(batch, to: current, key: key)
+                        }
+                    },
+                    onInterrupted: { [weak self] in
+                        Task { @MainActor [weak self] in
+                            guard let self, let current = self.watches[key],
+                                  ObjectIdentifier(current) == token else { return }
+                            self.interrupted(key, route: route, watch: current)
+                        }
+                    })
+                guard let self, let current = self.watches[key],
+                      ObjectIdentifier(current) == token else { return }
+                current.subscription = subscription
+            } catch {
+                // The box is unreachable, its daemon predates `head:`, or the
+                // root is not a repository there. The label stays hidden — the
+                // honest answer, and what these sessions always showed.
+            }
+        }
+    }
+
+    private func apply(_ batch: Termiod.HeadChangedPayload, to watch: Watch, key: Key) {
+        guard batch.seq > watch.lastSeq else { return }
+        watch.lastSeq = batch.seq
+        let label = batch.branch ?? batch.head
+        let detached = batch.branch == nil && batch.head != nil
+        if detached != detachedCheckouts.contains(key) {
+            if detached {
+                detachedCheckouts.insert(key)
+            } else {
+                detachedCheckouts.remove(key)
+            }
+        }
+        if branches[key] != label { branches[key] = label }
+    }
+
+    /// The channel dropped. The label is kept — the checkout did not stop
+    /// having a branch, the pipe stopped saying so — and the watch re-arms
+    /// after a beat, resuming as full state.
+    private func interrupted(_ key: Key, route: TermiodRoute, watch: Watch) {
+        watch.subscription = nil
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard let self, self.watches[key] === watch,
+                  watch.subscription == nil, !watch.arming else { return }
+            self.arm(key, route: route, watch: watch)
+        }
+    }
+}

--- a/Sources/termio/Terminal/Termiod/TermiodGit.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodGit.swift
@@ -27,6 +27,31 @@ extension Termiod {
     /// The `git:` resource id for a checkout — `resource.rs` `GIT_PREFIX`.
     static func gitResource(root: String) -> String { "git:\(root)" }
 
+    /// The `head:` resource id for a checkout — `resource.rs` `HEAD_PREFIX`.
+    static func headResource(root: String) -> String { "head:\(root)" }
+
+    /// One `head_changed` batch. Full state, not a delta: the branch the
+    /// checkout is on, or the commit it is detached at — each batch replaces
+    /// what the subscriber holds.
+    struct HeadChangedPayload: Sendable {
+        let seq: UInt64
+        /// The branch HEAD names, `nil` when detached — or when the root is
+        /// not a repository, which is how the label knows to hide.
+        let branch: String?
+        /// The short hash a detached HEAD sits at.
+        let head: String?
+    }
+
+    static func decodeHeadChanged(_ payload: Data) throws -> HeadChangedPayload {
+        struct WireHeadChanged: Decodable {
+            let seq: UInt64?
+            let branch: String?
+            let head: String?
+        }
+        let wire = try gitDecoder().decode(WireHeadChanged.self, from: payload)
+        return HeadChangedPayload(seq: wire.seq ?? 0, branch: wire.branch, head: wire.head)
+    }
+
     /// One `git_changed` batch: a delta against the subscriber's baseline, with
     /// branch metadata carried whole so a client never merges it.
     struct GitChangedPayload: Sendable {
@@ -252,6 +277,32 @@ extension Termiod {
                 since: since,
                 onEvent: { payload in
                     guard let batch = try? decodeGitChanged(payload) else { return }
+                    onBatch(batch)
+                },
+                onInterrupted: onInterrupted)
+        }
+    }
+
+    /// Subscribes to the checkout's HEAD alone. Unlike `git:`, whose every
+    /// event costs the device a `git status` run and is rightly reserved for
+    /// an open Changes pane, a `head:` event costs one file read — cheap
+    /// enough to keep armed while the checkout is merely on screen, which is
+    /// what a branch label beside a name needs.
+    static func watchHead(
+        route: TermiodRoute,
+        root: String,
+        since: UInt64? = nil,
+        onBatch: @escaping @Sendable (HeadChangedPayload) -> Void,
+        onInterrupted: @escaping @Sendable () -> Void
+    ) async throws -> (subscription: ResourceSubscription, gap: Bool, seq: UInt64) {
+        try await offMain {
+            try subscribeResource(
+                route: route,
+                caps: gitCapabilities,
+                resource: headResource(root: root),
+                since: since,
+                onEvent: { payload in
+                    guard let batch = try? decodeHeadChanged(payload) else { return }
                     onBatch(batch)
                 },
                 onInterrupted: onInterrupted)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -106,6 +106,9 @@ final class TermioStore: ObservableObject {
                 // forced past the coalesce window since it's a deliberate user action.
                 if let pid = project(for: id)?.id { noteProjectActivity(pid, force: true) }
             }
+            // The title bar's branch chip follows the selection onto whatever
+            // machine its checkout lives on.
+            syncDeviceBranchWatch()
             // Debounced, not inline: moving the selection is the most frequent
             // edit in the app — every row click, every ⌘⇧], every workspace
             // switch — and a synchronous encode-and-write of the whole tree on
@@ -946,6 +949,11 @@ final class TermioStore: ObservableObject {
     /// from here, so a `git checkout` inside a session updates the UI on its own.
     let branchModel = BranchModel()
 
+    /// The same label for checkouts on other machines, fed by each device's
+    /// `head:` resource instead of a local file watch. The title bar reads the
+    /// selected session's from here (see `deviceBranch(forCheckout:)`).
+    let deviceBranchModel = DeviceBranchModel()
+
     /// Realized file trees per root directory, so returning to a checkout hands the
     /// outline its tree back instead of rebuilding it. Lives here, beside the
     /// surface cache, for the same reason that one does: the model has to outlive
@@ -1065,6 +1073,7 @@ final class TermioStore: ObservableObject {
     private(set) var lastHostGridRows: Int
     private var settingsObserver: AnyCancellable?
     private var branchObserver: AnyCancellable?
+    private var deviceBranchObserver: AnyCancellable?
     private var linkObserver: AnyCancellable?
     private var appActiveObserver: AnyCancellable?
     /// Debounces the worktree re-scan so a burst of git-dir events (a rebase, a fetch)
@@ -1199,6 +1208,9 @@ final class TermioStore: ObservableObject {
         branchObserver = branchModel.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.objectWillChange.send() }
+        deviceBranchObserver = deviceBranchModel.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.objectWillChange.send() }
 
         // Cmd-clicking a link in any terminal surface republishes here (see `TerminalLinkOpening`):
         // route local files into the read-only preview overlay and hand web links to the system.
@@ -1225,6 +1237,9 @@ final class TermioStore: ObservableObject {
             return nil
         }
         syncWatchedFolders()
+        // The designated init set the selection without firing its didSet, so
+        // the selected checkout's device watch has to be armed by hand once.
+        syncDeviceBranchWatch()
 
         // Keep the worktree list honest against git, so worktrees made on the CLI show up
         // and ones removed drop out. Re-scan the affected project when a watched folder's
@@ -1238,6 +1253,9 @@ final class TermioStore: ObservableObject {
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.scheduleWorktreeReconcile()
+                // Also the retry for a device branch watch whose box was
+                // unreachable when the selection landed on it.
+                self.syncDeviceBranchWatch()
                 // Re-assert agent hooks on refocus: a third-party tool can overwrite the
                 // shared hooks file while termio is backgrounded, wiping ours. Re-installing
                 // restores them (and drops the conflicting entries); skipped when the file
@@ -1281,6 +1299,24 @@ final class TermioStore: ObservableObject {
             }
         }
         branchModel.setWatched(folders)
+    }
+
+    /// The live branch label for a checkout on another machine, from that
+    /// device's `head:` resource. `nil` — no daemon over there, no repo at the
+    /// root, no answer yet — hides the chip, exactly as the local model does.
+    func deviceBranch(forCheckout checkout: Checkout) -> String? {
+        deviceBranchModel.branch(for: checkout)
+    }
+
+    /// Tells the DeviceBranchModel which checkout to keep a live label for: the
+    /// selected session's, when it lives on another machine. One checkout
+    /// rather than the whole tree, because the title bar names only the
+    /// selection and every armed watch is a subscription the box holds open.
+    /// Called on every selection change and when the app becomes active — the
+    /// reconcile is idempotent, and re-calling it is also what retries a watch
+    /// whose device was unreachable the first time.
+    func syncDeviceBranchWatch() {
+        deviceBranchModel.setWatched([inspectorCheckout].compactMap { $0 })
     }
 
     /// Coalesces a burst of git-state events into a single re-scan a beat later,

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -3,7 +3,7 @@ title: termiod Session Protocol
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-09-08
+updated: 2026-09-09
 related:
   - 20260730-termiod-session-mux.md
   - 20260708-session-daemon-architecture.md
@@ -73,7 +73,14 @@ one is. The Mac makes surfaces for sessions no pane is showing — a phone openi
 one it never displayed — and each of those took the session's size for a frame
 before its first `R` gave it back. Same fact as `R`'s flags byte
 (`20260901-pty-size-is-not-the-write-token.md` §5.1); absent is `true`, so no
-client written before it changes. -->
+client written before it changes.
+2026-09-09: §C.13 gained the `head:` sibling kind — the checkout's HEAD alone
+(`head_changed {branch?, head?}`, full state per batch), read in-process off
+the same workspace watcher with no git child, so a client can keep a branch
+label live for every checkout it shows without the per-event `git status` the
+`git:` kind costs. Gated on the same `git` capability. Implemented in
+`termiod/src/resource.rs` (`head_loop`) and `git.rs` (`read_head`); first
+consumer is the Mac title bar's branch chip for sessions on other machines. -->
 
 
 # Design: termiod Session Protocol
@@ -870,6 +877,24 @@ no verb of its own. Every reply is capped and says so rather than being cut
 silently, and every one of them runs the box's own `git` as a child process
 with `--no-optional-locks` — nothing here reimplements git, and a read cannot
 contend with the agent committing in the terminal beside it.
+
+**The `head:` sibling kind** (2026-09-09) answers the one question a client
+asks about every checkout it *shows* rather than the one it has open: which
+branch is it on. Id `head:<canonical repo root>`, same cursor/ring/gap/linger,
+same `git` capability gate; every batch is the full state, so a gap subscriber
+is simply served the current snapshot:
+
+```
+E {ev:"head_changed", resource:"head:/work/termio", seq:3, branch?, head?}
+```
+
+`branch` absent with `head` set is a detached HEAD at that (short) commit. The
+host reads `.git/HEAD` in-process — resolving a linked worktree's `gitdir`
+pointer file — and spawns nothing, which is what makes the kind affordable
+always-on where `git:`'s per-event status run is reserved for an open Changes
+pane. Like `git:`, it re-reads on any watcher batch, not only `git_meta`: a
+linked worktree's HEAD lives *outside* the watched root, so the checkout that
+moves it arrives here only as the tree it rewrote.
 
 This still deletes the majority of Zed's git surface (mutation RPCs,
 optimistic-update reconciliation, a write-permission model). The mutation and

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1815,7 +1815,9 @@ async fn process_control(
                     "the resources capability was not negotiated",
                     false,
                 )
-            } else if resource.starts_with("git:") && !connection.capabilities.contains("git") {
+            } else if (resource.starts_with("git:") || resource.starts_with("head:"))
+                && !connection.capabilities.contains("git")
+            {
                 error(
                     seq,
                     ErrorCode::Denied,
@@ -2749,6 +2751,7 @@ fn subscribed_to(subscriptions: &HashSet<String>, event: &Event) -> bool {
         // through the roster broadcast, so they never match here.
         Event::FsChanged { .. }
         | Event::GitChanged { .. }
+        | Event::HeadChanged { .. }
         | Event::StatusChanged { .. }
         | Event::SearchResults { .. } => false,
         Event::Unknown => false,

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -211,6 +211,80 @@ impl GitBatch {
     }
 }
 
+/// Everything a `head:` resource says: which branch the checkout is on, or the
+/// commit it is detached at. This is the branch label a client keeps beside a
+/// checkout's name — always on, for every checkout a sidebar shows — so it has
+/// to cost nothing: one file read per workspace event, no git child. The full
+/// `git:` kind runs a status per event and is rightly reserved for an open
+/// Changes pane.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HeadSnapshot {
+    /// The branch `HEAD` names, `None` when detached — the same split the
+    /// `git_changed` metadata carries.
+    pub branch: Option<String>,
+    /// The commit a detached `HEAD` sits at, abbreviated to 7 characters. A
+    /// display label does not need git's ambiguity-aware lengthening, and
+    /// asking for it would cost the child process this kind exists to avoid.
+    pub head: Option<String>,
+}
+
+impl HeadSnapshot {
+    pub fn into_event(self, resource: String, seq: u64) -> Event {
+        Event::HeadChanged {
+            resource,
+            seq,
+            branch: self.branch,
+            head: self.head,
+        }
+    }
+}
+
+/// Read the checkout's HEAD without spawning git: `.git/HEAD` is either
+/// `ref: refs/heads/<branch>` or a bare commit hash. A linked worktree's
+/// `.git` is a *file* holding `gitdir: <admin dir>`, and its HEAD lives there.
+/// Any failure — not a repo, unreadable, garbage — is the empty snapshot: the
+/// client hides the label, the same degrade the Mac's own HEAD parser takes.
+pub fn read_head(root: &str) -> HeadSnapshot {
+    let dot_git = Path::new(root).join(".git");
+    let head_path = if dot_git.is_dir() {
+        dot_git.join("HEAD")
+    } else {
+        let Ok(pointer) = std::fs::read_to_string(&dot_git) else {
+            return HeadSnapshot::default();
+        };
+        let Some(git_dir) = pointer.trim().strip_prefix("gitdir:").map(str::trim) else {
+            return HeadSnapshot::default();
+        };
+        let git_dir = if Path::new(git_dir).is_absolute() {
+            std::path::PathBuf::from(git_dir)
+        } else {
+            Path::new(root).join(git_dir)
+        };
+        git_dir.join("HEAD")
+    };
+    let Ok(raw) = std::fs::read_to_string(&head_path) else {
+        return HeadSnapshot::default();
+    };
+    let content = raw.trim();
+    if let Some(reference) = content.strip_prefix("ref: ") {
+        let label = reference.strip_prefix("refs/heads/").unwrap_or(reference);
+        if label.is_empty() {
+            return HeadSnapshot::default();
+        }
+        return HeadSnapshot {
+            branch: Some(label.to_string()),
+            head: None,
+        };
+    }
+    if content.len() >= 7 && content.chars().all(|c| c.is_ascii_hexdigit()) {
+        return HeadSnapshot {
+            branch: None,
+            head: Some(content[..7].to_string()),
+        };
+    }
+    HeadSnapshot::default()
+}
+
 /// Run `git status --porcelain=v2 -z` for the repo at `root`.
 /// `--no-optional-locks` matters: a plain `git status` refreshes the index
 /// file, which the workspace watcher reports as `git_meta`, which would
@@ -2090,5 +2164,94 @@ mod tests {
         assert_eq!(list.branches.len(), BRANCH_CAP);
         assert!(list.truncated);
         assert_eq!(list.current, None);
+    }
+
+    /// `read_head` must agree with git about every HEAD shape a checkout can
+    /// be in — on a branch, detached, and inside a linked worktree, whose
+    /// `.git` is a pointer file rather than a directory — without ever
+    /// spawning git to find out.
+    #[test]
+    fn read_head_names_the_branch_the_detachment_and_the_linked_worktree() {
+        let dir = scratch_repo("read-head");
+        let root = dir.to_string_lossy().into_owned();
+        write(&dir, "a.txt", "one\n");
+        let first = commit(&dir, "first");
+
+        assert_eq!(
+            read_head(&root),
+            HeadSnapshot {
+                branch: Some("main".to_string()),
+                head: None
+            }
+        );
+
+        run_git(&dir, &["checkout", "-q", "-b", "feat/branch-chip"]);
+        assert_eq!(
+            read_head(&root).branch.as_deref(),
+            Some("feat/branch-chip")
+        );
+
+        run_git(&dir, &["checkout", "-q", "--detach", &first]);
+        let detached = read_head(&root);
+        assert_eq!(detached.branch, None);
+        assert_eq!(detached.head.as_deref(), Some(&first[..7]));
+
+        let linked = dir.with_file_name(format!(
+            "termiod-git-read-head-linked-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&linked);
+        run_git(
+            &dir,
+            &["worktree", "add", "-q", "-b", "linked", linked.to_str().unwrap(), "main"],
+        );
+        assert_eq!(
+            read_head(&linked.to_string_lossy()).branch.as_deref(),
+            Some("linked"),
+            "a linked worktree's HEAD is resolved through its gitdir pointer"
+        );
+
+        let _ = std::fs::remove_dir_all(&linked);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A directory git knows nothing about answers the empty snapshot — the
+    /// client hides the label — never an error.
+    #[test]
+    fn read_head_outside_a_repository_is_empty_not_an_error() {
+        let dir = std::env::temp_dir().join(format!(
+            "termiod-git-read-head-bare-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(read_head(&dir.to_string_lossy()), HeadSnapshot::default());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The wire shape the Mac decodes: `ev` names the kind, absent halves stay
+    /// off the wire entirely.
+    #[test]
+    fn head_snapshot_serializes_to_the_documented_event() {
+        let event = HeadSnapshot {
+            branch: Some("main".to_string()),
+            head: None,
+        }
+        .into_event("head:/repo".to_string(), 3);
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["ev"], "head_changed");
+        assert_eq!(json["resource"], "head:/repo");
+        assert_eq!(json["seq"], 3);
+        assert_eq!(json["branch"], "main");
+        assert!(json.get("head").is_none(), "a detached hash absent stays off the wire");
+
+        let detached = HeadSnapshot {
+            branch: None,
+            head: Some("abc1234".to_string()),
+        }
+        .into_event("head:/repo".to_string(), 4);
+        let json = serde_json::to_value(&detached).unwrap();
+        assert!(json.get("branch").is_none());
+        assert_eq!(json["head"], "abc1234");
     }
 }

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -1468,6 +1468,20 @@ pub enum Event {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         total: Option<u64>,
     },
+    /// The checkout's HEAD for a `head:` resource — the branch it is on, or
+    /// the commit it is detached at (`branch` absent, `head` a short hash).
+    /// Full state, not a delta: each batch replaces what the subscriber holds,
+    /// so the label beside a checkout's name can be kept live for every
+    /// checkout a client shows without the per-event `git status` the `git:`
+    /// kind costs.
+    HeadChanged {
+        resource: String,
+        seq: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        head: Option<String>,
+    },
     /// Roster delta used by control-channel `subscribe`.
     Roster {
         session: String,

--- a/termiod/src/resource.rs
+++ b/termiod/src/resource.rs
@@ -65,6 +65,9 @@ pub const STATUS_ID: &str = "status:";
 /// The `git:` resource id prefix (§C.13). Ids are `git:<canonical repo root>`.
 pub const GIT_PREFIX: &str = "git:";
 
+/// The `head:` resource id prefix. Ids are `head:<canonical repo root>`.
+pub const HEAD_PREFIX: &str = "head:";
+
 /// Extra quiet window between a watcher batch reaching the git loop and the
 /// `git status` run, so one `git checkout` costs one status run, not one per
 /// batch.
@@ -154,6 +157,12 @@ impl ResourceBatch for StatusBatch {
 impl ResourceBatch for crate::git::GitBatch {
     fn into_event(self, resource: String, seq: u64) -> Event {
         crate::git::GitBatch::into_event(self, resource, seq)
+    }
+}
+
+impl ResourceBatch for crate::git::HeadSnapshot {
+    fn into_event(self, resource: String, seq: u64) -> Event {
+        crate::git::HeadSnapshot::into_event(self, resource, seq)
     }
 }
 
@@ -315,6 +324,18 @@ struct GitEntry {
     snapshot: Arc<Mutex<crate::git::GitSnapshot>>,
 }
 
+/// A `head:` resource: the checkout's HEAD alone. Like `git:` it owns no
+/// watcher — it rides the workspace's `fs:` watch — but its refresh is one
+/// in-process file read, never a git child, which is what makes it affordable
+/// to keep armed for every checkout a client shows a label beside. Every batch
+/// is the full state, so `snapshot` and the ring answer a gap identically:
+/// with what HEAD says now.
+#[derive(Clone)]
+struct HeadEntry {
+    state: Arc<Mutex<ResourceState<crate::git::HeadSnapshot>>>,
+    snapshot: Arc<Mutex<crate::git::HeadSnapshot>>,
+}
+
 /// The `status:` resource. Like `git:` it owns no watcher — the session actors
 /// produce its batches — but unlike `git:` it cannot rescan on gap: a status is
 /// a history of transitions, and only the roster says what is true *now*. A gap
@@ -326,6 +347,7 @@ type StatusEntry = Arc<Mutex<ResourceState<StatusBatch>>>;
 enum ResourceEntry {
     Fs(WatchEntry),
     Git(GitEntry),
+    Head(HeadEntry),
     Status(StatusEntry),
 }
 
@@ -363,13 +385,16 @@ impl Registry {
         if spec == STATUS_ID {
             return Ok(STATUS_ID.to_string());
         }
-        if let Some(root) = spec.strip_prefix(GIT_PREFIX) {
+        for prefix in [GIT_PREFIX, HEAD_PREFIX] {
+            let Some(root) = spec.strip_prefix(prefix) else {
+                continue;
+            };
             let canonical = Registry::fs_resource_id(root)?;
             let canonical = canonical.trim_start_matches(FS_PREFIX);
             if !Path::new(canonical).join(".git").exists() {
                 return Err(anyhow!("not a git repository: {root}"));
             }
-            return Ok(format!("{GIT_PREFIX}{canonical}"));
+            return Ok(format!("{prefix}{canonical}"));
         }
         Registry::fs_resource_id(spec.strip_prefix(FS_PREFIX).unwrap_or(spec))
     }
@@ -416,6 +441,9 @@ impl Registry {
         if resource.starts_with(GIT_PREFIX) {
             return self.subscribe_git(resource, client, tx, since);
         }
+        if resource.starts_with(HEAD_PREFIX) {
+            return self.subscribe_head(resource, client, tx, since);
+        }
         let root = resource
             .strip_prefix(FS_PREFIX)
             .ok_or_else(|| anyhow!("unknown resource kind: {resource}"))?
@@ -441,9 +469,7 @@ impl Registry {
     ) -> Result<WatchEntry> {
         match watches.get(resource) {
             Some(ResourceEntry::Fs(existing)) => Ok(existing.clone()),
-            Some(ResourceEntry::Git(_)) | Some(ResourceEntry::Status(_)) => {
-                Err(anyhow!("resource id kind collision: {resource}"))
-            }
+            Some(_) => Err(anyhow!("resource id kind collision: {resource}")),
             None => {
                 let created = self.start_watch(resource.to_string(), root)?;
                 watches.insert(resource.to_string(), ResourceEntry::Fs(created.clone()));
@@ -516,9 +542,7 @@ impl Registry {
             let mut watches = self.watches.lock().unwrap();
             match watches.get(resource) {
                 Some(ResourceEntry::Git(existing)) => existing.clone(),
-                Some(ResourceEntry::Fs(_)) | Some(ResourceEntry::Status(_)) => {
-                    return Err(anyhow!("resource id kind collision: {resource}"))
-                }
+                Some(_) => return Err(anyhow!("resource id kind collision: {resource}")),
                 None => {
                     let created =
                         self.start_git_watch(&mut watches, resource.to_string(), &root)?;
@@ -598,6 +622,85 @@ impl Registry {
         Ok(entry)
     }
 
+    /// Subscribe to a `head:` resource: the same cursor/ring/gap/linger as
+    /// every resource. Every batch carries the full state, so a gap subscriber
+    /// is simply served the current snapshot at the current seq.
+    fn subscribe_head(
+        &self,
+        resource: &str,
+        client: ClientId,
+        tx: mpsc::UnboundedSender<Event>,
+        since: Option<u64>,
+    ) -> Result<SubscribeReply> {
+        let root = resource
+            .strip_prefix(HEAD_PREFIX)
+            .ok_or_else(|| anyhow!("unknown resource kind: {resource}"))?
+            .to_string();
+
+        let entry = {
+            let mut watches = self.watches.lock().unwrap();
+            match watches.get(resource) {
+                Some(ResourceEntry::Head(existing)) => existing.clone(),
+                Some(_) => return Err(anyhow!("resource id kind collision: {resource}")),
+                None => {
+                    let created =
+                        self.start_head_watch(&mut watches, resource.to_string(), &root)?;
+                    watches.insert(resource.to_string(), ResourceEntry::Head(created.clone()));
+                    created
+                }
+            }
+        };
+
+        let mut guard = entry.state.lock().unwrap();
+        let snapshot = entry.snapshot.clone();
+        let resource_id = resource.to_string();
+        // Same lock discipline as `subscribe_git`, with none of its weight:
+        // the snapshot is two small strings, and `refresh_head` releases it
+        // before touching the state, so the two never nest the other way.
+        Ok(guard.attach(resource, client, tx, since, move |seq| {
+            (seq > 0).then(|| {
+                let full = snapshot.lock().unwrap().clone();
+                vec![crate::git::HeadSnapshot::into_event(full, resource_id, seq)]
+            })
+        }))
+    }
+
+    /// Start the machinery behind one `head:` resource: ensure the workspace's
+    /// `fs:` watch is running, register an internal subscriber on it, and spawn
+    /// the loop that turns its batches into HEAD re-reads.
+    fn start_head_watch(
+        &self,
+        watches: &mut HashMap<String, ResourceEntry>,
+        resource: String,
+        root: &str,
+    ) -> Result<HeadEntry> {
+        let fs_id = Registry::fs_resource_id(root)?;
+        let fs_entry = self.fs_entry_locked(watches, &fs_id, Path::new(root))?;
+
+        let (signal_tx, signal_rx) = mpsc::unbounded_channel::<Event>();
+        let internal_client = ClientId::internal(format!("head-signal:{resource}"));
+        {
+            let mut guard = fs_entry.state.lock().unwrap();
+            guard.subscribers.insert(internal_client.clone(), signal_tx);
+            guard.idle_since = None;
+        }
+
+        let entry = HeadEntry {
+            state: Arc::new(Mutex::new(ResourceState::new(None))),
+            snapshot: Arc::new(Mutex::new(crate::git::HeadSnapshot::default())),
+        };
+        tokio::spawn(head_loop(
+            resource,
+            root.to_string(),
+            signal_rx,
+            entry.clone(),
+            self.clone(),
+            fs_id,
+            internal_client,
+        ));
+        Ok(entry)
+    }
+
     /// Drop one client's interest. Returns whether the client had been
     /// subscribed. The watch keeps running for `LINGER` so the same client can
     /// come back and resume from its cursor — detach ≠ kill, applied to the
@@ -618,6 +721,7 @@ impl Registry {
         match watches.get(resource) {
             Some(ResourceEntry::Fs(entry)) => drop_interest(&entry.state, client),
             Some(ResourceEntry::Git(entry)) => drop_interest(&entry.state, client),
+            Some(ResourceEntry::Head(entry)) => drop_interest(&entry.state, client),
             Some(ResourceEntry::Status(state)) => drop_interest(state, client),
             None => false,
         }
@@ -700,6 +804,62 @@ async fn git_loop(
     }
     registry.watches.lock().unwrap().remove(&resource);
     registry.unsubscribe(&fs_resource, &internal_client);
+}
+
+/// Drive one `head:` resource: coalesce the workspace watcher's signal,
+/// re-read HEAD in-process, publish when it moved. Retires itself — and its
+/// grip on the `fs:` watch — when its own linger runs out.
+///
+/// Every batch triggers a re-read, not only `git_meta` ones, for the same
+/// reason `git_loop` runs on every batch — with the roles reversed: a linked
+/// worktree's HEAD lives *outside* the watched root (in the primary checkout's
+/// `.git/worktrees/<name>`), so the checkout that moves it never arrives as
+/// `git_meta` here. What does arrive is the tree the checkout rewrote, and a
+/// HEAD read costs too little to gate.
+async fn head_loop(
+    resource: String,
+    root: String,
+    mut signal_rx: mpsc::UnboundedReceiver<Event>,
+    entry: HeadEntry,
+    registry: Registry,
+    fs_resource: String,
+    internal_client: ClientId,
+) {
+    refresh_head(&resource, &root, &entry);
+    loop {
+        match tokio::time::timeout(IDLE_TICK, signal_rx.recv()).await {
+            Ok(Some(_)) => {
+                while let Ok(Some(_)) =
+                    tokio::time::timeout(GIT_DEBOUNCE, signal_rx.recv()).await
+                {}
+                refresh_head(&resource, &root, &entry);
+            }
+            Ok(None) => break,
+            Err(_) => {
+                if entry.state.lock().unwrap().expired() {
+                    break;
+                }
+            }
+        }
+    }
+    registry.watches.lock().unwrap().remove(&resource);
+    registry.unsubscribe(&fs_resource, &internal_client);
+}
+
+/// Re-read HEAD and publish only when it moved — an `index` refresh must not
+/// spend a ring slot restating the same branch. The snapshot lock is released
+/// before the state lock is taken, the `subscribe_head` ordering's other half.
+fn refresh_head(resource: &str, root: &str, entry: &HeadEntry) {
+    let fresh = crate::git::read_head(root);
+    let changed = {
+        let mut snapshot = entry.snapshot.lock().unwrap();
+        let changed = *snapshot != fresh;
+        *snapshot = fresh.clone();
+        changed
+    };
+    if changed {
+        entry.state.lock().unwrap().publish(resource, fresh);
+    }
 }
 
 async fn refresh_git(resource: &str, root: &str, entry: &GitEntry) {
@@ -1183,6 +1343,74 @@ mod tests {
             }
         }
         assert_eq!(seqs, vec![2, 3], "exactly what the cursor had not seen");
+    }
+
+    /// The `head:` kind end to end, against a real repository and the real
+    /// workspace watcher: a first subscriber is delivered the current branch,
+    /// and a `git checkout` on the box reaches it as a live batch. This is the
+    /// one watcher-backed test in the module, because the plane it proves —
+    /// fs event → debounce → HEAD re-read → publish — has no seam to fake.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_head_subscriber_learns_the_branch_and_follows_a_checkout() {
+        let dir = std::env::temp_dir().join(format!(
+            "termiod-head-resource-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .args(args)
+                .output()
+                .expect("git is on PATH");
+            assert!(output.status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "test@termio.sh"]);
+        git(&["config", "user.name", "termio test"]);
+        git(&["config", "commit.gpgsign", "false"]);
+        std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "first"]);
+
+        let registry = Registry::new();
+        let resource =
+            Registry::resource_id(&format!("head:{}", dir.display())).expect("a repo");
+        assert!(resource.starts_with(HEAD_PREFIX));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        registry
+            .subscribe(&resource, ClientId::new("mac"), tx, None)
+            .expect("subscribe");
+
+        let branch_of = |event: Event| match event {
+            Event::HeadChanged { branch, .. } => branch,
+            other => panic!("head resources only emit head_changed, got {other:?}"),
+        };
+        let first = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("the initial HEAD read is published promptly")
+            .expect("channel open");
+        assert_eq!(branch_of(first).as_deref(), Some("main"));
+
+        git(&["checkout", "-q", "-b", "feat/live"]);
+        // The checkout may fan out as several batches; the branch settles on
+        // the new name within the debounce windows.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let event = tokio::time::timeout(remaining, rx.recv())
+                .await
+                .expect("a checkout must reach the subscriber")
+                .expect("channel open");
+            if branch_of(event).as_deref() == Some("feat/live") {
+                break;
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Publishing before anyone has ever asked must not conjure a ring: there is


### PR DESCRIPTION
A session on another box showed only its folder name in the title bar: the branch chip is fed by `BranchModel`, which parses the local `.git/HEAD` behind a local file watch, and a checkout on a VPS is invisible to it. The daemon over there already knew the branch — it just never reached the chip.

## What this does

**termiod** gains a `head:` resource kind beside `git:` (§C.10 one mechanism: id, cursor, ring, gap, linger). It rides the workspace's existing `fs:` watch, and its refresh is one in-process `HEAD` read (`read_head`, resolving a linked worktree's `gitdir` pointer file) — no git child — so it is affordable always-on for a checkout that is merely on screen, where `git:`'s per-event `git status` run stays reserved for an open Changes pane. Every `head_changed` batch is full state; a gap subscriber is served the current snapshot. Gated on the existing `git` capability.

**The Mac** gains `DeviceBranchModel` — `BranchModel`'s device-side twin — which subscribes `head:<root>` for the selected session's checkout when it lives on another machine, keyed by device identity plus root (never bare path, which can spell the same on two machines). The title view reads it where the local model cannot see; the watch follows the selection, retries on app activation, and resumes with full state after an interruption.

A box with no daemon, or one predating `head:`, never answers — the chip stays hidden exactly as before. The remote box needs its daemon updated (the deploy reconcile loop handles that) before the chip appears.

## Verification

- `cargo test`: all suites green, including a new end-to-end test (subscribe `head:` on a real repo through the real watcher, see the initial branch, then a live batch after `git checkout -b`) — stable across repeated runs — plus `read_head` unit tests (branch / detached / linked worktree / non-repo) and the wire-shape test.
- A raw-socket smoke against a real `termiod serve`: `hello` → `subscribe_resource head:<repo>` → ack → `head_changed {branch:"main"}` → checkout → `head_changed {branch:"feat/smoke"}`.
- `swift build` and `swift test` (999 tests) green.
- Not yet verified against a live remote: needs a box running the updated daemon.

Release Notes:
- The title bar now shows the live git branch for sessions running on another machine, updating when an agent or shell over there switches branches.